### PR TITLE
Rename /plan to /nano-plan (Claude Code built-in collision)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Each skill folder contains an `agents/openai.yaml` for OpenAI-compatible agent d
 | Skill | Directory | Description |
 |-------|-----------|-------------|
 | think | `think/` | Strategic product thinking. Three modes (Founder/Startup/Builder) with calibrated intensity. YC-grade forcing questions, CEO cognitive patterns, manual delivery test. |
-| plan | `plan/` | Implementation planning. Scope assessment, step-by-step plans with verification, product standards. |
+| nano-plan | `plan/` | Implementation planning. Scope assessment, step-by-step plans with verification, product standards. |
 | review | `review/` | Two-pass code review. Structural then adversarial. Scope drift detection against plan. Conflict detection with /security. |
 | qa | `qa/` | Quality assurance. Browser, API, CLI and debug testing with Playwright. WTF heuristic. |
 | security | `security/` | Security audit. OWASP Top 10, STRIDE, dependency scanning. Cross-references /review for conflicts. Graded report (A-F). |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Agent:  I'm going to push back on "notifications." You said users open
         push notifications, but now you have data, not a guess.
 
 You:    Makes sense. Let's do the dot.
-You:    /plan
+You:    /nano-plan
         [3 steps, 2 files, product standards: shadcn/ui + Tailwind]
 
 You:    [builds it]
@@ -63,15 +63,15 @@ You said "notifications." The agent said "your users have a freshness problem" a
 Nanostack is a process, not a collection of tools. The skills run in the order a sprint runs:
 
 ```
-/think → /plan → build → /review → /qa → /security → /ship
+/think → /nano-plan → build → /review → /qa → /security → /ship
 ```
 
-Each skill feeds into the next. `/plan` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. Nothing falls through the cracks because every step knows what came before it.
+Each skill feeds into the next. `/nano-plan` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. Nothing falls through the cracks because every step knows what came before it.
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
 | `/think` | **CEO / Founder** | Start here. Six forcing questions that reframe your product before you write code. Challenges premises, checks your ambition level, finds the narrowest wedge. |
-| `/plan` | **Eng Manager** | Scope, steps, files, risks, architecture checkpoint. Enforces product standards on frontend (shadcn/ui, SEO, LLM discoverability). |
+| `/nano-plan` | **Eng Manager** | Scope, steps, files, risks, architecture checkpoint. Enforces product standards on frontend (shadcn/ui, SEO, LLM discoverability). |
 | `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan. |
 | `/qa` | **QA Lead** | Test your code, find bugs, fix them, re-verify. Browser, API, CLI and debug modes. `--report-only` for findings without fixes. |
 | `/security` | **Security Engineer** | Auto-detects your stack, scans secrets, injection, auth, CI/CD, AI/LLM vulnerabilities. Graded report (A-F). Every finding includes the fix. |
@@ -120,7 +120,7 @@ Agent:  I'm going to push back on "security scanner." A scanner finds
         pre-deploy. Ship tomorrow. The full scanner is a 3-month project.
 
 You:    That makes sense. Let's start with S3.
-You:    /plan
+You:    /nano-plan
         [5 steps, 4 files, risks listed, out-of-scope explicit]
 
 You:    [builds the feature]
@@ -144,7 +144,7 @@ Nanostack works well with one agent. It gets interesting with three running at o
 `/conductor` coordinates multiple sessions. Each agent claims a phase, executes it and the next agent picks up the artifact. Review, QA and security run in parallel because they all depend on build, not on each other.
 
 ```
-/think → /plan → build ─┬─ /review   (Agent A) ─┐
+/think → /nano-plan → build ─┬─ /review   (Agent A) ─┐
                         ├─ /qa       (Agent B)  ├─ /ship
                         └─ /security (Agent C) ─┘
 ```
@@ -248,7 +248,7 @@ Every skill persists its output to `~/.nanostack/` after every run. You don't ad
 
 ```
 /think     →  ~/.nanostack/think/20260325-140000.json
