### PR TITLE
Rename /nano-plan to /nano

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Each skill folder contains an `agents/openai.yaml` for OpenAI-compatible agent d
 | Skill | Directory | Description |
 |-------|-----------|-------------|
 | think | `think/` | Strategic product thinking. Three modes (Founder/Startup/Builder) with calibrated intensity. YC-grade forcing questions, CEO cognitive patterns, manual delivery test. |
-| nano-plan | `plan/` | Implementation planning. Scope assessment, step-by-step plans with verification, product standards. |
+| nano | `plan/` | Implementation planning. Scope assessment, step-by-step plans with verification, product standards. |
 | review | `review/` | Two-pass code review. Structural then adversarial. Scope drift detection against plan. Conflict detection with /security. |
 | qa | `qa/` | Quality assurance. Browser, API, CLI and debug testing with Playwright. WTF heuristic. |
 | security | `security/` | Security audit. OWASP Top 10, STRIDE, dependency scanning. Cross-references /review for conflicts. Graded report (A-F). |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Agent:  I'm going to push back on "notifications." You said users open
         push notifications, but now you have data, not a guess.
 
 You:    Makes sense. Let's do the dot.
-You:    /nano-plan
+You:    /nano
         [3 steps, 2 files, product standards: shadcn/ui + Tailwind]
 
 You:    [builds it]
@@ -63,15 +63,15 @@ You said "notifications." The agent said "your users have a freshness problem" a
 Nanostack is a process, not a collection of tools. The skills run in the order a sprint runs:
 
 ```
-/think → /nano-plan → build → /review → /qa → /security → /ship
+/think → /nano → build → /review → /qa → /security → /ship
 ```
 
-Each skill feeds into the next. `/nano-plan` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. Nothing falls through the cracks because every step knows what came before it.
+Each skill feeds into the next. `/nano` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. Nothing falls through the cracks because every step knows what came before it.
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
 | `/think` | **CEO / Founder** | Three intensity modes: Founder (full pushback), Startup (challenges scope, respects pain) and Builder (minimal pushback). Six forcing questions including manual delivery test and community validation. `--autopilot` runs the full sprint after approval. |
-| `/nano-plan` | **Eng Manager** | Auto-generates product specs (Medium scope) or product + technical specs (Large scope) before implementation steps. Product standards for web (shadcn/ui), CLI/TUI (Bubble Tea, Rich, Ink, Ratatui). Stack defaults with CLI preference for beginners. |
+| `/nano` | **Eng Manager** | Auto-generates product specs (Medium scope) or product + technical specs (Large scope) before implementation steps. Product standards for web (shadcn/ui), CLI/TUI (Bubble Tea, Rich, Ink, Ratatui). Stack defaults with CLI preference for beginners. |
 | `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan. Cross-references `/security` with 10 conflict precedents. |
 | `/qa` | **QA Lead** | Functional testing + Visual QA. Takes screenshots and analyzes UI against product standards. Browser, API, CLI and debug modes. WTF heuristic stops before fixes cause regressions. |
 | `/security` | **Security Engineer** | Auto-detects your stack, scans secrets, injection, auth, CI/CD, AI/LLM vulnerabilities. Graded report (A-F). Cross-references `/review` for conflict detection. Every finding includes the fix. |
@@ -96,7 +96,7 @@ Not every change needs a full audit. `/review`, `/qa` and `/security` support th
 
 ### Specs by scope
 
-`/nano-plan` generates specs automatically based on project complexity:
+`/nano` generates specs automatically based on project complexity:
 
 | Scope | What you get |
 |-------|-------------|
@@ -134,7 +134,7 @@ Agent:  I'm going to push back on "security scanner." A scanner finds
         pre-deploy. Ship tomorrow. The full scanner is a 3-month project.
 
 You:    That makes sense. Let's start with S3.
-You:    /nano-plan
+You:    /nano
         [5 steps, 4 files, risks listed, out-of-scope explicit]
 
 You:    [builds the feature]
@@ -162,7 +162,7 @@ Discuss the idea, approve the brief, walk away. The agent runs the full sprint:
 `/think` is interactive: the agent asks questions, you answer, you align on the brief. After you approve, everything else runs automatically:
 
 ```
