### PR TITLE
Add repo quality standards to /ship, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Nanostack works well with one agent. It gets interesting with three running at o
 
 ```
 /think → /nano-plan → build ─┬─ /review   (Agent A) ─┐
-                        ├─ /qa       (Agent B)  ├─ /ship
-                        └─ /security (Agent C) ─┘
+                              ├─ /qa       (Agent B)  ├─ /ship
+                              └─ /security (Agent C) ─┘
 ```
 
 No daemon. No message queue. Just `mkdir` for atomic locking, JSON for state, symlinks for artifact handoff.
@@ -221,6 +221,13 @@ cd ~/nanostack && ./setup --host kiro
 Run from anywhere. Pulls latest, shows what changed, re-runs setup if needed.
 
 No build step. Skills use symlinks. Changes take effect immediately.
+
+### Requirements
+
+- macOS or Linux
+- [jq](https://jqlang.github.io/jq/) for artifact processing (`brew install jq` or `apt install jq`)
+- Git
+- One of: Claude Code, OpenAI Codex, Amazon Kiro
 
 ## The Zen of Nanostack
 
@@ -351,13 +358,13 @@ Find it: `lsof -ti:3000`. Kill it: `kill $(lsof -ti:3000)`.
 Dependencies not finished. Run `conductor/bin/sprint.sh status` to check.
 
 **Skills seem outdated.**
-Run `bin/upgrade.sh` to pull latest and re-run setup.
+Run `~/.claude/skills/nanostack/bin/upgrade.sh` to pull latest and re-run setup.
 
 ## Uninstall
 
 ```bash
 # Claude Code
-cd ~/.claude/skills && rm -f think plan review qa security ship guard conductor && rm -rf nanostack
+cd ~/.claude/skills && rm -f think nano-plan review qa security ship guard conductor && rm -rf nanostack
 
 # Codex
 rm -rf ~/.codex/skills/nanostack*

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -15,7 +15,14 @@ You get code from "done" to "verified in production" in one pass. You own the fu
 
 ### 1. Pre-flight Check
 
-Run `ship/bin/pre-ship-check.sh` first. It checks for uncommitted changes, missing tests, staged secrets, and committing on main. If it reports warnings, address them before proceeding.
+Run both checks before proceeding:
+
+```bash
+ship/bin/pre-ship-check.sh    # uncommitted changes, missing tests, staged secrets, branch check
+ship/bin/quality-check.sh     # broken README links, stale references, writing quality, secrets in diff
+```
+
+If either reports errors, fix them before proceeding. Warnings are informational but should be reviewed.
 
 Then verify:
 
@@ -109,6 +116,35 @@ gh pr create --title "Revert: {{original PR title}}" --body "Reverting due to {{
 ```
 
 Document what went wrong for the team.
+
+### 6. Repo Quality Standards
+
+Before creating the PR, verify these standards. The public repo is the face of the project.
+
+**README:**
+- All internal links resolve (check every `[text](path)` reference)
+- No stale command names or paths from previous versions
+- No AI writing tells: em dashes, en dashes, Oxford commas
+- Examples are accurate and runnable
+- Install instructions work on a clean machine
+
+**PR quality:**
+- Title under 70 characters, starts with a verb
+- Body explains what changed and why, not just what files were touched
+- Test plan is specific enough that someone else could verify it
+- No "Generated with" badges or AI attribution
+
+**Commit quality:**
+- Commit messages explain the why, not just the what
+- One concern per commit when possible
+- No AI attribution in commit messages
+
+**Repo hygiene:**
+- No secrets in the diff (API keys, tokens, passwords)
+- No large binary files committed
+- .gitignore covers editor files, OS files, build artifacts
+
+`ship/bin/quality-check.sh` automates the checks it can. Use your judgment for the rest.
 
 ## Save Artifact and Generate Sprint Journal
 

--- a/ship/bin/quality-check.sh
+++ b/ship/bin/quality-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# quality-check.sh — Verify repo quality before shipping
+# Checks: broken links in README, stale references, writing quality
+# Exit 0 = clean, output includes any warnings found
+set -e
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+WARNINGS=""
+ERRORS=""
+
+# ─── Check README links ──────────────────────────────────────
+if [ -f "$PROJECT_ROOT/README.md" ]; then
+  # Extract relative links from markdown [text](path)
+  LINKS=$(grep -oE '\[.*?\]\([^http][^)]+\)' "$PROJECT_ROOT/README.md" | grep -oE '\([^)]+\)' | tr -d '()' || true)
+  for link in $LINKS; do
+    # Strip anchor fragments
+    file_path=$(echo "$link" | sed 's/#.*//')
+    [ -z "$file_path" ] && continue
+    if [ ! -e "$PROJECT_ROOT/$file_path" ]; then
+      ERRORS="${ERRORS}BROKEN_LINK: README.md links to '$link' but file does not exist\n"
+    fi
+  done
+fi
+
+# ─── Check for stale references in changed files ─────────────
+CHANGED=$(git diff --cached --name-only 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || true)
+for file in $CHANGED; do
+  [ -f "$PROJECT_ROOT/$file" ] || continue
+  case "$file" in
+    *.md|*.txt)
+      # Check for common stale patterns
+      if grep -qn '/plan[^-]' "$PROJECT_ROOT/$file" 2>/dev/null; then
+        LINE=$(grep -n '/plan[^-]' "$PROJECT_ROOT/$file" | head -1 | cut -d: -f1)
+        WARNINGS="${WARNINGS}STALE_REF: $file:$LINE may reference old '/plan' (should be '/nano-plan')\n"
+      fi
+      ;;
+  esac
+done
+
+# ─── Check writing quality in public files ────────────────────
+PUBLIC_FILES="README.md llms.txt AGENTS.md"
+for file in $PUBLIC_FILES; do
+  [ -f "$PROJECT_ROOT/$file" ] || continue
+
+  # Em dashes
+  if grep -Pn '—|–' "$PROJECT_ROOT/$file" >/dev/null 2>&1; then
+    WARNINGS="${WARNINGS}WRITING: $file contains em/en dashes\n"
+  fi
+
+  # Oxford commas (rough check: ", and " in a list context)
+  if grep -n ', and ' "$PROJECT_ROOT/$file" >/dev/null 2>&1; then
+    WARNINGS="${WARNINGS}WRITING: $file may contain Oxford commas\n"
+  fi
+done
+
+# ─── Check for secrets in diff ────────────────────────────────
+DIFF=$(git diff --cached 2>/dev/null || git diff HEAD~1 2>/dev/null || true)
+if echo "$DIFF" | grep -qiE 'api_key|secret_key|password|token.*=.*[a-zA-Z0-9]{20}' 2>/dev/null; then
+  ERRORS="${ERRORS}SECRETS: Possible secrets detected in diff. Review before pushing.\n"
+fi
+
+# ─── Output ───────────────────────────────────────────────────
+if [ -n "$ERRORS" ]; then
+  echo "QUALITY ERRORS"
+  echo -e "$ERRORS"
+fi
+
+if [ -n "$WARNINGS" ]; then
+  echo "QUALITY WARNINGS"
+  echo -e "$WARNINGS"
+fi
+
+if [ -z "$ERRORS" ] && [ -z "$WARNINGS" ]; then
+  echo "QUALITY CLEAN"
+fi

--- a/ship/templates/pr-template.md
+++ b/ship/templates/pr-template.md
@@ -22,5 +22,3 @@
 <!-- How to undo this change if something goes wrong -->
 Revert this PR's merge commit.
 
----
-🤖 Generated with [Nanostack](https://github.com/garagon/nanostack) `/ship`


### PR DESCRIPTION
## Summary

- New `ship/bin/quality-check.sh`: verifies broken README links, stale references, writing quality (em dashes, Oxford commas), secrets in diff
- New "Repo Quality Standards" section in ship/SKILL.md: README, PR, commit and repo hygiene standards
- Removed AI attribution badge from PR template
- Fixed README: stale uninstall refs (plan -> nano-plan), upgrade path, diagram alignment, added Requirements section
- Enabled delete-branch-on-merge on repo

## Test plan

- [ ] Run `ship/bin/quality-check.sh` in a clean repo, verify "QUALITY CLEAN"
- [ ] Verify README links resolve on GitHub
- [ ] Verify Requirements section renders correctly