### PR TITLE
Update llms.txt and AGENTS.md with current features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,21 @@ Each skill folder contains an `agents/openai.yaml` for OpenAI-compatible agent d
 
 | Skill | Directory | Description |
 |-------|-----------|-------------|
-| think | `think/` | Strategic product thinking — YC-grade forcing questions, CEO cognitive patterns, premise validation |
-| plan | `plan/` | Implementation planning — scope assessment, step-by-step execution plans with verification |
-| review | `review/` | Two-pass code review — structural correctness then adversarial edge-case hunting |
-| qa | `qa/` | Quality assurance — browser-based testing with Playwright, root-cause debugging |
-| security | `security/` | Security audit — OWASP Top 10, STRIDE threat modeling, dependency scanning |
-| ship | `ship/` | Shipping pipeline — PR creation, CI monitoring, post-merge verification |
-| guard | `guard/` | Safety guardrails — on-demand protection against destructive operations |
-| conductor | `conductor/` | Multi-agent sprint orchestrator — coordinate parallel sessions via claim/complete protocol |
+| think | `think/` | Strategic product thinking. Three modes (Founder/Startup/Builder) with calibrated intensity. YC-grade forcing questions, CEO cognitive patterns, manual delivery test. |
+| plan | `plan/` | Implementation planning. Scope assessment, step-by-step plans with verification, product standards. |
+| review | `review/` | Two-pass code review. Structural then adversarial. Scope drift detection against plan. Conflict detection with /security. |
+| qa | `qa/` | Quality assurance. Browser, API, CLI and debug testing with Playwright. WTF heuristic. |
+| security | `security/` | Security audit. OWASP Top 10, STRIDE, dependency scanning. Cross-references /review for conflicts. Graded report (A-F). |
+| ship | `ship/` | Shipping pipeline. PR creation, CI monitoring, post-merge verification. Generates sprint journal on success. |
+| guard | `guard/` | Three-tier safety. Allowlist, in-project bypass, 28 block rules with safer alternatives. Configurable in guard/rules.json. |
+| conductor | `conductor/` | Multi-agent sprint orchestrator. Parallel sessions via claim/complete protocol with atomic file locking. |
+
+## Know-how Pipeline
+
+Skills automatically save artifacts to `~/.nanostack/` and cross-reference each other. `/ship` generates a sprint journal. The vault at `~/.nanostack/know-how/` works as an Obsidian vault. Run `bin/discard-sprint.sh` to clean up bad sessions.
 
 ## Usage
 
 Each skill's `SKILL.md` contains the full instructions. Read it and follow the process described.
 
-Supporting files (templates, references, checklists, scripts) are in subdirectories — read them when referenced by the SKILL.md.
+Supporting files (templates, references, checklists, scripts) are in subdirectories. Read them when referenced by the SKILL.md.

--- a/llms.txt
+++ b/llms.txt
@@ -1,21 +1,25 @@
 # Nanostack
 
-Nanostack is a set of AI coding agent skills for the full engineering workflow. It works with Claude Code, OpenAI Codex, Amazon Kiro, and any agent that reads SKILL.md files.
+Nanostack is a set of AI coding agent skills for the full engineering workflow. It works with Claude Code, OpenAI Codex, Amazon Kiro and any agent that reads SKILL.md files.
 
 ## What it does
 
-Nanostack gives an AI coding agent a structured sprint process: think, plan, build, review, test, secure, ship. Each skill acts as a specialist (CEO, engineer, QA lead, security auditor) that challenges assumptions, catches bugs, and enforces quality before code reaches production.
+Nanostack gives an AI coding agent a structured sprint process: think, plan, build, review, test, secure, ship. Each skill acts as a specialist (CEO, engineer, QA lead, security auditor) that finds the right problem, scopes the solution, catches bugs and enforces quality before code reaches production.
 
 ## Skills
 
