### PR TITLE
Move storage to project-local .nanostack/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Each skill folder contains an `agents/openai.yaml` for OpenAI-compatible agent d
 
 ## Know-how Pipeline
 
-Skills automatically save artifacts to `~/.nanostack/` and cross-reference each other. `/ship` generates a sprint journal. The vault at `~/.nanostack/know-how/` works as an Obsidian vault. Run `bin/discard-sprint.sh` to clean up bad sessions.
+Skills automatically save artifacts to `.nanostack/` and cross-reference each other. `/ship` generates a sprint journal. The vault at `.nanostack/know-how/` works as an Obsidian vault. Run `bin/discard-sprint.sh` to clean up bad sessions.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -251,15 +251,15 @@ Most AI coding tools are stateless. Every session starts from zero. Nanostack bu
 
 ### Every skill saves automatically
 
-Every skill persists its output to `~/.nanostack/` after every run. You don't add flags. It just happens.
+Every skill persists its output to `.nanostack/` after every run. You don't add flags. It just happens.
 
 ```
-/think     →  ~/.nanostack/think/20260325-140000.json
-/nano-plan →  ~/.nanostack/plan/20260325-143000.json
-/review    →  ~/.nanostack/review/20260325-150000.json
-/qa        →  ~/.nanostack/qa/20260325-151500.json
-/security  →  ~/.nanostack/security/20260325-152000.json
-/ship      →  ~/.nanostack/ship/20260325-160000.json
+/think     →  .nanostack/think/20260325-140000.json
+/nano-plan →  .nanostack/plan/20260325-143000.json
+/review    →  .nanostack/review/20260325-150000.json
+/qa        →  .nanostack/qa/20260325-151500.json
+/security  →  .nanostack/security/20260325-152000.json
+/ship      →  .nanostack/ship/20260325-160000.json
 ```
 
 A review artifact captures everything: findings, scope drift, conflicts resolved.
@@ -277,7 +277,7 @@ A review artifact captures everything: findings, scope drift, conflicts resolved
 }
 ```
 
-Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). To disable, set `auto_save: false` in `~/.nanostack/config.json`.
+Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). To disable, set `auto_save: false` in `.nanostack/config.json`.
 
 ### Skills read each other
 
@@ -306,7 +306,7 @@ When you run `/ship` and the PR lands, it automatically generates a sprint journ
 ```
 /ship  →  saves PR data
        →  runs bin/sprint-journal.sh
-       →  writes ~/.nanostack/know-how/journal/2026-03-25-myproject.md
+       →  writes .nanostack/know-how/journal/2026-03-25-myproject.md
 ```
 
 The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/nano-plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
@@ -335,11 +335,11 @@ This removes artifacts and the journal entry. Analytics recalculate on next run.
 
 ### The Obsidian vault
 
-Open `~/.nanostack/know-how/` in Obsidian. Sprint journals link to conflict precedents. The dashboard links to journals. Graph view shows how sprints, conflicts and learnings connect over time.
+Open `.nanostack/know-how/` in Obsidian. Sprint journals link to conflict precedents. The dashboard links to journals. Graph view shows how sprints, conflicts and learnings connect over time.
 
 ## Privacy
 
-All data stays on your machine in `~/.nanostack/`. No remote calls. No telemetry.
+All data stays on your machine in `.nanostack/`. No remote calls. No telemetry.
 
 Run `bin/analytics.sh` to see your own usage: which skills you run, how often, in what mode. Reads local artifacts only.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,10 +59,10 @@ Skills auto-suggest a mode based on the diff, but the user always decides.
 
 ## Artifact Persistence
 
-Skills automatically save their output to `~/.nanostack/` after every run:
+Skills automatically save their output to `.nanostack/` after every run:
 
 ```bash
