### PR TITLE
Add Cursor, OpenCode and Gemini CLI support

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "nanostack",
+  "description": "Minimal AI coding agent team skills for the full engineering workflow",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "skills": "../",
+  "keywords": ["skills", "engineering-workflow", "code-review", "security", "planning"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Nanostack — Agent Discovery
 
-This file lists all available skills for non-Claude Code agents (Codex, Kiro, etc.).
-Each skill folder contains an `agents/openai.yaml` for OpenAI-compatible agent discovery.
+This file lists all available skills for all supported agents (Claude Code, Cursor, Codex, OpenCode, Gemini CLI).
+Each skill folder contains a `SKILL.md` for agent discovery and an `agents/openai.yaml` for OpenAI-compatible agents.
 
 ## Available Skills
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+# Nanostack
+
+You have access to nanostack engineering workflow skills. Read the SKILL.md in each skill directory for instructions.
+
+Available skills: /think, /nano, /review, /qa, /security, /ship, /guard, /conductor
+
+Workflow: /think → /nano → build → /review → /qa → /security → /ship
+
+Read `SKILL.md` in the project root for the full skill reference.

--- a/README.md
+++ b/README.md
@@ -246,9 +246,17 @@ cd ~/.claude/skills/nanostack && ./setup
 git clone https://github.com/garagon/nanostack.git ~/nanostack
 cd ~/nanostack && ./setup --host codex
 
-# Amazon Kiro
+# Cursor
 git clone https://github.com/garagon/nanostack.git ~/nanostack
-cd ~/nanostack && ./setup --host kiro
+cd ~/nanostack && ./setup --host cursor
+
+# OpenCode
+git clone https://github.com/garagon/nanostack.git ~/nanostack
+cd ~/nanostack && ./setup --host opencode
+
+# Gemini CLI
+git clone https://github.com/garagon/nanostack.git ~/nanostack
+cd ~/nanostack && ./setup --host gemini
 
 # Auto-detect all installed agents
 ./setup --host auto
@@ -279,7 +287,7 @@ This creates `.claude/settings.json` with permissions so Claude Code doesn't int
 - macOS or Linux
 - [jq](https://jqlang.github.io/jq/) for artifact processing (`brew install jq` or `apt install jq`)
 - Git
-- One of: Claude Code, OpenAI Codex, Amazon Kiro
+- One of: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI
 
 ## The Zen of Nanostack
 
@@ -419,10 +427,16 @@ Run `~/.claude/skills/nanostack/bin/upgrade.sh` to pull latest and re-run setup.
 cd ~/.claude/skills && rm -f think nano review qa security ship guard conductor && rm -rf nanostack
 
 # Codex
-rm -rf ~/.codex/skills/nanostack*
+rm -rf ~/.agents/skills/nanostack*
 
-# Kiro
-rm -rf ~/.kiro/skills/nanostack
+# Cursor
+rm -f .cursor/rules/nanostack.md
+
+# OpenCode
+rm -rf ~/.agents/skills/nanostack
+
+# Gemini CLI
+gemini extensions uninstall nanostack
 ```
 
 ## License

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,7 +91,7 @@ Read `reference/conflict-precedents.md` for known conflict patterns and pre-defi
 
 On first use in a project, run `bin/init-config.sh --interactive` to create `.nanostack/config.json`. This stores:
 
-- **Installed agents** — auto-detected (claude, codex, kiro)
+- **Installed agents** — auto-detected (claude, codex, cursor, opencode, gemini)
 - **Detected stack** — node, go, python, docker
 - **Preferences** — default intensity mode, auto-save, conflict precedence
 

--- a/bin/init-config.sh
+++ b/bin/init-config.sh
@@ -29,7 +29,9 @@ mkdir -p "$NANOSTACK_STORE"
 AGENTS="[]"
 command -v claude >/dev/null 2>&1 && AGENTS=$(echo "$AGENTS" | jq '. + ["claude"]')
 command -v codex >/dev/null 2>&1 && AGENTS=$(echo "$AGENTS" | jq '. + ["codex"]')
-{ command -v kiro-cli >/dev/null 2>&1 || command -v kiro >/dev/null 2>&1; } && AGENTS=$(echo "$AGENTS" | jq '. + ["kiro"]')
+command -v cursor >/dev/null 2>&1 && AGENTS=$(echo "$AGENTS" | jq '. + ["cursor"]')
+command -v opencode >/dev/null 2>&1 && AGENTS=$(echo "$AGENTS" | jq '. + ["opencode"]')
+command -v gemini >/dev/null 2>&1 && AGENTS=$(echo "$AGENTS" | jq '. + ["gemini"]')
 
 # Detect project context from current directory
 PROJECT_NAME=$(basename "$(pwd)")

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -164,7 +164,7 @@ Multiple developers, each running their own agent:
 Dev A (claude):   /think → /nano
 Dev B (codex):    build (claims after plan.done)
 Dev A (claude):   /review (claims after build.done)
-Dev C (kiro):     /security (claims after build.done, parallel with review)
+Dev C (opencode):     /security (claims after build.done, parallel with review)
 Dev A (claude):   /ship (claims after review.done + security.done)
 ```
 

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -30,8 +30,8 @@ detect_agent() {
     echo "claude"
   elif [ -n "${CODEX_SESSION_ID:-}" ]; then
     echo "codex"
-  elif [ -n "${KIRO_SESSION_ID:-}" ]; then
-    echo "kiro"
+  elif [ -n "${OPENCODE_SESSION_ID:-}" ]; then
+    echo "opencode"
   else
     echo "agent-$(whoami)"
   fi

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "nanostack",
+  "description": "Minimal AI coding agent team skills for the full engineering workflow",
+  "version": "0.2.0",
+  "contextFileName": "GEMINI.md"
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Nanostack
 
-Nanostack is a set of AI coding agent skills for the full engineering workflow. It works with Claude Code, OpenAI Codex, Amazon Kiro and any agent that reads SKILL.md files.
+Nanostack is a set of AI coding agent skills for the full engineering workflow. It works with Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI and any agent that reads SKILL.md files.
 
 ## What it does
 

--- a/setup
+++ b/setup
@@ -48,7 +48,7 @@ while [ $# -gt 0 ]; do
 Usage: ./setup [OPTIONS]
 
 Options:
-  --host <agent>    Target: claude (default), codex, kiro, auto
+  --host <agent>    Target: claude (default), codex, cursor, opencode, gemini, auto
   --local           Install to .claude/skills/ in current working directory
   --help            Show this help
 
@@ -70,15 +70,14 @@ HELP
 done
 
 case "$HOST" in
-  claude|codex|kiro|auto) ;;
-  *) echo "Unknown --host: $HOST (expected claude, codex, kiro, or auto)" >&2; exit 1 ;;
+  claude|codex|cursor|opencode|gemini|auto) ;;
+  *) echo "Unknown --host: $HOST (expected claude, codex, cursor, opencode, gemini, or auto)" >&2; exit 1 ;;
 esac
 
 # --local override
 if [ "$LOCAL_INSTALL" -eq 1 ]; then
   SKILLS_DIR="$(pwd)/.claude/skills"
   mkdir -p "$SKILLS_DIR"
