### PR TITLE
Clarify that know-how generation is automatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,40 +198,22 @@ Full version in [`ZEN.md`](ZEN.md).
 
 ## Know-how
 
-Most AI coding tools are stateless. Every session starts from zero. Nanostack builds knowledge as you work. You don't run extra commands. The skills do it.
+Most AI coding tools are stateless. Every session starts from zero. Nanostack builds knowledge as you work without extra commands.
 
-### What happens automatically
+### Every skill saves automatically
 
-When you run `/plan --save`, the plan gets persisted as structured JSON in `~/.nanostack/plan/`. When you then run `/review`, it automatically finds that plan and checks scope drift: did you touch files that weren't in the plan? Did you skip files that were? You don't configure this. If a plan artifact exists, `/review` reads it.
-
-```
-/plan --save  →  saves plan with planned_files list
-/review       →  finds plan, runs scope drift, reports:
-                  "drift_detected: src/unplanned.ts is out of scope"
-```
-
-Same with conflicts. `/review` says "add detail to error messages." Later, `/security` automatically finds the review artifact and flags the contradiction: "don't expose internals in errors." The resolution gets matched against [10 built-in precedents](reference/conflict-precedents.md) and recorded in the artifact.
+Every skill persists its output to `~/.nanostack/` after every run. You don't add flags. It just happens.
 
 ```
-/review --save  →  saves findings including "REV-003: error messages too vague"
-/security       →  finds review, detects conflict with REV-003, resolves:
-                    "structured errors: code + generic msg to user, details to logs"
+/think     →  ~/.nanostack/think/20260325-140000.json
+/plan      →  ~/.nanostack/plan/20260325-143000.json
+/review    →  ~/.nanostack/review/20260325-150000.json
+/qa        →  ~/.nanostack/qa/20260325-151500.json
+/security  →  ~/.nanostack/security/20260325-152000.json
+/ship      →  ~/.nanostack/ship/20260325-160000.json
 ```
 
-New precedents accumulate as you work. The tenth sprint resolves conflicts faster than the first because more patterns are documented.
-
-### What gets persisted
-
-Add `--save` to any skill and it writes JSON to `~/.nanostack/`:
-
-```
-~/.nanostack/plan/20260325-143000.json
-~/.nanostack/review/20260325-150000.json
-~/.nanostack/qa/20260325-151500.json
-~/.nanostack/security/20260325-152000.json
-```
-
-A review artifact looks like this:
+A review artifact captures everything: findings, scope drift, conflicts resolved.
 
 ```json
 {
@@ -246,28 +228,65 @@ A review artifact looks like this:
 }
 ```
 
-Set `auto_save: true` in `~/.nanostack/config.json` to save every run without the flag. Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md).
+Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). To disable, set `auto_save: false` in `~/.nanostack/config.json`.
 
-### Visualize: the Obsidian vault
+### Skills read each other
 
-Three scripts turn raw artifacts into an Obsidian vault at `~/.nanostack/know-how/`:
+`/review` automatically finds the most recent `/plan` artifact and checks scope drift: did you touch files outside the plan? Did you skip files that were in it?
 