-/plan      →  ~/.nanostack/plan/20260325-143000.json
+/nano-plan →  ~/.nanostack/plan/20260325-143000.json
 /review    →  ~/.nanostack/review/20260325-150000.json
 /qa        →  ~/.nanostack/qa/20260325-151500.json
 /security  →  ~/.nanostack/security/20260325-152000.json
@@ -274,10 +274,10 @@ Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). T
 
 ### Skills read each other
 
-`/review` automatically finds the most recent `/plan` artifact and checks scope drift: did you touch files outside the plan? Did you skip files that were in it?
+`/review` automatically finds the most recent `/nano-plan` artifact and checks scope drift: did you touch files outside the plan? Did you skip files that were in it?
 
 ```
-/plan     →  saves planned_files list
+/nano-plan     →  saves planned_files list
 /review   →  finds plan, compares against git diff, reports:
               "drift_detected: src/unplanned.ts out of scope, tests/auth.test.ts missing"
 ```
@@ -302,7 +302,7 @@ When you run `/ship` and the PR lands, it automatically generates a sprint journ
        →  writes ~/.nanostack/know-how/journal/2026-03-25-myproject.md
 ```
 
-The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
+The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/nano-plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
 
 ### Analytics and learnings
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 | Skill | When to use | Modes | Key files |
 |-------|-------------|-------|-----------|
 | `/think` | Before planning — strategic product thinking, premise validation, scope decisions. | — | `think/references/forcing-questions.md`, `think/references/cognitive-patterns.md` |
-| `/plan` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
+| `/nano-plan` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
 | `/review` | After code is written. Two-pass review + scope drift detection + conflict resolution. | `--quick` `--standard` `--thorough` | `review/checklist.md`, `reference/conflict-precedents.md` |
 | `/qa` | To verify code works. Browser-based testing with Playwright, plus root-cause debugging. | `--quick` `--standard` `--thorough` | `qa/bin/screenshot.sh` |
 | `/security` | Before shipping. OWASP Top 10 + STRIDE + variant analysis + conflict detection. | `--quick` `--standard` `--thorough` | `security/references/owasp-checklist.md`, `security/templates/security-report.md` |
@@ -22,7 +22,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 
 ## Workflow Order
 
-The default workflow is: `/think` → `/plan` → build → `/review` → `/qa` → `/security` → `/ship`
+The default workflow is: `/think` → `/nano-plan` → build → `/review` → `/qa` → `/security` → `/ship`
 
 With `/conductor`, review + qa + security run **in parallel** — they all depend on build, not on each other:
 
@@ -119,7 +119,7 @@ Suggest skills when context matches — don't wait for the user to remember:
 | Trigger | Suggest |
 |---------|---------|
 | User says "what should I build" / unclear on direction | `/think` |
-| Task touches 3+ files or user says "how should I approach this" | `/plan` |
+| Task touches 3+ files or user says "how should I approach this" | `/nano-plan` |
 | User says "done", "finished", "ready for review" | `/review` |
 | User says "does this work", "test this", bug report | `/qa` |
 | Pre-ship, user says "ready to deploy", or diff touches auth/env/infra | `/security` |
@@ -129,7 +129,7 @@ Suggest skills when context matches — don't wait for the user to remember:
 ## Usage Rules
 
 - Start with `/think` for new products or when the "what" is unclear
-- Run `/plan` before building anything that touches more than 3 files
+- Run `/nano-plan` before building anything that touches more than 3 files
 - Run `/review` on your own code — the adversarial pass catches what you missed
 - `/security` is not optional before shipping to production
 - `/guard` is on-demand — activate it, don't leave it always on

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -136,7 +136,7 @@ One agent, one sprint. Same as today — the conductor just adds visibility:
 
 ```
 You:  /conductor start