-  # Clone or symlink nanostack into local skills
   NANOSTACK_LOCAL="$SKILLS_DIR/nanostack"
   if [ ! -e "$NANOSTACK_LOCAL" ]; then
     ln -snf "$SOURCE_DIR" "$NANOSTACK_LOCAL"
@@ -90,21 +89,29 @@ fi
 # ─── Auto-detect agents ──────────────────────────────────────
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
-INSTALL_KIRO=0
+INSTALL_CURSOR=0
+INSTALL_OPENCODE=0
+INSTALL_GEMINI=0
 
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
-  command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
-  command -v kiro >/dev/null 2>&1 && INSTALL_KIRO=1
+  command -v cursor >/dev/null 2>&1 && INSTALL_CURSOR=1
+  command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v gemini >/dev/null 2>&1 && INSTALL_GEMINI=1
   # Default to claude if nothing detected
-  [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && INSTALL_CLAUDE=1
+  TOTAL=$((INSTALL_CLAUDE + INSTALL_CODEX + INSTALL_CURSOR + INSTALL_OPENCODE + INSTALL_GEMINI))
+  [ "$TOTAL" -eq 0 ] && INSTALL_CLAUDE=1
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
-elif [ "$HOST" = "kiro" ]; then
-  INSTALL_KIRO=1
+elif [ "$HOST" = "cursor" ]; then
+  INSTALL_CURSOR=1
+elif [ "$HOST" = "opencode" ]; then
+  INSTALL_OPENCODE=1
+elif [ "$HOST" = "gemini" ]; then
+  INSTALL_GEMINI=1
 fi
 
 # ─── Claude Code ──────────────────────────────────────────────
@@ -165,30 +172,46 @@ install_codex() {
   fi
 }
 
-# ─── Amazon Kiro ──────────────────────────────────────────────
-# Copies SKILL.md files with path rewriting (Kiro doesn't follow symlinks well)
-install_kiro() {
-  local kiro_skills="${HOME}/.kiro/skills"
-  local kiro_root="$kiro_skills/nanostack"
-  mkdir -p "$kiro_root"
+# ─── Cursor ───────────────────────────────────────────────────
+# Creates .cursor/rules/ with skill references
+install_cursor() {
+  local cursor_rules=".cursor/rules"
+  mkdir -p "$cursor_rules"
 
-  # Copy root files
-  sed -e 's|~/.claude/skills/nanostack|~/.kiro/skills/nanostack|g' \
-      -e 's|\.claude/skills|.kiro/skills|g' \
-      "$SOURCE_DIR/SKILL.md" > "$kiro_root/SKILL.md"
-  cp "$SOURCE_DIR/AGENTS.md" "$kiro_root/AGENTS.md"
+  # Create a rule that loads nanostack skills
+  cat > "$cursor_rules/nanostack.md" << CURSORRULE
+---
+description: "Nanostack engineering workflow skills"
+alwaysApply: true
+---
 
-  for skill in "${SKILLS[@]}"; do
-    local target="$kiro_root/$skill"
-    rm -rf "$target"
-    cp -r "$SOURCE_DIR/$skill" "$target"
-    # Rewrite paths
-    while IFS= read -r mdfile; do
-      sed_inplace -e 's|~/.claude/skills/nanostack|~/.kiro/skills/nanostack|g' "$mdfile"
-    done < <(find "$target" -name "*.md")
-  done
+You have access to nanostack skills. Read SKILL.md files in ~/.claude/skills/nanostack/ for instructions.
 
-  find "$kiro_root" -path "*/bin/*" -type f -exec chmod +x {} \;
+Available: /think, /nano, /review, /qa, /security, /ship, /guard, /conductor
+Workflow: /think → /nano → build → /review → /qa → /security → /ship
+CURSORRULE
+
+  echo "  Created $cursor_rules/nanostack.md"
+}
+
+# ─── OpenCode ─────────────────────────────────────────────────
+# Symlinks into ~/.agents/skills/ (OpenCode scans this natively)
+install_opencode() {
+  local agents_skills="${HOME}/.agents/skills"
+  mkdir -p "$agents_skills"
+
+  local agents_root="$agents_skills/nanostack"
+  if [ -L "$agents_root" ] || [ ! -e "$agents_root" ]; then
+    ln -snf "$SOURCE_DIR" "$agents_root"
+    echo "  Linked $agents_root → $SOURCE_DIR"
+  fi
+}
+
+# ─── Gemini CLI ───────────────────────────────────────────────
+# Installs as Gemini extension
+install_gemini() {
+  echo "  Gemini CLI: run 'gemini extensions install $SOURCE_DIR' to install"
+  echo "  Or for development: 'gemini extensions link $SOURCE_DIR'"
 }
 
 # ─── Config ──────────────────────────────────────────────────
@@ -200,7 +223,9 @@ write_setup_config() {
   local agents="[]"
   [ "$INSTALL_CLAUDE" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["claude"]')
   [ "$INSTALL_CODEX" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["codex"]')
-  [ "$INSTALL_KIRO" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["kiro"]')
+  [ "$INSTALL_CURSOR" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["cursor"]')
+  [ "$INSTALL_OPENCODE" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["opencode"]')
+  [ "$INSTALL_GEMINI" -eq 1 ] && agents=$(echo "$agents" | jq '. + ["gemini"]')
 
   jq -n \
     --arg src "$SOURCE_DIR" \
@@ -239,10 +264,20 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   echo "  skills: ${HOME}/.codex/skills"
 fi
 
-if [ "$INSTALL_KIRO" -eq 1 ]; then
-  install_kiro
-  echo "nanostack ready (kiro)."
-  echo "  skills: ${HOME}/.kiro/skills/nanostack"
+if [ "$INSTALL_CURSOR" -eq 1 ]; then
+  install_cursor
+  echo "nanostack ready (cursor)."
+fi
+
+if [ "$INSTALL_OPENCODE" -eq 1 ]; then
+  install_opencode
+  echo "nanostack ready (opencode)."
+  echo "  skills: ${HOME}/.agents/skills/nanostack"
+fi
+
+if [ "$INSTALL_GEMINI" -eq 1 ]; then
+  install_gemini
+  echo "nanostack ready (gemini)."
 fi
 
 # Save installation config


### PR DESCRIPTION
## Summary

Nanostack now supports 5 agents: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI.

New files:
- `.cursor-plugin/plugin.json` for Cursor discovery
- `gemini-extension.json` + `GEMINI.md` for Gemini CLI extension system
- Setup creates `.cursor/rules/nanostack.md` for Cursor
- Setup symlinks to `~/.agents/skills/` for OpenCode (shared with Codex)

```
./setup --host auto    # detects all 5 agents
./setup --host cursor  # Cursor only
./setup --host gemini  # Gemini CLI only
```

## Test plan

- [ ] `./setup --help` shows all 5 agents
- [ ] `./setup --host cursor` creates `.cursor/rules/nanostack.md`
- [ ] `./setup --host opencode` creates `~/.agents/skills/nanostack` symlink