### PR TITLE
Add processize and community validation to /think

### DIFF
--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -140,5 +140,6 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 - **Don't confuse conviction with evidence.** The user being excited about an idea is not validation. Who else is excited? Who would pay?
 - **Don't expand scope when reducing is the right call.** More features ≠ better product. The best v1s do one thing exceptionally well.
 - **"Search Before Building" is literal.** Before proposing to build anything, search for existing solutions. The best code is the code you don't write.
+- **"Processize before you productize."** If the user can't describe how they'd deliver the value by hand (no code), they don't understand the problem well enough to automate it. The manual process comes first.
 - **Don't let this become a planning session.** /think produces a brief, not a plan. If you're writing implementation steps, you've gone too far. Hand off to /plan.
 - **Don't let the user think small by habit.** An AI agent builds a web app as fast as a bash script. If the user defaults to "just a CLI" when a real product would serve them better, say so. The narrowest wedge should be narrow in scope, not narrow in ambition.

--- a/think/references/forcing-questions.md
+++ b/think/references/forcing-questions.md
@@ -22,7 +22,7 @@ These questions are designed to be uncomfortable. If they're easy to answer, eit
 **Follow-up probes:**
 - How much time/money are people currently spending on this problem?
 - If you took away their current solution, what would they say?
-- Can you name 3 specific people who would use this tomorrow?
+- Can you name 10 specific people who have this problem? Not personas. Names. If you can't name 10, the problem is either too broad or you're not close enough to the community.
 
 ---
 
@@ -50,11 +50,13 @@ These questions are designed to be uncomfortable. If they're easy to answer, eit
 - "Oncall engineers at startups with <50 employees who get paged at 3am"
 - "Solo founders doing their own bookkeeping before they can afford an accountant"
 - A specific person with a name who said "yes, I'd use that today"
+- You can list 10 real people in the community who struggle with this
 
 **Red flags:**
 - "Developers" — too broad. Which developers? What stack? What company size?
 - "Enterprise companies" — who at the enterprise? The CTO? A platform engineer? A PM?
 - Can't name a specific person or company — the target is imaginary
+- You don't belong to the community you're building for — you're guessing instead of observing
 
 **Why this matters:**
 If nobody would use a broken v1, your v1 scope is wrong. Either narrow the audience or narrow the feature set until someone desperate emerges.
@@ -77,6 +79,8 @@ If nobody would use a broken v1, your v1 scope is wrong. Either narrow the audie
 - If your wedge serves more than 1 user persona, it's too wide
 
 **The test:** Can you describe the wedge in one sentence without using the word "and"?
+
+**Manual delivery test:** Could you deliver this wedge by hand to one person today? No code, just you doing the work. If you can't describe the manual process (trigger, steps, tools, what you deliver), you don't understand the problem well enough to automate it. Build the process first, then the product.
 
 ---
 


### PR DESCRIPTION
## Summary

Three targeted additions from The Minimalist Entrepreneur (Sahil Lavingia) to the `/think` diagnostic:

- **"Name 10 people"**: Raised the bar from "name 3" to "name 10 specific people with this problem." If you can't, the problem is too broad or you're not close enough to the community.
- **Manual delivery test**: Added to Narrowest Wedge. "Could you deliver this wedge by hand to one person today?" If you can't describe the manual process, you don't understand the problem well enough to automate it.
- **Community membership**: New red flag in Desperate Specificity. Building for a community you don't belong to means you're guessing instead of observing.

No structural changes. Same 6 forcing questions, same phases, same handoff format.

## Test plan

- [ ] Run `/think` in startup mode and verify the new probes appear naturally in the diagnostic
- [ ] Verify forcing-questions.md renders correctly