-You:  /think → /plan → build → /review → /qa → /security → /ship
+You:  /think → /nano-plan → build → /review → /qa → /security → /ship
       [each phase auto-claims and auto-completes]
 ```
 
@@ -146,7 +146,7 @@ One build, then fan out review + qa + security in parallel:
 
 ```
 Terminal 1:  /conductor start
-Terminal 1:  /think → /plan → build
+Terminal 1:  /think → /nano-plan → build
 Terminal 1:  /review
 
 Terminal 2:  /qa              # claims qa (build.done exists)
@@ -161,7 +161,7 @@ Terminal 1:  /ship            # waits until review + qa + security all done
 Multiple developers, each running their own agent:
 
 ```
-Dev A (claude):   /think → /plan
+Dev A (claude):   /think → /nano-plan
 Dev B (codex):    build (claims after plan.done)
 Dev A (claude):   /review (claims after build.done)
 Dev C (kiro):     /security (claims after build.done, parallel with review)

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ Nanostack gives an AI coding agent a structured sprint process: think, plan, bui
 ## Skills
 
 - /think: Strategic product thinking. Three intensity modes: Founder (full pushback for experienced entrepreneurs), Startup (challenges scope but respects pain points), Builder (minimal pushback, focus on simplest solution). Six forcing questions including manual delivery test and community validation.
-- /plan: Implementation planning. Scope, steps, files, risks, architecture checkpoint, product standards (shadcn/ui, SEO, LLM SEO).
+- /nano-plan: Implementation planning. Scope, steps, files, risks, architecture checkpoint, product standards (shadcn/ui, SEO, LLM SEO).
 - /review: Two-pass code review. Structural correctness then adversarial edge-case hunting. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan artifact.
 - /qa: Quality assurance. Browser, API, CLI and debug testing. Fixes bugs with atomic commits. WTF heuristic stops when further fixes would introduce regressions.
 - /security: Security audit. Auto-detects stack, scans for secrets, injection, auth flaws, CI/CD misconfigs, AI/LLM vulnerabilities. Graded report (A-F). Cross-references /review findings for conflict detection.
@@ -19,7 +19,7 @@ Nanostack gives an AI coding agent a structured sprint process: think, plan, bui
 
 ## Know-how
 
-Skills automatically save structured artifacts to ~/.nanostack/ after every run. Skills cross-reference each other: /review reads /plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at ~/.nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
+Skills automatically save structured artifacts to ~/.nanostack/ after every run. Skills cross-reference each other: /review reads /nano-plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at ~/.nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
 
 ## Install
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: plan
-description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /plan.
+description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /nano-plan.
 ---
 
-# /plan — Implementation Planning
+# /nano-plan — Implementation Planning
 
 You turn validated ideas into executable steps. Every file gets named. Every step gets a verification. Every unknown gets surfaced. The plan is a contract: if it says 4 files, the PR should touch 4 files.
 

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -36,7 +36,7 @@ All artifacts share this base structure:
 }
 ```
 
