### PR TITLE
Fix bash 3.x compatibility, simplify upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ cd ~/nanostack && ./setup --host kiro
 ### Update
 
 ```bash
-bin/upgrade.sh
+~/.claude/skills/nanostack/bin/upgrade.sh
 ```
 
-Shows what changed, re-runs setup if needed. Or just `git pull`.
+Run from anywhere. Pulls latest, shows what changed, re-runs setup if needed.
 
 No build step. Skills use symlinks. Changes take effect immediately.
 

--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 # upgrade.sh — Update nanostack to latest version
-# Usage: bin/upgrade.sh
+# Usage: ~/.claude/skills/nanostack/bin/upgrade.sh (from anywhere)
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Find nanostack directory
+if [ -f "$(dirname "$0")/../setup" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+elif [ -d "$HOME/.claude/skills/nanostack/.git" ]; then
+  SCRIPT_DIR="$HOME/.claude/skills/nanostack"
+elif [ -f "$HOME/.nanostack/setup.json" ]; then
+  SCRIPT_DIR=$(jq -r '.source' "$HOME/.nanostack/setup.json" 2>/dev/null)
+else
+  echo "Error: can't find nanostack. Is it installed?" >&2
+  exit 1
+fi
+
 cd "$SCRIPT_DIR"
 
-# Check we're in a git repo
 if [ ! -d .git ]; then
-  echo "Error: not a git repository. Run this from the nanostack directory." >&2
+  echo "Error: not a git repository at $SCRIPT_DIR" >&2
   exit 1
 fi
 

--- a/setup
+++ b/setup
@@ -19,9 +19,14 @@ NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
 SKILLS=(think nano-plan review qa security ship guard conductor)
-# Map skill names to directories (when they differ)
-declare -A SKILL_DIRS
-SKILL_DIRS[nano-plan]=plan
+
+# Map skill name to directory (when they differ)
+skill_dir() {
+  case "$1" in
+    nano-plan) echo "plan" ;;
+    *) echo "$1" ;;
+  esac
+}
 
 # sed -i portability (BSD vs GNU)
 if sed --version >/dev/null 2>&1; then
@@ -120,7 +125,8 @@ install_claude() {
 
   for skill in "${SKILLS[@]}"; do
     local target="$skills_dir/$skill"
-    local dir="${SKILL_DIRS[$skill]:-$skill}"
+    local dir
+    dir=$(skill_dir "$skill")
     # Only create symlink if it doesn't exist as a real directory
     if [ -L "$target" ] || [ ! -e "$target" ]; then
       ln -snf "nanostack/$dir" "$target"
@@ -250,8 +256,7 @@ for skill in "${SKILLS[@]}"; do
   echo "  /$skill"
 done
 echo ""
-echo "Workflow: /think → /plan → build → /review → /qa → /security → /ship"
+echo "Workflow: /think → /nano-plan → build → /review → /qa → /security → /ship"
 echo "Safety:   /guard (activate on-demand)"
 echo ""
-echo "Configure: run bin/init-config.sh --interactive in any project"
-echo "Update:    cd $(basename "$NANOSTACK_DIR") && git pull"
+echo "Update:    ~/.claude/skills/nanostack/bin/upgrade.sh"


### PR DESCRIPTION
## Summary

- `declare -A` breaks on macOS default bash (3.x). Replaced with a function.
- `upgrade.sh` now auto-finds nanostack from anywhere. No need to cd first.
- Single command update: `~/.claude/skills/nanostack/bin/upgrade.sh`

## Context

Setup was failing on macOS with `declare: -A: invalid option`. Discovered during real-world testing.

## Test plan

- [ ] Run `bash setup` on macOS (bash 3.x) without errors
- [ ] Run `~/.claude/skills/nanostack/bin/upgrade.sh` from any directory