### PR TITLE
Fix plan frontmatter name to nano-plan

### DIFF
--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan
+name: nano-plan
 description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /nano-plan.
 ---
 


### PR DESCRIPTION
## Summary

One line fix: `name: plan` -> `name: nano-plan` in plan/SKILL.md frontmatter.

Claude Code registers skills by the `name` field, not the directory/symlink name. The previous PR renamed the symlink and all references but missed the frontmatter name, so `/plan` (built-in) was still being invoked instead of the nanostack skill.

## Test plan

- [ ] Type `/nano-plan` in Claude Code, verify it invokes the nanostack skill (not Plan Mode)