### PR TITLE
Add community files and contribution guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything
+* @garagon

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: Report a bug in Nanostack
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent
+      description: Which AI agent are you using?
+      placeholder: "Claude Code 2.1.86"
+    validations:
+      required: true
+
+  - type: input
+    id: skill
+    attributes:
+      label: Skill
+      description: Which skill is affected?
+      placeholder: "/review"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Run /review on a project with...
+        2. The agent does...
+        3. Expected vs actual...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows (WSL)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/garagon/nanostack/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+      placeholder: "When I use /review, I always have to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How do you think this should work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - /think
+        - /nano (planning)
+        - /review
+        - /qa
+        - /security
+        - /ship
+        - /guard
+        - /conductor
+        - Setup / install
+        - Artifacts / cross-referencing
+        - Documentation
+        - Extensibility
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Checklist
+
+- [ ] `./setup` runs without errors
+- [ ] SKILL.md follows existing format (if adding/modifying a skill)
+- [ ] No hardcoded paths or usernames
+- [ ] No secrets or credentials
+- [ ] Tested on macOS or Linux

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer. All complaints will be reviewed and
+investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Nanostack
+
+Contributions are welcome. Here's how to get started.
+
+## Setup
+
+```bash
+git clone https://github.com/garagon/nanostack.git ~/.claude/skills/nanostack
+cd ~/.claude/skills/nanostack && ./setup
+```
+
+No build step. No dependencies. Skills use symlinks and take effect immediately.
+
+## Project Structure
+
+```
+think/         /think skill (product thinking, forcing questions)
+plan/          /nano skill (planning, specs by scope)
+review/        /review skill (two-pass code review, scope drift)
+qa/            /qa skill (browser, API, CLI testing)
+security/      /security skill (OWASP, STRIDE, variant analysis)
+ship/          /ship skill (PR, CI, deploy, sprint journal)
+guard/         /guard skill (command blocking, safer alternatives)
+conductor/     /conductor skill (parallel agent orchestration)
+bin/           Shared scripts (artifacts, analytics, journal)
+reference/     Conflict precedents, artifact schema
+```
+
+Each skill is a directory with a `SKILL.md` that contains the agent instructions.
+
+## What You Can Contribute
+
+- **New skills**: Add a domain-specific skill that composes with the existing workflow
+- **Skill improvements**: Better instructions, edge cases, examples
+- **Guard rules**: New block/warn rules in `guard/rules.json`
+- **Bug fixes**: Anything broken in the bin/ scripts
+- **Documentation**: README, EXTENDING.md, examples
+
+## Adding a Skill
+
+1. Create a directory with a `SKILL.md`:
+   ```
+   my-skill/
+     SKILL.md
+   ```
+
+2. Follow the frontmatter format:
+   ```yaml
+   ---
+   name: my-skill
+   description: What it does. When to use it. Triggers on /my-skill.
+   ---
+   ```
+
+3. Use `bin/save-artifact.sh` to persist output
+4. Use `bin/find-artifact.sh` to read other skills' output
+5. Include a "Next Step" section pointing to the next skill in the workflow
+
+## Adding Guard Rules
+
+Edit `guard/rules.json`. Each rule needs:
+
+```json
+{
+  "id": "G-100",
+  "pattern": "your-regex-pattern",
+  "category": "category-name",
+  "description": "What this blocks and why",
+  "alternative": "Safer way to do the same thing"
+}
+```
+
+Test your pattern before submitting.
+
+## Pull Request Process
+
+1. Branch from `main`
+2. Keep changes focused (one skill or one fix per PR)
+3. Test that setup still works: `./setup --help`
+4. Test affected bin/ scripts if you changed them
+5. Submit a PR with a clear description
+
+### PR Checklist
+
+- [ ] setup runs without errors
+- [ ] SKILL.md follows existing format
+- [ ] No hardcoded paths or usernames
+- [ ] No secrets or credentials in any file
+
+## Code Style
+
+- Shell scripts: POSIX-compatible where possible, bash when needed
+- SKILL.md: clear, direct instructions. No filler.
+- Avoid AI slop in documentation (no "leverage", "utilize", "robust", "cutting-edge")
+
+## Reporting Issues
+
+- [Bug reports](https://github.com/garagon/nanostack/issues/new?template=bug_report.yml)
+- [Feature requests](https://github.com/garagon/nanostack/issues/new?template=feature_request.yml)
+- Security vulnerabilities: see [SECURITY.md](SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -482,6 +482,14 @@ rm -rf ~/.agents/skills/nanostack
 gemini extensions remove nanostack
 ```
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, project structure and PR guidelines.
+
+- [Bug reports](https://github.com/garagon/nanostack/issues/new?template=bug_report.yml)
+- [Feature requests](https://github.com/garagon/nanostack/issues/new?template=feature_request.yml)
+- Security vulnerabilities: [SECURITY.md](SECURITY.md)
+
 ## License
 
 Apache 2.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Nanostack, please report it through
+[GitHub Security Advisories](https://github.com/garagon/nanostack/security/advisories/new).
+
+**Do not open a public issue.**
+
+## Scope
+
+### In Scope
+
+- Guard rule bypass (command that should be blocked passes through)
+- Artifact injection (malicious data in .nanostack/ artifacts that affects downstream skills)
+- Setup script vulnerabilities (symlink attacks, path traversal)
+- Secrets exposure in skill output or artifacts
+- Command injection through bin/ scripts
+
+### Out of Scope
+
+- Vulnerabilities in the AI agent itself (Claude Code, Codex, etc.)
+- Issues in code that nanostack reviews or generates (that's what /security is for)
+- Third-party skill sets built on top of nanostack
+
+## Response Timeline
+
+| Stage | Timeline |
+|-------|----------|
+| Acknowledgment | 48 hours |
+| Initial assessment | 7 days |
+| Fix or mitigation | 30 days |
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest on main | Yes |
+| Older commits | Best effort |
+
+## Disclosure
+
+We follow coordinated disclosure. We will:
+
+1. Confirm the vulnerability
+2. Develop a fix
+3. Release a patch
+4. Credit the reporter (unless anonymity is requested)


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md: setup, project structure, how to contribute, PR process
- CODE_OF_CONDUCT.md: Contributor Covenant v2.1
- SECURITY.md: vulnerability reporting with scope and response timeline
- .github/CODEOWNERS: @garagon as default reviewer on all PRs
- .github/pull_request_template.md: PR checklist
- .github/ISSUE_TEMPLATE: structured bug reports and feature requests
- README.md: Contributing section with links to issue templates
- Disabled empty Projects tab

## Checklist

- [x] `./setup` runs without errors
- [x] No hardcoded paths or usernames (except CODEOWNERS)
- [x] No secrets or credentials