-```bash
-bin/sprint-journal.sh
-# reads all artifacts from the current sprint
-# writes ~/.nanostack/know-how/journal/2026-03-25-myproject.md
-# one file per sprint: what /think reframed, what /plan scoped,
-# what /review found, how conflicts resolved, what /security graded
-
-bin/analytics.sh --obsidian
-# writes ~/.nanostack/know-how/dashboard.md
-# phase counts, intensity modes, security score trends across sprints
-
-bin/capture-learning.sh "we forgot to update the plan after changing the API contract"
-# appends to ~/.nanostack/know-how/learnings/ongoing.md
+```
+/plan     →  saves planned_files list
+/review   →  finds plan, compares against git diff, reports:
+              "drift_detected: src/unplanned.ts out of scope, tests/auth.test.ts missing"
 ```
 
-Open `~/.nanostack/know-how/` in Obsidian. Sprint journals link to conflict precedents. The dashboard links to recent journals. Graph view shows how sprints, conflicts and learnings connect over time.
+`/security` automatically finds the most recent `/review` artifact and detects conflicts. `/review` says "add detail to error messages." `/security` says "don't expose internals." The resolution gets matched against [10 built-in precedents](reference/conflict-precedents.md) and recorded.
+
+```
+/review   →  saves "REV-003: error messages too vague"
+/security →  finds review, detects conflict, resolves:
+              "structured errors: code + generic msg to user, details to logs"
+```
+
+This happens in all modes. No flags needed. If an artifact exists, the next skill reads it.
+
+### Sprint journal on /ship
+
+When you run `/ship` and the PR lands, it automatically generates a sprint journal:
+
+```
+/ship  →  saves PR data
+       →  runs bin/sprint-journal.sh
+       →  writes ~/.nanostack/know-how/journal/2026-03-25-myproject.md
+```
+
+The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
+
+### Analytics and learnings
+
+Two optional scripts for when you want to see patterns across sprints:
+
+```bash
+bin/analytics.sh --obsidian    # dashboard with phase counts and security trends
+bin/capture-learning.sh "..."  # append a learning to the knowledge base
+```
+
+### Discard a bad session
+
+If a sprint went wrong (agent hallucinated findings, aborted halfway, bad data), discard it:
+
+```bash
+bin/discard-sprint.sh                     # discard all artifacts from today for this project
+bin/discard-sprint.sh --phase review      # discard only review artifacts
+bin/discard-sprint.sh --date 2026-03-24   # discard artifacts from a specific date
+bin/discard-sprint.sh --dry-run           # show what would be deleted without deleting
+```
+
+This removes artifacts and the journal entry. Analytics recalculate on next run.
+
+### The Obsidian vault
+
+Open `~/.nanostack/know-how/` in Obsidian. Sprint journals link to conflict precedents. The dashboard links to journals. Graph view shows how sprints, conflicts and learnings connect over time.
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -198,20 +198,40 @@ Full version in [`ZEN.md`](ZEN.md).
 
 ## Know-how
 
-Most AI coding tools are stateless. Every session starts from zero. Nanostack remembers.
+Most AI coding tools are stateless. Every session starts from zero. Nanostack builds knowledge as you work. You don't run extra commands. The skills do it.
 
-### Artifacts: how knowledge enters the system
+### What happens automatically
 
-Run any skill with `--save` and it writes structured JSON to `~/.nanostack/`:
+When you run `/plan --save`, the plan gets persisted as structured JSON in `~/.nanostack/plan/`. When you then run `/review`, it automatically finds that plan and checks scope drift: did you touch files that weren't in the plan? Did you skip files that were? You don't configure this. If a plan artifact exists, `/review` reads it.
 
 ```
-/plan --save       →  ~/.nanostack/plan/20260325-143000.json
-/review --save     →  ~/.nanostack/review/20260325-150000.json
-/qa --save         →  ~/.nanostack/qa/20260325-151500.json
-/security --save   →  ~/.nanostack/security/20260325-152000.json
+/plan --save  →  saves plan with planned_files list
+/review       →  finds plan, runs scope drift, reports:
+                  "drift_detected: src/unplanned.ts is out of scope"
 ```
 
-Each artifact captures the full output of that phase. A `/review --save` produces:
+Same with conflicts. `/review` says "add detail to error messages." Later, `/security` automatically finds the review artifact and flags the contradiction: "don't expose internals in errors." The resolution gets matched against [10 built-in precedents](reference/conflict-precedents.md) and recorded in the artifact.
+
+```
+/review --save  →  saves findings including "REV-003: error messages too vague"
+/security       →  finds review, detects conflict with REV-003, resolves:
+                    "structured errors: code + generic msg to user, details to logs"
+```
+
+New precedents accumulate as you work. The tenth sprint resolves conflicts faster than the first because more patterns are documented.
+
+### What gets persisted
+
+Add `--save` to any skill and it writes JSON to `~/.nanostack/`:
+
+```
+~/.nanostack/plan/20260325-143000.json
+~/.nanostack/review/20260325-150000.json
+~/.nanostack/qa/20260325-151500.json
+~/.nanostack/security/20260325-152000.json
+```
+
+A review artifact looks like this:
 
 ```json
 {
@@ -226,63 +246,28 @@ Each artifact captures the full output of that phase. A `/review --save` produce
 }
 ```
 
-Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md).
+Set `auto_save: true` in `~/.nanostack/config.json` to save every run without the flag. Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md).
 
-### Cross-skill intelligence
+### Visualize: the Obsidian vault
 
-Skills read each other's artifacts. This happens automatically when artifacts exist.
-
-`/review` finds the most recent `/plan` artifact and checks scope drift:
-
-```bash
-bin/find-artifact.sh plan 2     # find plan artifact from last 2 days for this project
-bin/scope-drift.sh              # compare planned files vs actual git changes
-```
-
-```json
-{ "status": "drift_detected", "out_of_scope_files": ["src/unplanned.ts"], "missing_files": ["tests/auth.test.ts"] }
-```
-
-`/security` finds the most recent `/review` artifact and detects conflicts. `/review` says "add detail to error messages." `/security` says "don't expose internals." Both are right. The resolution gets recorded in the artifact and matches against [10 built-in precedents](reference/conflict-precedents.md). New precedents accumulate as you work.
-
-### Knowledge extraction
-
-Three scripts turn raw artifacts into something you can read and search:
-
-**Sprint journals.** One entry per sprint with the full decision trail.
+Three scripts turn raw artifacts into an Obsidian vault at `~/.nanostack/know-how/`:
 
 ```bash
 bin/sprint-journal.sh