-/nano-plan → build → /review → /security → /qa → /ship
+/nano → build → /review → /security → /qa → /ship
 ```
 
 Autopilot only stops if:
@@ -186,7 +186,7 @@ Nanostack works well with one agent. It gets interesting with three running at o
 `/conductor` coordinates multiple sessions. Each agent claims a phase, executes it and the next agent picks up the artifact. Review, QA and security run in parallel because they all depend on build, not on each other.
 
 ```
-/think → /nano-plan → build ─┬─ /review   (Agent A) ─┐
+/think → /nano → build ─┬─ /review   (Agent A) ─┐
                               ├─ /qa       (Agent B)  ├─ /ship
                               └─ /security (Agent C) ─┘
 ```
@@ -307,7 +307,7 @@ Every skill persists its output to `.nanostack/` after every run. You don't add 
 
 ```
 /think     →  .nanostack/think/20260325-140000.json
-/nano-plan →  .nanostack/plan/20260325-143000.json
+/nano →  .nanostack/plan/20260325-143000.json
 /review    →  .nanostack/review/20260325-150000.json
 /qa        →  .nanostack/qa/20260325-151500.json
 /security  →  .nanostack/security/20260325-152000.json
@@ -333,10 +333,10 @@ Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). T
 
 ### Skills read each other
 
-`/review` automatically finds the most recent `/nano-plan` artifact and checks scope drift: did you touch files outside the plan? Did you skip files that were in it?
+`/review` automatically finds the most recent `/nano` artifact and checks scope drift: did you touch files outside the plan? Did you skip files that were in it?
 
 ```
-/nano-plan     →  saves planned_files list
+/nano     →  saves planned_files list
 /review   →  finds plan, compares against git diff, reports:
               "drift_detected: src/unplanned.ts out of scope, tests/auth.test.ts missing"
 ```
@@ -361,7 +361,7 @@ When you run `/ship` and the PR lands, it automatically generates a sprint journ
        →  writes .nanostack/know-how/journal/2026-03-25-myproject.md
 ```
 
-The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/nano-plan` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
+The journal reads every phase artifact from the sprint and writes one file with the full decision trail: what `/think` reframed, what `/nano` scoped, what `/review` found, how conflicts were resolved, what `/security` graded.
 
 ### Analytics and learnings
 