-~/.nanostack/<phase>/<timestamp>.json
+.nanostack/<phase>/<timestamp>.json
 ```
 
 This enables:
@@ -71,7 +71,7 @@ This enables:
 - **Sprint journals** — `/ship` generates a journal entry from all phase artifacts
 - **Trend tracking** — Are security findings decreasing over time?
 
-Auto-saving is on by default. The user can disable it by setting `auto_save: false` in `~/.nanostack/config.json`.
+Auto-saving is on by default. The user can disable it by setting `auto_save: false` in `.nanostack/config.json`.
 
 Artifacts are validated before saving: `save-artifact.sh` rejects invalid JSON, missing required fields (`phase`, `summary`), and phase mismatches.
 
@@ -89,7 +89,7 @@ Read `reference/conflict-precedents.md` for known conflict patterns and pre-defi
 
 ## Project Config
 
-On first use in a project, run `bin/init-config.sh --interactive` to create `~/.nanostack/config.json`. This stores:
+On first use in a project, run `bin/init-config.sh --interactive` to create `.nanostack/config.json`. This stores:
 
 - **Installed agents** — auto-detected (claude, codex, kiro)
 - **Detected stack** — node, go, python, docker

--- a/bin/analytics.sh
+++ b/bin/analytics.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # analytics.sh — Local usage stats from your nanostack artifacts
 # Usage: analytics.sh [--month YYYY-MM] [--json]
-# No remote calls. Reads ~/.nanostack/ only.
+# No remote calls. Reads .nanostack/ only.
 set -e
 
-STORE="$HOME/.nanostack"
-KNOW_HOW="$HOME/.nanostack/know-how"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+STORE="$NANOSTACK_STORE"
+KNOW_HOW="$NANOSTACK_STORE/know-how"
 MONTH="${2:-$(date +"%Y-%m")}"
 JSON_OUTPUT=false
 OBSIDIAN_OUTPUT=false

--- a/bin/capture-learning.sh
+++ b/bin/capture-learning.sh
@@ -4,7 +4,10 @@
 # Or: capture-learning.sh (reads from stdin)
 set -e
 
-KNOW_HOW="$HOME/.nanostack/know-how"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+KNOW_HOW="$NANOSTACK_STORE/know-how"
 LEARNINGS_FILE="$KNOW_HOW/learnings/ongoing.md"
 DATE=$(date +"%Y-%m-%d")
 PROJECT=$(basename "$(pwd)")

--- a/bin/discard-sprint.sh
+++ b/bin/discard-sprint.sh
@@ -7,7 +7,10 @@
 #   discard-sprint.sh --dry-run           # show what would be deleted without deleting
 set -e
 
-STORE="$HOME/.nanostack"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+STORE="$NANOSTACK_STORE"
 KNOW_HOW="$STORE/know-how"
 PROJECT="$(pwd)"
 PROJECT_NAME=$(basename "$PROJECT")

--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -5,9 +5,12 @@
 # Returns: path to most recent artifact, or empty + exit 1 if none found
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
 PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days]}"
 MAX_AGE="${2:-30}"
-STORE="$HOME/.nanostack/$PHASE"
+STORE="$NANOSTACK_STORE/$PHASE"
 PROJECT="$(pwd)"
 
 [ -d "$STORE" ] || exit 1

--- a/bin/init-config.sh
+++ b/bin/init-config.sh
@@ -5,7 +5,10 @@
 # With --interactive: prompts user via stdout questions (for agent to parse)
 set -e
 
-CONFIG="$HOME/.nanostack/config.json"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+CONFIG="$NANOSTACK_STORE/config.json"
 
 # If config exists, output it and exit
 if [ -f "$CONFIG" ]; then
@@ -20,7 +23,7 @@ if [ "$1" != "--interactive" ]; then
 fi
 
 # Interactive mode — create config directory
-mkdir -p "$HOME/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
 
 # Detect installed agents
 AGENTS="[]"

--- a/bin/lib/store-path.sh
+++ b/bin/lib/store-path.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# store-path.sh — Resolve the .nanostack store path
+# Sources into other scripts. Sets NANOSTACK_STORE variable.
+#
+# Priority:
+#   1. NANOSTACK_STORE env var (explicit override)
+#   2. <git-root>/.nanostack (project-local, default)
+#   3. $HOME/.nanostack (fallback if not in a git repo)
+
+if [ -z "${NANOSTACK_STORE:-}" ]; then
+  _GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [ -n "$_GIT_ROOT" ]; then
+    NANOSTACK_STORE="$_GIT_ROOT/.nanostack"
+  else
+    NANOSTACK_STORE="$HOME/.nanostack"
+  fi
+  unset _GIT_ROOT
+fi
+
+export NANOSTACK_STORE

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# save-artifact.sh — Save a skill artifact to ~/.nanostack/<phase>/
+# save-artifact.sh — Save a skill artifact to .nanostack/<phase>/
 # Usage: save-artifact.sh <phase> <json-string>
 # Example: save-artifact.sh review '{"phase":"review","summary":{"blocking":0}}'
 # Validates JSON has required fields before saving. Fails on invalid input.
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
 PHASE="${1:?Usage: save-artifact.sh <phase> <json>}"
 JSON="${2:?Missing JSON argument}"
-STORE="$HOME/.nanostack/$PHASE"
+STORE="$NANOSTACK_STORE/$PHASE"
 VALID_PHASES="think plan review qa security ship"
 
 # Validate phase name

--- a/bin/sprint-journal.sh
+++ b/bin/sprint-journal.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # sprint-journal.sh — Generate an Obsidian journal entry from sprint artifacts
 # Usage: sprint-journal.sh [--project <name>]
-# Reads ~/.nanostack/ artifacts and writes to ~/.nanostack/know-how/journal/<date>-<project>.md
+# Reads .nanostack/ artifacts and writes to .nanostack/know-how/journal/<date>-<project>.md
 set -e
 
-STORE="$HOME/.nanostack"
-KNOW_HOW="$HOME/.nanostack/know-how"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+STORE="$NANOSTACK_STORE"
+KNOW_HOW="$NANOSTACK_STORE/know-how"
 PROJECT_NAME="${2:-$(basename "$(pwd)")}"
 DATE=$(date -u +"%Y-%m-%d")
 MONTH=$(date -u +"%Y-%m")

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -7,7 +7,7 @@ description: Orchestrate parallel agent sessions through a sprint. Coordinates t
 
 Coordinate multiple agent sessions working on the same project. Each agent claims a task, executes it, produces an artifact, and the next agent picks up where it left off.
 
-**No daemon. No service. No IPC.** Just atomic file operations on `~/.nanostack/conductor/`.
+**No daemon. No service. No IPC.** Just atomic file operations on `.nanostack/conductor/`.
 
 ## How it works
 
@@ -57,7 +57,7 @@ Note: `review`, `qa`, and `security` can run **in parallel** — they all depend
 conductor/bin/sprint.sh start [--phases "think,plan,build,review,qa,security,ship"]
 ```
 