-# → ~/.nanostack/know-how/journal/2026-03-25-myproject.md
-```
+# reads all artifacts from the current sprint
+# writes ~/.nanostack/know-how/journal/2026-03-25-myproject.md
+# one file per sprint: what /think reframed, what /plan scoped,
+# what /review found, how conflicts resolved, what /security graded
 
-Reads every artifact from the current sprint. Writes what `/think` reframed, what `/plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded, what `/ship` deployed. One file, one sprint, everything connected.
-
-**Analytics.** Phase counts, intensity modes, security trends across sprints.
-
-```bash
 bin/analytics.sh --obsidian
-# → ~/.nanostack/know-how/dashboard.md
+# writes ~/.nanostack/know-how/dashboard.md
+# phase counts, intensity modes, security score trends across sprints
+
+bin/capture-learning.sh "we forgot to update the plan after changing the API contract"
+# appends to ~/.nanostack/know-how/learnings/ongoing.md
 ```
 
-After a few months you can see patterns: are security grades improving? Is scope drift happening less? Are you using `--thorough` more often on auth changes?
-
-**Learnings.** Things that surprised you during a sprint.
-
-```bash
-bin/capture-learning.sh "scope drift happened because we forgot to update the plan after changing the API contract"
-# → appends to ~/.nanostack/know-how/learnings/ongoing.md
-```
-
-### The Obsidian vault
-
-Open `~/.nanostack/know-how/` as an Obsidian vault. Sprint journals link to conflict precedents. The dashboard links to recent journals. Learnings reference the sprint where they happened. Graph view shows how everything connects.
-
-### Why this matters
-
-After ten sprints you have a decision log. After fifty you have institutional knowledge that survives context switches, onboarding and team changes. You can answer questions like "why did we choose structured error codes over verbose messages" by tracing back to the sprint where the conflict was resolved.
-
-No other AI coding tool does this. They forget everything between sessions. Nanostack doesn't. Every sprint makes the next one better.
+Open `~/.nanostack/know-how/` in Obsidian. Sprint journals link to conflict precedents. The dashboard links to recent journals. Graph view shows how sprints, conflicts and learnings connect over time.
 
 ## Privacy
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,11 +12,11 @@ You have access to a set of composable engineering workflow skills. Each skill i
 | Skill | When to use | Modes | Key files |
 |-------|-------------|-------|-----------|
 | `/think` | Before planning — strategic product thinking, premise validation, scope decisions. | — | `think/references/forcing-questions.md`, `think/references/cognitive-patterns.md` |
-| `/plan` | Before starting any non-trivial work. Produces a scoped, actionable plan. | `--save` | `plan/templates/plan-template.md` |
-| `/review` | After code is written. Two-pass review + scope drift detection + conflict resolution. | `--quick` `--standard` `--thorough` `--save` | `review/checklist.md`, `reference/conflict-precedents.md` |
-| `/qa` | To verify code works. Browser-based testing with Playwright, plus root-cause debugging. | `--quick` `--standard` `--thorough` `--save` | `qa/bin/screenshot.sh` |
-| `/security` | Before shipping. OWASP Top 10 + STRIDE + variant analysis + conflict detection. | `--quick` `--standard` `--thorough` `--save` | `security/references/owasp-checklist.md`, `security/templates/security-report.md` |
-| `/ship` | To create PRs, merge, deploy, and verify. | — | `ship/templates/pr-template.md` |
+| `/plan` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
+| `/review` | After code is written. Two-pass review + scope drift detection + conflict resolution. | `--quick` `--standard` `--thorough` | `review/checklist.md`, `reference/conflict-precedents.md` |
+| `/qa` | To verify code works. Browser-based testing with Playwright, plus root-cause debugging. | `--quick` `--standard` `--thorough` | `qa/bin/screenshot.sh` |
+| `/security` | Before shipping. OWASP Top 10 + STRIDE + variant analysis + conflict detection. | `--quick` `--standard` `--thorough` | `security/references/owasp-checklist.md`, `security/templates/security-report.md` |
+| `/ship` | To create PRs, merge, deploy, and verify. Generates sprint journal on success. | — | `ship/templates/pr-template.md` |
 | `/guard` | When working near production, destructive operations, or sensitive systems. | — | `guard/bin/check-dangerous.sh` |
 | `/conductor` | Orchestrate parallel agent sessions through a sprint. Coordinate task claiming and artifact handoff. | `start` `claim` `complete` `status` | `conductor/bin/sprint.sh` |
 