@@ -416,7 +416,7 @@ Run `~/.claude/skills/nanostack/bin/upgrade.sh` to pull latest and re-run setup.
 
 ```bash
 # Claude Code
-cd ~/.claude/skills && rm -f think nano-plan review qa security ship guard conductor && rm -rf nanostack
+cd ~/.claude/skills && rm -f think nano review qa security ship guard conductor && rm -rf nanostack
 
 # Codex
 rm -rf ~/.codex/skills/nanostack*

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 | Skill | When to use | Modes | Key files |
 |-------|-------------|-------|-----------|
 | `/think` | Before planning — strategic product thinking, premise validation, scope decisions. | — | `think/references/forcing-questions.md`, `think/references/cognitive-patterns.md` |
-| `/nano-plan` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
+| `/nano` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
 | `/review` | After code is written. Two-pass review + scope drift detection + conflict resolution. | `--quick` `--standard` `--thorough` | `review/checklist.md`, `reference/conflict-precedents.md` |
 | `/qa` | To verify code works. Browser-based testing with Playwright, plus root-cause debugging. | `--quick` `--standard` `--thorough` | `qa/bin/screenshot.sh` |
 | `/security` | Before shipping. OWASP Top 10 + STRIDE + variant analysis + conflict detection. | `--quick` `--standard` `--thorough` | `security/references/owasp-checklist.md`, `security/templates/security-report.md` |
@@ -22,7 +22,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 
 ## Workflow Order
 
-The default workflow is: `/think` → `/nano-plan` → build → `/review` → `/qa` → `/security` → `/ship`
+The default workflow is: `/think` → `/nano` → build → `/review` → `/qa` → `/security` → `/ship`
 
 With `/conductor`, review + qa + security run **in parallel** — they all depend on build, not on each other:
 
@@ -119,7 +119,7 @@ Suggest skills when context matches — don't wait for the user to remember:
 | Trigger | Suggest |
 |---------|---------|
 | User says "what should I build" / unclear on direction | `/think` |
-| Task touches 3+ files or user says "how should I approach this" | `/nano-plan` |
+| Task touches 3+ files or user says "how should I approach this" | `/nano` |
 | User says "done", "finished", "ready for review" | `/review` |
 | User says "does this work", "test this", bug report | `/qa` |
 | Pre-ship, user says "ready to deploy", or diff touches auth/env/infra | `/security` |
@@ -129,7 +129,7 @@ Suggest skills when context matches — don't wait for the user to remember:
 ## Usage Rules
 
 - Start with `/think` for new products or when the "what" is unclear
-- Run `/nano-plan` before building anything that touches more than 3 files
+- Run `/nano` before building anything that touches more than 3 files
 - Run `/review` on your own code — the adversarial pass catches what you missed
 - `/security` is not optional before shipping to production
 - `/guard` is on-demand — activate it, don't leave it always on

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -136,7 +136,7 @@ One agent, one sprint. Same as today — the conductor just adds visibility:
 
 ```
 You:  /conductor start
-You:  /think → /nano-plan → build → /review → /qa → /security → /ship
+You:  /think → /nano → build → /review → /qa → /security → /ship
       [each phase auto-claims and auto-completes]
 ```
 
@@ -146,7 +146,7 @@ One build, then fan out review + qa + security in parallel:
 
 ```
 Terminal 1:  /conductor start
-Terminal 1:  /think → /nano-plan → build
+Terminal 1:  /think → /nano → build
 Terminal 1:  /review
 
 Terminal 2:  /qa              # claims qa (build.done exists)