-Creates `~/.nanostack/conductor/<sprint_id>/` with the phase graph. Default is the full workflow.
+Creates `.nanostack/conductor/<sprint_id>/` with the phase graph. Default is the full workflow.
 
 ### Claim a phase
 
@@ -97,13 +97,13 @@ Release a claim without completing. Use when an agent encounters a blocker.
 ## Filesystem Protocol
 
 ```
-~/.nanostack/conductor/
+.nanostack/conductor/
 └── <sprint_id>/
     ├── sprint.json              # Sprint definition + metadata
     ├── think/
     │   ├── lock                 # Contains: {"agent":"claude","claimed_at":"...","pid":1234}
     │   ├── done                 # Exists = phase complete. Contains: {"completed_at":"...","artifact":"..."}
-    │   └── artifact.json → ...  # Symlink to the actual artifact in ~/.nanostack/think/
+    │   └── artifact.json → ...  # Symlink to the actual artifact in .nanostack/think/
     ├── plan/
     │   ├── lock
     │   └── ...

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -4,7 +4,10 @@
 # Commands: start, claim, complete, abort, status, clean
 set -e
 
-CONDUCTOR_DIR="$HOME/.nanostack/conductor"
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$SCRIPT_DIR/bin/lib/store-path.sh"
+
+CONDUCTOR_DIR="$NANOSTACK_STORE/conductor"
 PROJECT="$(pwd)"
 PROJECT_HASH=$(echo -n "$PROJECT" | shasum -a 256 | cut -c1-12)
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ Nanostack gives an AI coding agent a structured sprint process: think, plan, bui
 
 ## Know-how
 
-Skills automatically save structured artifacts to ~/.nanostack/ after every run. Skills cross-reference each other: /review reads /nano-plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at ~/.nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
+Skills automatically save structured artifacts to .nanostack/ after every run. Skills cross-reference each other: /review reads /nano-plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at .nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
 
 ## Install
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -102,7 +102,7 @@ bin/save-artifact.sh plan '<json with phase, summary including planned_files arr
 
 The `planned_files` list is critical. `/review` uses it for scope drift detection via `bin/scope-drift.sh`. See `reference/artifact-schema.md` for the full schema.
 
-The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Next Step
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -118,7 +118,7 @@ Always persist the QA results after completing the run:
 bin/save-artifact.sh qa '<json with phase, mode, summary including wtf_likelihood, findings>'
 ```
 