@@ -59,7 +59,7 @@ Skills auto-suggest a mode based on the diff, but the user always decides.
 
 ## Artifact Persistence
 
-Skills can save their output with `--save` for trend tracking and cross-skill coordination:
+Skills automatically save their output to `~/.nanostack/` after every run:
 
 ```bash
 ~/.nanostack/<phase>/<timestamp>.json
@@ -68,7 +68,14 @@ Skills can save their output with `--save` for trend tracking and cross-skill co
 This enables:
 - **Scope drift detection** — `/review` compares planned vs actual files
 - **Conflict detection** — `/review` and `/security` cross-reference each other's findings
+- **Sprint journals** — `/ship` generates a journal entry from all phase artifacts
 - **Trend tracking** — Are security findings decreasing over time?
+
+Auto-saving is on by default. The user can disable it by setting `auto_save: false` in `~/.nanostack/config.json`.
+
+Artifacts are validated before saving: `save-artifact.sh` rejects invalid JSON, missing required fields (`phase`, `summary`), and phase mismatches.
+
+To discard artifacts from a bad session: `bin/discard-sprint.sh` (removes artifacts and journal entry for the current project and date).
 
 ## Conflict Resolution
 
@@ -122,7 +129,7 @@ Suggest skills when context matches — don't wait for the user to remember:
 ## Usage Rules
 
 - Start with `/think` for new products or when the "what" is unclear
-- Run `/plan` before building anything that touches more than 3 files — use `--save` for Medium/Large scope
+- Run `/plan` before building anything that touches more than 3 files
 - Run `/review` on your own code — the adversarial pass catches what you missed
 - `/security` is not optional before shipping to production
 - `/guard` is on-demand — activate it, don't leave it always on

--- a/bin/discard-sprint.sh
+++ b/bin/discard-sprint.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# discard-sprint.sh — Remove artifacts from a bad session
+# Usage:
+#   discard-sprint.sh                     # discard all artifacts from today for this project
+#   discard-sprint.sh --phase review      # discard only review artifacts
+#   discard-sprint.sh --date 2026-03-24   # discard artifacts from a specific date
+#   discard-sprint.sh --dry-run           # show what would be deleted without deleting
+set -e
+
+STORE="$HOME/.nanostack"
+KNOW_HOW="$STORE/know-how"
+PROJECT="$(pwd)"
+PROJECT_NAME=$(basename "$PROJECT")
+DATE=$(date +"%Y-%m-%d")
+PHASE=""
+DRY_RUN=false
+PHASES="think plan review qa security ship"
+
+# Parse args
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --phase) PHASE="$2"; shift 2 ;;
+    --date) DATE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# If --phase given, only clean that phase
+if [ -n "$PHASE" ]; then
+  PHASES="$PHASE"
+fi
+
+# Convert date to prefix for matching artifact filenames (YYYYMMDD)
+DATE_PREFIX=$(echo "$DATE" | tr -d '-')
+
+DELETED=0
+
+# Remove matching artifacts
+for phase in $PHASES; do
+  dir="$STORE/$phase"
+  [ -d "$dir" ] || continue
+  for f in "$dir"/*.json; do
+    [ -f "$f" ] || continue
+    fname=$(basename "$f")
+    # Check filename starts with date prefix
+    case "$fname" in
+      ${DATE_PREFIX}-*)
+        # Check it belongs to this project
+        if jq -e --arg p "$PROJECT" '.project == $p' "$f" >/dev/null 2>&1; then
+          if $DRY_RUN; then
+            echo "[dry-run] would delete: $f"
+          else
+            rm "$f"
+            echo "deleted: $f"
+          fi
+          DELETED=$((DELETED + 1))
+        fi
+        ;;
+    esac
+  done
+done
+
+# Remove journal entry for that date if it exists
+JOURNAL="$KNOW_HOW/journal/$DATE-$PROJECT_NAME.md"
+if [ -f "$JOURNAL" ]; then
+  if $DRY_RUN; then
+    echo "[dry-run] would delete: $JOURNAL"
+  else
+    rm "$JOURNAL"
+    echo "deleted: $JOURNAL"
+  fi
+  DELETED=$((DELETED + 1))
+fi
+
+if [ "$DELETED" -eq 0 ]; then
+  echo "Nothing to discard for $PROJECT_NAME on $DATE."
+else
+  if $DRY_RUN; then
+    echo "$DELETED file(s) would be deleted."
+  else
+    echo "$DELETED file(s) deleted."
+  fi
+fi

--- a/bin/init-config.sh
+++ b/bin/init-config.sh
@@ -60,7 +60,7 @@ jq -n \
     },
     preferences: {
       default_intensity: "standard",
-      auto_save: false,
+      auto_save: true,
       conflict_precedence: "security > review > qa"
     },
     configured_at: $date

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -2,11 +2,45 @@
 # save-artifact.sh — Save a skill artifact to ~/.nanostack/<phase>/
 # Usage: save-artifact.sh <phase> <json-string>
 # Example: save-artifact.sh review '{"phase":"review","summary":{"blocking":0}}'
+# Validates JSON has required fields before saving. Fails on invalid input.
 set -e
 
 PHASE="${1:?Usage: save-artifact.sh <phase> <json>}"
 JSON="${2:?Missing JSON argument}"
 STORE="$HOME/.nanostack/$PHASE"
+VALID_PHASES="think plan review qa security ship"
+
+# Validate phase name
+case " $VALID_PHASES " in
+  *" $PHASE "*) ;;
+  *) echo "error: invalid phase '$PHASE'. Must be one of: $VALID_PHASES" >&2; exit 1 ;;
+esac
+
+# Validate JSON is parseable
+if ! echo "$JSON" | jq '.' >/dev/null 2>&1; then
+  echo "error: invalid JSON input" >&2
+  exit 1
+fi
+
+# Validate required fields
+MISSING=""
+if ! echo "$JSON" | jq -e '.phase' >/dev/null 2>&1; then
+  MISSING="phase"
+fi
+if ! echo "$JSON" | jq -e '.summary' >/dev/null 2>&1; then
+  MISSING="${MISSING:+$MISSING, }summary"
+fi
+if [ -n "$MISSING" ]; then
+  echo "error: artifact missing required fields: $MISSING" >&2
+  exit 1
+fi
+
+# Validate phase field matches argument
+ARTIFACT_PHASE=$(echo "$JSON" | jq -r '.phase')
+if [ "$ARTIFACT_PHASE" != "$PHASE" ]; then
+  echo "error: phase argument '$PHASE' does not match artifact phase '$ARTIFACT_PHASE'" >&2
+  exit 1
+fi
 
 mkdir -p "$STORE"
 

--- a/bin/sprint-journal.sh
+++ b/bin/sprint-journal.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sprint-journal.sh — Generate an Obsidian journal entry from sprint artifacts
 # Usage: sprint-journal.sh [--project <name>]
-# Reads ~/.nanostack/ artifacts and writes to docs/journal/<date>-<project>.md
+# Reads ~/.nanostack/ artifacts and writes to ~/.nanostack/know-how/journal/<date>-<project>.md
 set -e
 
 STORE="$HOME/.nanostack"
@@ -14,17 +14,36 @@ JOURNAL_FILE="$JOURNAL_DIR/$DATE-$PROJECT_NAME.md"
 
 mkdir -p "$JOURNAL_DIR"
 
-# Find most recent artifact per phase
+# Find most recent artifact per phase for this project
 find_latest() {
   local phase="$1"
   local dir="$STORE/$phase"
   [ -d "$dir" ] || { echo ""; return 0; }
-  ls -t "$dir"/*.json 2>/dev/null | head -1 || echo ""
+  local project
+  project="$(pwd)"
+  for f in $(ls -t "$dir"/*.json 2>/dev/null); do
+    if jq -e --arg p "$project" '.project == $p' "$f" >/dev/null 2>&1; then
+      echo "$f"
+      return 0
+    fi
+  done
+  echo ""
 }
 
-# Extract field from JSON
+# Extract field from JSON with empty string default
 field() {
-  jq -r "$1 // \"\"" "$2" 2>/dev/null
+  jq -r "$1 // \"\"" "$2" 2>/dev/null || echo ""
+}
+
+# Extract numeric field with 0 default
+numfield() {
+  local val
+  val=$(jq -r "$1 // 0" "$2" 2>/dev/null || echo "0")
+  # Ensure it's actually a number
+  case "$val" in
+    ''|*[!0-9]*) echo "0" ;;
+    *) echo "$val" ;;
+  esac
 }
 
 # Start building the journal
@@ -59,8 +78,8 @@ field() {
     echo ""
     GOAL=$(field '.summary.goal' "$PLAN_FILE")
     SCOPE=$(field '.summary.scope' "$PLAN_FILE")
-    STEPS=$(field '.summary.step_count' "$PLAN_FILE")
-    FILES=$(field '.summary.planned_files | length' "$PLAN_FILE")
+    STEPS=$(numfield '.summary.step_count' "$PLAN_FILE")
+    FILES=$(numfield '.summary.planned_files | length' "$PLAN_FILE")
     [ -n "$GOAL" ] && echo "**Goal:** $GOAL"
     echo "**Scope:** $SCOPE | **Steps:** $STEPS | **Files:** $FILES"
     echo ""
@@ -71,12 +90,12 @@ field() {
   if [ -n "$REVIEW_FILE" ]; then
     echo "## /review"
     echo ""
-    BLOCKING=$(field '.summary.blocking' "$REVIEW_FILE")
-    SHOULD=$(field '.summary.should_fix' "$REVIEW_FILE")
-    NITS=$(field '.summary.nitpicks' "$REVIEW_FILE")
-    POSITIVE=$(field '.summary.positive' "$REVIEW_FILE")
+    BLOCKING=$(numfield '.summary.blocking' "$REVIEW_FILE")
+    SHOULD=$(numfield '.summary.should_fix' "$REVIEW_FILE")
+    NITS=$(numfield '.summary.nitpicks' "$REVIEW_FILE")
+    POSITIVE=$(numfield '.summary.positive' "$REVIEW_FILE")
     MODE=$(field '.mode' "$REVIEW_FILE")
-    echo "**Mode:** $MODE"
+    [ -n "$MODE" ] && echo "**Mode:** $MODE"
     echo "**Findings:** blocking=$BLOCKING, should_fix=$SHOULD, nitpicks=$NITS, positive=$POSITIVE"
 
     # Scope drift
@@ -84,8 +103,8 @@ field() {
     [ -n "$DRIFT" ] && echo "**Scope drift:** $DRIFT"
 
     # Conflicts
-    CONFLICTS=$(field '.conflicts | length' "$REVIEW_FILE")
-    [ "$CONFLICTS" != "0" ] && [ -n "$CONFLICTS" ] && echo "**Conflicts resolved:** $CONFLICTS (see [[reference/conflict-precedents]])"
+    CONFLICTS=$(numfield '.conflicts | length' "$REVIEW_FILE")
+    [ "$CONFLICTS" -gt 0 ] && echo "**Conflicts resolved:** $CONFLICTS (see [[reference/conflict-precedents]])"
     echo ""
   fi
 
@@ -95,14 +114,15 @@ field() {
     echo "## /qa"
     echo ""
     STATUS=$(field '.summary.status' "$QA_FILE")
-    TESTS_RUN=$(field '.summary.tests_run' "$QA_FILE")
-    PASSED=$(field '.summary.tests_passed' "$QA_FILE")
-    FAILED=$(field '.summary.tests_failed' "$QA_FILE")
-    BUGS=$(field '.summary.bugs_found' "$QA_FILE")
-    FIXED=$(field '.summary.bugs_fixed' "$QA_FILE")
-    WTF=$(field '.summary.wtf_likelihood' "$QA_FILE")
+    TESTS_RUN=$(numfield '.summary.tests_run' "$QA_FILE")
+    PASSED=$(numfield '.summary.tests_passed' "$QA_FILE")
+    FAILED=$(numfield '.summary.tests_failed' "$QA_FILE")
+    BUGS=$(numfield '.summary.bugs_found' "$QA_FILE")
+    FIXED=$(numfield '.summary.bugs_fixed' "$QA_FILE")
+    WTF=$(numfield '.summary.wtf_likelihood' "$QA_FILE")
     echo "**Status:** $STATUS | **Tests:** $TESTS_RUN ($PASSED passed, $FAILED failed)"
-    echo "**Bugs:** $BUGS found, $FIXED fixed | **WTF:** ${WTF}%"
+    echo "**Bugs:** $BUGS found, $FIXED fixed"
+    [ "$WTF" -gt 0 ] && echo "**WTF likelihood:** ${WTF}%"
     echo ""
   fi
 
@@ -111,21 +131,21 @@ field() {
   if [ -n "$SEC_FILE" ]; then
     echo "## /security"
     echo ""
-    CRIT=$(field '.summary.critical' "$SEC_FILE")
-    HIGH=$(field '.summary.high' "$SEC_FILE")
-    MED=$(field '.summary.medium' "$SEC_FILE")
-    LOW=$(field '.summary.low' "$SEC_FILE")
-    TOTAL=$(field '.summary.total_findings' "$SEC_FILE")
+    CRIT=$(numfield '.summary.critical' "$SEC_FILE")
+    HIGH=$(numfield '.summary.high' "$SEC_FILE")
+    MED=$(numfield '.summary.medium' "$SEC_FILE")
+    LOW=$(numfield '.summary.low' "$SEC_FILE")
+    TOTAL=$(numfield '.summary.total_findings' "$SEC_FILE")
     MODE=$(field '.mode' "$SEC_FILE")
 
     # Calculate grade
     GRADE="A"
-    [ "$CRIT" -gt 2 ] 2>/dev/null && GRADE="F"
-    [ "$CRIT" -gt 0 ] 2>/dev/null && [ "$CRIT" -le 2 ] 2>/dev/null && GRADE="D"
-    [ "$HIGH" -gt 2 ] 2>/dev/null && [ "$CRIT" -eq 0 ] 2>/dev/null && GRADE="C"
-    [ "$HIGH" -gt 0 ] 2>/dev/null && [ "$HIGH" -le 2 ] 2>/dev/null && [ "$CRIT" -eq 0 ] 2>/dev/null && GRADE="B"
+    [ "$CRIT" -gt 2 ] && GRADE="F"
+    [ "$CRIT" -gt 0 ] && [ "$CRIT" -le 2 ] && GRADE="D"
+    [ "$HIGH" -gt 2 ] && [ "$CRIT" -eq 0 ] && GRADE="C"
+    [ "$HIGH" -gt 0 ] && [ "$HIGH" -le 2 ] && [ "$CRIT" -eq 0 ] && GRADE="B"
 
-    echo "**Mode:** $MODE | **Score:** $GRADE"
+    [ -n "$MODE" ] && echo "**Mode:** $MODE | **Score:** $GRADE" || echo "**Score:** $GRADE"
     echo "**Findings:** CRITICAL=$CRIT HIGH=$HIGH MEDIUM=$MED LOW=$LOW (total: $TOTAL)"
     echo ""
   fi
@@ -151,7 +171,7 @@ field() {
   # Links
   echo "---"
   echo ""
-  echo "Related: [[learnings/from-building]] | [[reference/conflict-precedents]]"
+  echo "Related: [[learnings/ongoing]] | [[reference/conflict-precedents]]"
 
 } > "$JOURNAL_FILE"
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -76,17 +76,17 @@ If none of these apply (pure backend, CLI, library), skip this section.
 
 Present the plan to the user. Wait for explicit approval before executing. If the user modifies the plan, update it before proceeding.
 
-### 7. Save Artifact (with `--save`)
+### 7. Save Artifact
 
-If the user invoked `/plan --save`, persist the plan for scope drift detection and trend tracking:
+Always persist the plan after presenting it to the user:
 
 ```bash
 bin/save-artifact.sh plan '<json with phase, summary including planned_files array>'
 ```
 
-The `planned_files` list is critical — `/review` uses it for scope drift detection via `bin/scope-drift.sh`. See `reference/artifact-schema.md` for the full schema.
+The `planned_files` list is critical. `/review` uses it for scope drift detection via `bin/scope-drift.sh`. See `reference/artifact-schema.md` for the full schema.
 
-**Always suggest `--save` for Medium and Large scope plans.** Small scope plans rarely need scope tracking.
+The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
 
 ## Gotchas
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -110,13 +110,15 @@ Then the full report:
 
 Report progress as you go. After each test group (happy path, error states, edge cases), output results immediately. Don't wait until the end to dump everything.
 
-## Save Artifact (with `--save`)
+## Save Artifact
+
+Always persist the QA results after completing the run:
 
 ```bash