@@ -161,7 +161,7 @@ Terminal 1:  /ship            # waits until review + qa + security all done
 Multiple developers, each running their own agent:
 
 ```
-Dev A (claude):   /think → /nano-plan
+Dev A (claude):   /think → /nano
 Dev B (codex):    build (claims after plan.done)
 Dev A (claude):   /review (claims after build.done)
 Dev C (kiro):     /security (claims after build.done, parallel with review)

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ Nanostack gives an AI coding agent a structured sprint process: think, plan, bui
 ## Skills
 
 - /think: Strategic product thinking. Three intensity modes: Founder (full pushback for experienced entrepreneurs), Startup (challenges scope but respects pain points), Builder (minimal pushback, focus on simplest solution). Six forcing questions including manual delivery test and community validation.
-- /nano-plan: Implementation planning. Scope, steps, files, risks, architecture checkpoint, product standards (shadcn/ui, SEO, LLM SEO).
+- /nano: Implementation planning. Scope, steps, files, risks, architecture checkpoint, product standards (shadcn/ui, SEO, LLM SEO).
 - /review: Two-pass code review. Structural correctness then adversarial edge-case hunting. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan artifact.
 - /qa: Quality assurance. Browser, API, CLI and debug testing. Fixes bugs with atomic commits. WTF heuristic stops when further fixes would introduce regressions.
 - /security: Security audit. Auto-detects stack, scans for secrets, injection, auth flaws, CI/CD misconfigs, AI/LLM vulnerabilities. Graded report (A-F). Cross-references /review findings for conflict detection.
@@ -19,7 +19,7 @@ Nanostack gives an AI coding agent a structured sprint process: think, plan, bui
 
 ## Know-how
 
-Skills automatically save structured artifacts to .nanostack/ after every run. Skills cross-reference each other: /review reads /nano-plan for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at .nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
+Skills automatically save structured artifacts to .nanostack/ after every run. Skills cross-reference each other: /review reads /nano for scope drift, /security reads /review for conflict detection. /ship generates a sprint journal from all phase artifacts. The know-how vault at .nanostack/know-how/ works as an Obsidian vault with linked journals, analytics dashboards and learnings. Bad sessions can be discarded with bin/discard-sprint.sh.
 
 ## Install
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: nano-plan
-description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /nano-plan.
+name: nano
+description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /nano.
 ---
 
-# /nano-plan — Implementation Planning
+# /nano — Implementation Planning
 
 You turn validated ideas into executable steps. Every file gets named. Every step gets a verification. Every unknown gets surfaced. The plan is a contract: if it says 4 files, the PR should touch 4 files.
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -75,7 +75,7 @@ After functional tests pass, take screenshots of every key state and analyze the
 6. **Responsive**: Does the layout work at mobile width or does it break/overflow?
 7. **Dark mode**: If dark mode is enabled, are there contrast issues, invisible borders, or text that blends into the background?
 
-**Cross-reference against `/nano-plan` product standards.** If the plan said "shadcn/ui + Tailwind" and the output looks like raw HTML with inline styles, that's a finding.
+**Cross-reference against `/nano` product standards.** If the plan said "shadcn/ui + Tailwind" and the output looks like raw HTML with inline styles, that's a finding.
 
 **Report visual findings as QA findings:**
 ```

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -36,7 +36,7 @@ All artifacts share this base structure:
 }
 ```
 
-### /nano-plan
+### /nano
 
 ```json
 {

--- a/reference/conflict-precedents.md
+++ b/reference/conflict-precedents.md
@@ -25,7 +25,7 @@ Known conflicts between skills with pre-defined resolutions. Check this table be
 
 ## Scope: Iteration vs Atomicity
 
-| ID | /nano-plan says | /review says | Tension | Resolution |
+| ID | /nano says | /review says | Tension | Resolution |
 |----|-----------|-------------|---------|------------|
 | CP-007 | "Ship incremental, 3 small PRs" | "These changes are atomic, don't split" | Tradeoff | **Atomicity wins if there's real coupling**. If the system breaks with a subset of the changes, it's one PR. If each subset is independent and deployable, split. Test: can you rollback one PR without breaking the others? |
 | CP-008 | "Add feature X to the scope" | "Scope creep. File a separate issue" | Tradeoff | **/review wins by default**. Scope additions during implementation are almost always scope creep. The exception: you discovered X is a prerequisite of what was planned (not "nice to have" but "breaks without it"). |

--- a/setup
+++ b/setup
@@ -18,12 +18,12 @@ set -e
 NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
-SKILLS=(think nano-plan review qa security ship guard conductor)
+SKILLS=(think nano review qa security ship guard conductor)
 
 # Map skill name to directory (when they differ)
 skill_dir() {
   case "$1" in
-    nano-plan) echo "plan" ;;
+    nano) echo "plan" ;;
     *) echo "$1" ;;
   esac
 }
@@ -256,7 +256,7 @@ for skill in "${SKILLS[@]}"; do
   echo "  /$skill"
 done
 echo ""
-echo "Workflow: /think → /nano-plan → build → /review → /qa → /security → /ship"
+echo "Workflow: /think → /nano → build → /review → /qa → /security → /ship"
 echo "Safety:   /guard (activate on-demand)"
 echo ""
 echo "Per-project setup (run once in each project):"

--- a/ship/bin/quality-check.sh
+++ b/ship/bin/quality-check.sh
@@ -31,7 +31,7 @@ for file in $CHANGED; do
       # Check for common stale patterns
       if grep -qn '/plan[^-]' "$PROJECT_ROOT/$file" 2>/dev/null; then
         LINE=$(grep -n '/plan[^-]' "$PROJECT_ROOT/$file" | head -1 | cut -d: -f1)
