### PR TITLE
Add --autopilot mode for full sprint automation

### DIFF
--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -38,12 +38,12 @@ if [ "$BEFORE" = "$AFTER" ]; then
   exit 0
 fi
 
-# Show what changed
-COMMITS=$(git log --oneline "$BEFORE".."$AFTER" | wc -l | tr -d ' ')
+# Show what changed (--no-pager prevents opening less/vim)
+COMMITS=$(git --no-pager log --oneline "$BEFORE".."$AFTER" | wc -l | tr -d ' ')
 echo ""
 echo "Updated: $COMMITS new commits"
 echo ""
-git log --oneline "$BEFORE".."$AFTER"
+git --no-pager log --oneline "$BEFORE".."$AFTER"
 
 # Check if setup needs re-run (new skills or setup changes)
 CHANGED=$(git diff --name-only "$BEFORE".."$AFTER")

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -118,7 +118,24 @@ The user can disable auto-saving by setting `auto_save: false` in `.nanostack/co
 
 ## Next Step
 
-After the user approves the plan and you finish building, tell the user:
+After the user approves the plan and you finish building:
+
+**If AUTOPILOT is active:**
+
+Proceed directly to `/review`. After review completes, run `/security`. After security, run `/qa`. After all three pass, run `/ship`. Only stop if:
+- `/review` finds **blocking** issues that need user decision
+- `/security` finds **critical** vulnerabilities
+- A product question comes up that you can't answer from context
+
+Between each step, show a brief status:
+> Autopilot: build complete. Running /review...
+> Autopilot: review clean. Running /security...
+> Autopilot: security grade A. Running /qa...
+> Autopilot: qa passed. Running /ship...
+
+**Otherwise (default):**
+
+Tell the user:
 
 > Build complete. Next steps in the sprint:
 > - `/review` to run a two-pass code review with scope drift detection
@@ -127,7 +144,7 @@ After the user approves the plan and you finish building, tell the user:
 >
 > These three can run in any order. After all pass, `/ship` to create the PR.
 
-Do NOT run `/review`, `/qa`, or `/security` automatically. Wait for the user to invoke each one.
+Wait for the user to invoke each one.
 
 ## Gotchas
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -132,8 +132,13 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 
 ## Next Step
 
-After QA is complete and the artifact is saved, tell the user what's next:
+After QA is complete and the artifact is saved:
 
+**If AUTOPILOT is active and tests pass:** Proceed to `/ship`. Show: `Autopilot: qa passed (X tests, 0 failed). Running /ship...`
+
+**If AUTOPILOT is active but tests fail:** Stop and ask the user. Show failures and wait.
+
+**Otherwise:** Tell the user:
 > QA complete. Remaining steps:
 > - `/review` to run code review (if not done yet)
 > - `/security` to audit for vulnerabilities (if not done yet)

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -124,8 +124,13 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 
 ## Next Step
 
-After the review is complete and the artifact is saved, tell the user what's next in the sprint:
+After the review is complete and the artifact is saved:
 
+**If AUTOPILOT is active and no blocking issues found:** Proceed directly to the next pending skill (`/security` or `/qa`). Show: `Autopilot: review complete (X findings, 0 blocking). Running /security...`
+
+**If AUTOPILOT is active but blocking issues found:** Stop and ask the user to resolve. Show the blocking issues and wait. After resolution, continue autopilot.
+
+**Otherwise:** Tell the user:
 > Review complete. Remaining steps:
 > - `/security` to audit for vulnerabilities (if not done yet)
 > - `/qa` to test that everything works (if not done yet)

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -228,8 +228,13 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 
 ## Next Step
 
-After the security audit is complete and the artifact is saved, tell the user what's next:
+After the security audit is complete and the artifact is saved:
 
+**If AUTOPILOT is active and no critical/high findings:** Proceed to next pending skill (`/qa` or `/ship`). Show: `Autopilot: security grade X (0 critical, 0 high). Running /qa...`
+
+**If AUTOPILOT is active but critical or high findings found:** Stop and ask the user to review. Show the findings and wait. After resolution, continue autopilot.
+
+**Otherwise:** Tell the user:
 > Security audit complete. Remaining steps:
 > - `/review` to run code review (if not done yet)
 > - `/qa` to test that everything works (if not done yet)

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: think
-description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Triggers on /think, /office-hours, /ceo-review.
+description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Supports --autopilot to run the full sprint automatically after approval. Triggers on /think, /office-hours, /ceo-review.
 ---
 
 # /think — Strategic Product Thinking
@@ -152,11 +152,23 @@ See `reference/artifact-schema.md` for the full schema. The user can disable aut
 
 ## Next Step
 
-After the Think Summary and artifact are saved, tell the user:
+After the Think Summary and artifact are saved:
+
+**If `--autopilot` was used (or the user said "autopilot", "run everything", "ship it end to end"):**
+
+Tell the user:
+
+> Autopilot active. Proceeding with the full sprint: /nano-plan, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
+
+Then proceed directly to `/nano-plan` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
+
+**Otherwise (default):**
+
+Tell the user:
 
 > Ready for `/nano-plan`. Say `/nano-plan` to create the implementation plan, or adjust the brief first.
 
-Do NOT proceed to planning automatically. Wait for the user to invoke `/nano-plan`.
+Wait for the user to invoke `/nano-plan`.
 
 ## Gotchas
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -35,7 +35,11 @@ This skill runs BEFORE `/nano-plan`. Think answers WHAT and WHY. Plan answers HO
 
 ### Phase 1: Context Gathering
 
-Understand the landscape, then determine the mode. Ask using `AskUserQuestion` if unclear:
+Understand the landscape, then determine the mode.
+
+**If the user didn't provide an idea or problem** (e.g. they just said `/think` or `/think --autopilot` with no context), simply ask in your response: "What do you want to build?" Do NOT use `AskUserQuestion` for this. Just ask in plain text and wait for their reply.
+
+Determine the mode from the user's description:
 
 - **Founder mode**: Experienced entrepreneur stress-testing an idea. Wants to be challenged hard. Applies full YC diagnostic with maximum pushback. Use when the user explicitly asks for a tough review or says something like "tear this apart."
 - **Startup mode** (default for product ideas): Building a product for users/customers. Applies YC diagnostic. Challenges scope and approach but respects stated pain points.


### PR DESCRIPTION
## Summary

New `--autopilot` flag on `/think` that runs the entire sprint automatically after the user approves the idea:

```
/think --autopilot
```

The user discusses the idea interactively with `/think` as usual. After approving the brief, the agent runs the full sprint without manual invocation of each skill:

`/nano-plan` → build → `/review` → `/security` → `/qa` → `/ship`

Autopilot stops only for:
- Blocking issues in `/review` that need user decision
- Critical/high findings in `/security`
- Test failures in `/qa`
- Product questions the agent can't answer

Between steps the agent shows brief status updates. Default behavior (without --autopilot) is unchanged.

Also triggers on natural language: "autopilot", "run everything", "ship it end to end".

## Test plan

- [ ] Run `/think --autopilot`, approve brief, verify full sprint runs automatically
- [ ] Run `/think` without flag, verify manual flow is unchanged
- [ ] Verify autopilot stops on blocking review findings