-bin/save-artifact.sh qa '<json with phase, mode, summary, findings>'
+bin/save-artifact.sh qa '<json with phase, mode, summary including wtf_likelihood, findings>'
 ```
 
-See `reference/artifact-schema.md` for the full schema.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
 
 ## Mode Summary
 

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -98,7 +98,8 @@ All artifacts share this base structure:
     "tests_passed": 11,
     "tests_failed": 1,
     "bugs_found": 1,
-    "bugs_fixed": 1
+    "bugs_fixed": 1,
+    "wtf_likelihood": 15
   },
   "findings": [
     {

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -32,7 +32,7 @@ Calibrate depth by diff size: **Small** (< 100 lines, quick pass) / **Medium** (
 
 ## Step 0: Scope Drift Check
 
-**Skip in `--quick` mode.** In `--standard`, run if a recent plan exists. In `--thorough`, always run — drift is BLOCKING.
+Always run if a recent plan artifact exists. In `--quick` mode, drift is informational. In `--standard`, drift is informational. In `--thorough`, drift is BLOCKING.
 
 Run the scope drift script:
 
@@ -102,15 +102,15 @@ When a conflict is detected, mark it inline:
 **In `--standard` mode:** Document conflicts inline in output.
 **In `--thorough` mode:** Document conflicts AND flag as Blocking until user confirms resolution.
 
-## Save Artifact (with `--save`)
+## Save Artifact
 
-If the user invoked `/review --save`, persist using the shared script:
+Always persist the review after completing it:
 
 ```bash
 bin/save-artifact.sh review '<json with phase, mode, summary, scope_drift, findings, conflicts>'
 ```
 
-See `reference/artifact-schema.md` for the full schema.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
 
 ## Mode Summary
 
@@ -118,7 +118,7 @@ See `reference/artifact-schema.md` for the full schema.
 |--------|-------|----------|----------|
 | Pass 1 (structural) | Correctness only | Full checklist | Full checklist + architecture |
 | Pass 2 (adversarial) | Skip | Standard | Deep + threat model |
-| Scope drift | Skip | Check if plan exists | Always, BLOCKING on drift |
+| Scope drift | Informational | Informational | BLOCKING on drift |
 | Conflict detection | Auto-resolve | Document inline | BLOCKING until resolved |
 | Output | Blocking issues only | All categories | All + rationale per finding |
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -189,7 +189,7 @@ Always close with **What's solid**: 2-3 specific things the codebase does well o
 
 ## Conflict Detection
 
-**In `--thorough` mode only.** Check for conflicts with prior `/review` findings:
+Always check for conflicts with prior `/review` findings if a review artifact exists:
 
 ```bash
 bin/find-artifact.sh review 30
