### PR TITLE
Add configurable stack defaults with auto-detection

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -2,6 +2,53 @@
 
 Add your own skills that plug into nanostack's workflow. Your skills save artifacts, read what other skills produced, and compose with /think, /review and /ship.
 
+## Configure your stack
+
+nanostack has opinionated defaults for new projects (Next.js, Supabase, Drizzle, etc.). You can override any of them with your own preferences.
+
+### Auto-detect from your project
+
+```bash
+bin/init-stack.sh
+```
+
+Reads package.json, go.mod, requirements.txt and generates `.nanostack/stack.json` with your detected stack. If nothing is detected, creates a template to edit.
+
+### Global preferences (all projects)
+
+```bash
+bin/init-stack.sh --global
+```
+
+Saves to `~/.nanostack/stack.json`. Applies to every project where you don't have a project-level config.
+
+### Manual config
+
+Create `.nanostack/stack.json` in your project:
+
+```json
+{
+  "web": {
+    "framework": "Django",
+    "auth": "django-allauth",
+    "database": "PostgreSQL",
+    "orm": "Django ORM",
+    "hosting": "Railway",
+    "css": "Tailwind + daisyUI"
+  }
+}
+```
+
+Only include categories you want to override. Everything else uses nanostack defaults.
+
+### Priority order
+
+1. `.nanostack/stack.json` (project) - highest
+2. `~/.nanostack/stack.json` (user)
+3. `plan/references/stack-defaults.md` (nanostack defaults) - fallback
+
+If the project already has dependencies (package.json, go.mod, etc.), /nano uses the existing stack regardless of any config.
+
 ## Example: build a /deploy skill in 5 minutes
 
 Let's create a skill that verifies a deploy after /ship creates the PR.

--- a/bin/init-stack.sh
+++ b/bin/init-stack.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Generate .nanostack/stack.json with detected or default stack preferences.
+# Usage:
+#   bin/init-stack.sh           # project-level (.nanostack/stack.json)
+#   bin/init-stack.sh --global  # user-level (~/.nanostack/stack.json)
+set -e
+
+GLOBAL=0
+if [ "${1:-}" = "--global" ]; then
+  GLOBAL=1
+fi
+
+if [ "$GLOBAL" -eq 1 ]; then
+  TARGET_DIR="$HOME/.nanostack"
+else
+  # Find project root
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  TARGET_DIR="$ROOT/.nanostack"
+fi
+
+TARGET="$TARGET_DIR/stack.json"
+mkdir -p "$TARGET_DIR"
+
+if [ -f "$TARGET" ]; then
+  echo "stack.json already exists: $TARGET"
+  echo "Edit it directly or delete it to regenerate."
+  exit 0
+fi
+
+# Detect stack from project files
+detect_stack() {
+  local detected="{}"
+
+  # Node/TypeScript projects
+  if [ -f "package.json" ]; then
+    local pkg
+    pkg=$(cat package.json 2>/dev/null)
+
+    # Framework
+    if echo "$pkg" | grep -q '"next"'; then
+      detected=$(echo "$detected" | jq '.web.framework = "Next.js"')
+    elif echo "$pkg" | grep -q '"remix"'; then
+      detected=$(echo "$detected" | jq '.web.framework = "Remix"')
+    elif echo "$pkg" | grep -q '"nuxt"'; then
+      detected=$(echo "$detected" | jq '.web.framework = "Nuxt"')
+    elif echo "$pkg" | grep -q '"svelte"'; then
+      detected=$(echo "$detected" | jq '.web.framework = "SvelteKit"')
+    fi
+
+    # CSS
+    if echo "$pkg" | grep -q '"tailwindcss"'; then
+      detected=$(echo "$detected" | jq '.web.css = "Tailwind"')
+    fi
+
+    # ORM
+    if echo "$pkg" | grep -q '"prisma"'; then
+      detected=$(echo "$detected" | jq '.web.orm = "Prisma"')
+    elif echo "$pkg" | grep -q '"drizzle-orm"'; then
+      detected=$(echo "$detected" | jq '.web.orm = "Drizzle"')
+    fi
+
+    # Database
+    if echo "$pkg" | grep -q '"@supabase/supabase-js"'; then
+      detected=$(echo "$detected" | jq '.web.database = "Supabase"')
+    fi
+
+    # Auth
+    if echo "$pkg" | grep -q '"@clerk"'; then
+      detected=$(echo "$detected" | jq '.web.auth = "Clerk"')
+    elif echo "$pkg" | grep -q '"better-auth"'; then
+      detected=$(echo "$detected" | jq '.web.auth = "Better-Auth"')
+    fi
+
+    # Testing
+    if echo "$pkg" | grep -q '"vitest"'; then
+      detected=$(echo "$detected" | jq '.web.testing = "Vitest"')
+    fi
+  fi
+
+  # Go projects
+  if [ -f "go.mod" ]; then
+    detected=$(echo "$detected" | jq '.go = {}')
+    local gomod
+    gomod=$(cat go.mod 2>/dev/null)
+
+    if echo "$gomod" | grep -q 'chi'; then
+      detected=$(echo "$detected" | jq '.go.http = "Chi"')
+    elif echo "$gomod" | grep -q 'fiber'; then
+      detected=$(echo "$detected" | jq '.go.http = "Fiber"')
+    fi
+
+    if echo "$gomod" | grep -q 'cobra'; then
+      detected=$(echo "$detected" | jq '.go.cli = "Cobra"')
+    fi
+
+    if echo "$gomod" | grep -q 'bubbletea'; then
+      detected=$(echo "$detected" | jq '.go.tui = "Bubble Tea"')
+    fi
+  fi
+
+  # Python projects
+  if [ -f "requirements.txt" ] || [ -f "pyproject.toml" ]; then
+    detected=$(echo "$detected" | jq '.python = {}')
+    local reqs=""
+    [ -f "requirements.txt" ] && reqs=$(cat requirements.txt 2>/dev/null)
+    [ -f "pyproject.toml" ] && reqs="$reqs $(cat pyproject.toml 2>/dev/null)"
+
+    if echo "$reqs" | grep -qi 'django'; then
+      detected=$(echo "$detected" | jq '.python.web = "Django"')
+    elif echo "$reqs" | grep -qi 'fastapi'; then
+      detected=$(echo "$detected" | jq '.python.web = "FastAPI"')
+    elif echo "$reqs" | grep -qi 'flask'; then
+      detected=$(echo "$detected" | jq '.python.web = "Flask"')
+    fi
+
+    if echo "$reqs" | grep -qi 'sqlalchemy'; then
+      detected=$(echo "$detected" | jq '.python.database = "SQLAlchemy"')
+    fi
+  fi
+
+  echo "$detected"
+}
+
+# Detect or use empty template
+DETECTED=$(detect_stack)
+
+# Check if anything was detected
+KEYS=$(echo "$DETECTED" | jq 'keys | length')
+
+if [ "$KEYS" -gt 0 ] && [ "$DETECTED" != "{}" ]; then
+  echo "Detected stack:"
+  echo "$DETECTED" | jq '.'
+  echo ""
+  echo "Saving to: $TARGET"
+  echo "$DETECTED" | jq '.' > "$TARGET"
+else
+  echo "No stack detected. Creating template."
+  cat > "$TARGET" << 'TEMPLATE'
+{
+  "web": {
+    "framework": "",
+    "auth": "",
+    "database": "",
+    "orm": "",
+    "hosting": "",
+    "css": ""
+  }
+}
+TEMPLATE
+  echo "Template saved to: $TARGET"
+  echo "Edit it with your preferred stack. Empty values use nanostack defaults."
+fi
+
+echo ""
+echo "The agent reads this file when planning new projects."
+echo "Categories you leave empty or omit will use nanostack defaults."

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -24,8 +24,13 @@ You turn validated ideas into executable steps. Every file gets named. Every ste
 
 - Check git history for recent changes in the affected area — someone may have already started this work or made decisions you need to respect.
 - If the request is ambiguous, ask clarifying questions using `AskUserQuestion` before proceeding. Do not guess scope.