-        WARNINGS="${WARNINGS}STALE_REF: $file:$LINE may reference old '/plan' (should be '/nano-plan')\n"
+        WARNINGS="${WARNINGS}STALE_REF: $file:$LINE may reference old '/plan' (should be '/nano')\n"
       fi
       ;;
   esac

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -7,7 +7,7 @@ description: Use before planning when you need strategic clarity — product dis
 
 You are a strategic thinking partner. Not a yes-man. Your job is to find the version of this idea that actually ships and actually matters. Most features fail not because the code is bad but because the problem was wrong. Find the right problem first.
 
-This skill runs BEFORE `/nano-plan`. Think answers WHAT and WHY. Plan answers HOW.
+This skill runs BEFORE `/nano`. Think answers WHAT and WHY. Plan answers HOW.
 
 ## Anti-Sycophancy Rules
 
@@ -139,7 +139,7 @@ Based on the diagnostic, recommend one of four scope modes:
 | **Hold** | Solid plan, no reason to change | Bulletproof the current scope |
 | **Reduce** | Weak demand signal, unclear wedge, too broad | Strip to absolute essentials |
 
-### Phase 6: Handoff to /nano-plan
+### Phase 6: Handoff to /nano
 
 Produce a clear brief for the next phase:
 
@@ -153,7 +153,7 @@ Produce a clear brief for the next phase:
 **Key risk:** {{the one thing most likely to make this fail}}
 **Premise validated:** {{yes/no — and why}}
 
-Ready for: /nano-plan
+Ready for: /nano
 ```
 
 ## Save Artifact
@@ -174,17 +174,17 @@ After the Think Summary and artifact are saved:
 
 Tell the user:
 
-> Autopilot active. Proceeding with the full sprint: /nano-plan, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
+> Autopilot active. Proceeding with the full sprint: /nano, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
 
-Then proceed directly to `/nano-plan` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
+Then proceed directly to `/nano` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
 
 **Otherwise (default):**
 
 Tell the user:
 
-> Ready for `/nano-plan`. Say `/nano-plan` to create the implementation plan, or adjust the brief first.
+> Ready for `/nano`. Say `/nano` to create the implementation plan, or adjust the brief first.
 
-Wait for the user to invoke `/nano-plan`.
+Wait for the user to invoke `/nano`.
 
 ## Gotchas
 
@@ -193,7 +193,7 @@ Wait for the user to invoke `/nano-plan`.
 - **Don't expand scope when reducing is the right call.** More features ≠ better product. The best v1s do one thing exceptionally well.
 - **"Search Before Building" is now a step, not a suggestion.** Phase 1.5 runs before the diagnostic. If you skipped it, go back.
 - **"Processize before you productize."** If the user can't describe how they'd deliver the value by hand (no code), they don't understand the problem well enough to automate it. The manual process comes first.
-- **Don't let this become a planning session.** /think produces a brief, not a plan. If you're writing implementation steps, you've gone too far. Hand off to /nano-plan.
+- **Don't let this become a planning session.** /think produces a brief, not a plan. If you're writing implementation steps, you've gone too far. Hand off to /nano.
 - **Don't let the user think small by habit.** An AI agent builds a web app as fast as a bash script. If the user defaults to "just a CLI" when a real product would serve them better, say so. The narrowest wedge should be narrow in scope, not narrow in ambition.
 
 ## Anti-patterns (from real usage)


### PR DESCRIPTION
## Summary

Renamed the planning skill from `/nano-plan` to `/nano`. Shorter, cleaner.

```
/think → /nano → build → /review → /qa → /security → /ship
```

Updated across all 12 files.

## Test plan

- [ ] Run `./setup` and verify `nano` symlink points to `nanostack/plan`
- [ ] Type `/nano` in Claude Code and verify it invokes the planning skill