-### /plan
+### /nano-plan
 
 ```json
 {

--- a/reference/conflict-precedents.md
+++ b/reference/conflict-precedents.md
@@ -25,7 +25,7 @@ Known conflicts between skills with pre-defined resolutions. Check this table be
 
 ## Scope: Iteration vs Atomicity
 
-| ID | /plan says | /review says | Tension | Resolution |
+| ID | /nano-plan says | /review says | Tension | Resolution |
 |----|-----------|-------------|---------|------------|
 | CP-007 | "Ship incremental, 3 small PRs" | "These changes are atomic, don't split" | Tradeoff | **Atomicity wins if there's real coupling**. If the system breaks with a subset of the changes, it's one PR. If each subset is independent and deployable, split. Test: can you rollback one PR without breaking the others? |
 | CP-008 | "Add feature X to the scope" | "Scope creep. File a separate issue" | Tradeoff | **/review wins by default**. Scope additions during implementation are almost always scope creep. The exception: you discovered X is a prerequisite of what was planned (not "nice to have" but "breaks without it"). |

--- a/setup
+++ b/setup
@@ -18,7 +18,10 @@ set -e
 NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
-SKILLS=(think plan review qa security ship guard conductor)
+SKILLS=(think nano-plan review qa security ship guard conductor)
+# Map skill names to directories (when they differ)
+declare -A SKILL_DIRS
+SKILL_DIRS[nano-plan]=plan
 
 # sed -i portability (BSD vs GNU)
 if sed --version >/dev/null 2>&1; then
@@ -117,9 +120,10 @@ install_claude() {
 
   for skill in "${SKILLS[@]}"; do
     local target="$skills_dir/$skill"
+    local dir="${SKILL_DIRS[$skill]:-$skill}"
     # Only create symlink if it doesn't exist as a real directory
     if [ -L "$target" ] || [ ! -e "$target" ]; then
-      ln -snf "nanostack/$skill" "$target"
+      ln -snf "nanostack/$dir" "$target"
       linked+=("$skill")
     fi
   done

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -7,7 +7,7 @@ description: Use before planning when you need strategic clarity — product dis
 
 You are a strategic thinking partner. Not a yes-man. Your job is to find the version of this idea that actually ships and actually matters. Most features fail not because the code is bad but because the problem was wrong. Find the right problem first.
 
-This skill runs BEFORE `/plan`. Think answers WHAT and WHY. Plan answers HOW.
+This skill runs BEFORE `/nano-plan`. Think answers WHAT and WHY. Plan answers HOW.
 
 ## Anti-Sycophancy Rules
 
@@ -123,7 +123,7 @@ Based on the diagnostic, recommend one of four scope modes:
 | **Hold** | Solid plan, no reason to change | Bulletproof the current scope |
 | **Reduce** | Weak demand signal, unclear wedge, too broad | Strip to absolute essentials |
 
-### Phase 6: Handoff to /plan
+### Phase 6: Handoff to /nano-plan
 
 Produce a clear brief for the next phase:
 
@@ -137,7 +137,7 @@ Produce a clear brief for the next phase:
 **Key risk:** {{the one thing most likely to make this fail}}
 **Premise validated:** {{yes/no — and why}}
 
-Ready for: /plan
+Ready for: /nano-plan
 ```
 
 ## Save Artifact
@@ -157,5 +157,5 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 - **Don't expand scope when reducing is the right call.** More features ≠ better product. The best v1s do one thing exceptionally well.
 - **"Search Before Building" is literal.** Before proposing to build anything, search for existing solutions. The best code is the code you don't write.
 - **"Processize before you productize."** If the user can't describe how they'd deliver the value by hand (no code), they don't understand the problem well enough to automate it. The manual process comes first.
-- **Don't let this become a planning session.** /think produces a brief, not a plan. If you're writing implementation steps, you've gone too far. Hand off to /plan.
+- **Don't let this become a planning session.** /think produces a brief, not a plan. If you're writing implementation steps, you've gone too far. Hand off to /nano-plan.
 - **Don't let the user think small by habit.** An AI agent builds a web app as fast as a bash script. If the user defaults to "just a CLI" when a real product would serve them better, say so. The narrowest wedge should be narrow in scope, not narrow in ambition.


### PR DESCRIPTION
## Summary

`/plan` is a native Claude Code command (Plan Mode). When users type `/plan`, Claude Code captures it instead of invoking the nanostack skill. Discovered during real-world testing.

- Renamed slash command from `/plan` to `/nano-plan` across all 10 files
- Updated setup script to create symlink `nano-plan -> nanostack/plan`
- The `plan/` directory stays the same, only the command name changes
- Artifacts still save to `~/.nanostack/plan/` (no change)

## Test plan

- [ ] Run `./setup` and verify `~/.claude/skills/nano-plan` symlink exists
- [ ] Run `/nano-plan` in a project and verify it invokes the nanostack skill, not Claude Code Plan Mode