-- /think: Strategic product thinking. Challenges the user's framing, finds the narrowest valuable wedge, applies forcing questions before code is written.
+- /think: Strategic product thinking. Three intensity modes: Founder (full pushback for experienced entrepreneurs), Startup (challenges scope but respects pain points), Builder (minimal pushback, focus on simplest solution). Six forcing questions including manual delivery test and community validation.
 - /plan: Implementation planning. Scope, steps, files, risks, architecture checkpoint, product standards (shadcn/ui, SEO, LLM SEO).
-- /review: Two-pass code review. Structural correctness then adversarial edge-case hunting. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift.
-- /qa: Quality assurance. Browser, API, CLI, and debug testing. Fixes bugs with atomic commits. Stops when further fixes would introduce regressions.
-- /security: Security audit. Auto-detects stack, scans for secrets, injection, auth flaws, CI/CD misconfigs, AI/LLM vulnerabilities. Graded report (A-F).
-- /ship: Ship to production. Pre-flight checks, PR creation, CI monitoring, post-deploy verification, rollback plan.
-- /guard: On-demand safety guardrails. Warns before destructive commands. Locks edits to specific directories.
-- /conductor: Multi-agent sprint orchestrator. Coordinates parallel sessions through claim/complete protocol.
+- /review: Two-pass code review. Structural correctness then adversarial edge-case hunting. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan artifact.
+- /qa: Quality assurance. Browser, API, CLI and debug testing. Fixes bugs with atomic commits. WTF heuristic stops when further fixes would introduce regressions.
+- /security: Security audit. Auto-detects stack, scans for secrets, injection, auth flaws, CI/CD misconfigs, AI/LLM vulnerabilities. Graded report (A-F). Cross-references /review findings for conflict detection.
+- /ship: Ship to production. Pre-flight checks, PR creation, CI monitoring, post-deploy verification, rollback plan. Generates sprint journal automatically.
+- /guard: Three-tier safety. Tier 1: allowlist of safe commands. Tier 2: in-project operations pass (reviewable via git). Tier 3: pattern matching against 28 block rules and 9 warn rules. Blocked commands get a safer alternative. Rules configurable in guard/rules.json.
+- /conductor: Multi-agent sprint orchestrator. Coordinates parallel sessions through claim/complete protocol with atomic file locking.
+
+## Know-how
+
+Skills automatically save structured artifacts to ~/.nanostack/ after every run. Skills cross-reference each other: /review reads /plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at ~/.nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
 
 ## Install
 
@@ -25,8 +29,11 @@ cd ~/.claude/skills/nanostack && ./setup
 ## Key differentiators
 
 - Questions what you're building before you build it (not just a coding assistant)
-- Structured sprint: think → plan → build → review → qa → security → ship
-- Cross-skill coordination: scope drift detection, conflict resolution between review and security findings
+- Calibrated intensity: full pushback for founders, respectful diagnostic for users with clear pain
+- Structured sprint: think, plan, build, review, qa, security, ship
+- Cross-skill coordination: scope drift detection, conflict resolution with 10 built-in precedents
+- Know-how pipeline: artifacts auto-save, skills cross-reference, sprint journals generate on ship
+- Three-tier guard with deny-and-continue (suggests safer alternatives)
 - Product standards enforced at planning time (shadcn/ui, SEO, LLM SEO)
 - Zero dependencies, zero build step, works with any AI coding agent
 - Privacy: no telemetry, no remote calls, all data stays local


### PR DESCRIPTION
## Summary

Both files were stale from v0.1.0. Updated to reflect all changes since:

- **llms.txt**: Added know-how pipeline, guard three-tier, /think calibrated modes, processize, deny-and-continue, cross-skill references, discard-sprint
- **AGENTS.md**: Updated every skill description, added Know-how Pipeline section

## Test plan

- [ ] Verify llms.txt reads well as plain text (this is what LLMs see)
- [ ] Verify AGENTS.md renders correctly on GitHub