-See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Mode Summary
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -110,7 +110,7 @@ Always persist the review after completing it:
 bin/save-artifact.sh review '<json with phase, mode, summary, scope_drift, findings, conflicts>'
 ```
 
-See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Mode Summary
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -22,7 +22,7 @@ Auto-suggest:
 
 **Thorough-only features:**
 - **Variant analysis:** When a finding is VERIFIED, search the entire codebase for the same pattern. One confirmed SQL injection means there may be more.
-- **Conflict detection:** Cross-reference with `/review` artifacts in `~/.nanostack/review/` for contradictions.
+- **Conflict detection:** Cross-reference with `/review` artifacts in `.nanostack/review/` for contradictions.
 - **TENTATIVE findings:** Below confidence gate but worth noting. Mark as `TENTATIVE: <description>`.
 
 ## Setup (first run per project)
@@ -213,7 +213,7 @@ Always persist the security audit after completing it:
 bin/save-artifact.sh security '<json with phase, mode, summary, findings, conflicts>'
 ```
 
-See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Mode Summary
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -155,9 +155,9 @@ bin/save-artifact.sh ship '<json with phase, summary including pr_number, pr_url
 bin/sprint-journal.sh
 ```
 
-The sprint journal reads all phase artifacts (think, plan, review, qa, security, ship) and writes a single entry to `~/.nanostack/know-how/journal/`. This happens automatically on every successful ship.
+The sprint journal reads all phase artifacts (think, plan, review, qa, security, ship) and writes a single entry to `.nanostack/know-how/journal/`. This happens automatically on every successful ship.
 
-The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Output
 
@@ -165,7 +165,7 @@ After shipping, close with a summary:
 ```
 Ship: PR #42 created. CI passed. Deployed. Smoke test clean.
 Tests: 42 → 51 (+9 new). No regressions.
-Journal: ~/.nanostack/know-how/journal/2026-03-25-myproject.md
+Journal: .nanostack/know-how/journal/2026-03-25-myproject.md
 ```
 
 Include before/after test counts when tests were added during the sprint. Quantify the improvement.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -148,7 +148,7 @@ Always persist the think output after the handoff brief:
 bin/save-artifact.sh think '<json with phase, summary including value_proposition, scope_mode, target_user, narrowest_wedge, key_risk, premise_validated>'
 ```
 
-See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `~/.nanostack/config.json`.
+See `reference/artifact-schema.md` for the full schema. The user can disable auto-saving by setting `auto_save: false` in `.nanostack/config.json`.
 
 ## Next Step
 


### PR DESCRIPTION
## Summary

All artifacts, know-how, journals and config now live inside the project directory at `.nanostack/` instead of `~/.nanostack/`.

- New `bin/lib/store-path.sh` resolves store path: project-local by default, global fallback
- All 8 scripts updated to source the helper
- All 19 docs updated from `~/.nanostack` to `.nanostack`
- Supports `NANOSTACK_STORE` env var for explicit override

The user opens their project and sees everything. Each project has its own know-how, artifacts and journals. No hidden global state mixing data from different projects.

## Test plan

- [ ] Run `bin/save-artifact.sh` from a git repo and verify artifact goes to `<repo>/.nanostack/`
- [ ] Run `bin/sprint-journal.sh` and verify journal goes to `<repo>/.nanostack/know-how/journal/`
- [ ] Run from outside a git repo and verify fallback to `~/.nanostack/`
- [ ] Set `NANOSTACK_STORE=/tmp/test` and verify override works