-- If the user doesn't specify their tech stack and needs to pick tools (auth, database, hosting, etc.), read `plan/references/stack-defaults.md` for recommended defaults. Suggest them, don't impose them. If the project already has a stack (check package.json, go.mod, requirements.txt), use what's there.
-- **Always use the latest stable version** of every dependency. Read `plan/references/stack-defaults.md` for version checking instructions. Don't rely on versions from training data.
+- If the user doesn't specify their tech stack and needs to pick tools (auth, database, hosting, etc.), check for overrides first, then fall back to defaults:
+  1. Read `.nanostack/stack.json` if it exists (project-level preferences)
+  2. Read `~/.nanostack/stack.json` if it exists (user-level preferences)
+  3. Read `plan/references/stack-defaults.md` for anything not covered above
+  4. If the project already has a stack (check package.json, go.mod, requirements.txt), use what's there regardless of any config.
+  Suggest, don't impose. The user always has the final say.
+- **Always use the latest stable version** of every dependency. Don't rely on versions from training data.
 
 ### 2. Evaluate Scope
 

--- a/plan/references/stack-defaults.md
+++ b/plan/references/stack-defaults.md
@@ -71,16 +71,6 @@ Do NOT force these choices. If the user says "I want to use Firebase," use Fireb
 | Validation | Pydantic v2 | Standard for FastAPI, Rust-powered, fast | msgspec for maximum performance |
 | Testing | pytest | Universal standard | No serious alternative |
 
-## Avoid (outdated or problematic)
+## User overrides
 
-- **Lucia Auth**: deprecated March 2025
-- **PlanetScale**: killed free tier, $39/mo minimum
-- **Firebase Realtime DB**: proprietary, no SQL, hard to migrate
-- **Auth0**: enterprise pricing, overkill for startups
-- **TypeORM**: stale, poor TypeScript inference
-- **Styled-components / Emotion**: incompatible with React Server Components
-- **Jest for new projects**: Vitest is 3-5x faster with compatible API
-- **Redux for new projects**: Zustand covers 90% of cases in 3KB
-- **Formik**: React Hook Form is faster and lighter
-- **Yup**: Zod won the TypeScript ecosystem
-- **Mongoose**: use Drizzle/Prisma with Postgres instead of MongoDB for relational data
+Users can override any default by creating `.nanostack/stack.json` in their project or `~/.nanostack/stack.json` globally. See [EXTENDING.md](../../EXTENDING.md) for details.


### PR DESCRIPTION
## Summary

Users can override nanostack's stack defaults per project or globally.

**New:**
- `bin/init-stack.sh`: auto-detects stack from package.json, go.mod, requirements.txt
- `bin/init-stack.sh --global`: user-level preferences for all projects
- `.nanostack/stack.json`: only include categories to override, rest uses defaults
- Priority: project > user > nanostack defaults

**Updated:**
- /nano reads stack.json before falling back to defaults
- EXTENDING.md documents configuration and priority order
- stack-defaults.md references user overrides

## Test plan

- [x] Detects Next.js + Tailwind + Drizzle + Supabase from package.json
- [x] Detects Chi + Cobra from go.mod
- [x] Creates template when no stack detected
- [x] Does not overwrite existing stack.json
- [x] --global saves to ~/.nanostack/stack.json
- [x] All bin/ scripts pass syntax check