@@ -201,13 +201,19 @@ Read `reference/conflict-precedents.md` for known conflict patterns. When detect
 **Conflicts with:** REV-003 → RESOLUTION: structured errors (code + generic msg to user, details to logs)
 ```
 
-## Save Artifact (with `--save`)
+In `--quick` mode, apply default precedence (security > review) without documenting.
+In `--standard` mode, document conflicts inline.
+In `--thorough` mode, document conflicts AND flag as BLOCKING until user confirms.
+
+## Save Artifact
+
+Always persist the security audit after completing it:
 
 ```bash
 bin/save-artifact.sh security '<json with phase, mode, summary, findings, conflicts>'
 ```
 
-See `reference/artifact-schema.md` for the full schema.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
 
 ## Mode Summary
 
@@ -216,7 +222,7 @@ See `reference/artifact-schema.md` for the full schema.
 | OWASP scope | A01-A03 only | Full A01-A10 | Full + variant analysis |
 | STRIDE | Skip | Per component | Per component + attack trees |
 | Dependencies | `npm audit` only | Full scan | Full + license check |
-| Conflict detection | Skip | Skip | Cross-reference /review |
+| Conflict detection | Auto-resolve | Document inline | BLOCKING until resolved |
 | Tentative findings | Skip | Skip | Report as TENTATIVE |
 | Confidence gate | 9/10 | 7/10 | 3/10 |
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -110,12 +110,26 @@ gh pr create --title "Revert: {{original PR title}}" --body "Reverting due to {{
 
 Document what went wrong for the team.
 
+## Save Artifact and Generate Sprint Journal
+
+After shipping, persist the result and generate the sprint journal:
+
+```bash
+bin/save-artifact.sh ship '<json with phase, summary including pr_number, pr_url, title, status, ci_passed>'
+bin/sprint-journal.sh
+```
+
+The sprint journal reads all phase artifacts (think, plan, review, qa, security, ship) and writes a single entry to `~/.nanostack/know-how/journal/`. This happens automatically on every successful ship.
+
+The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+
 ## Output
 
 After shipping, close with a summary:
 ```
 Ship: PR #42 created. CI passed. Deployed. Smoke test clean.
 Tests: 42 → 51 (+9 new). No regressions.
+Journal: ~/.nanostack/know-how/journal/2026-03-25-myproject.md
 ```
 
 Include before/after test counts when tests were added during the sprint. Quantify the improvement.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -124,6 +124,16 @@ Produce a clear brief for the next phase:
 Ready for: /plan
 ```
 
+## Save Artifact
+
+Always persist the think output after the handoff brief:
+
+```bash
+bin/save-artifact.sh think '<json with phase, summary including value_proposition, scope_mode, target_user, narrowest_wedge, key_risk, premise_validated>'
+```
+
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+
 ## Gotchas
 
 - **Don't skip the diagnostic to "save time."** The diagnostic IS the time savings — it prevents building the wrong thing.


### PR DESCRIPTION
## Summary

- Restructured Know-how section to lead with what happens automatically (scope drift, conflict detection) instead of manual commands
- Skills cross-reference each other during normal execution. The user runs `/review`, not `bin/find-artifact.sh`
- Three subsections: What happens automatically, What gets persisted (`--save` / `auto_save`), Visualize (Obsidian vault as optional)
- Net -15 lines: removed redundant subsections, tighter examples

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Check links to `reference/artifact-schema.md` and `reference/conflict-precedents.md` resolve