### PR TITLE
Add /compound skill for knowledge compounding

### DIFF
--- a/bin/find-solution.sh
+++ b/bin/find-solution.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# find-solution.sh — Search solutions by keyword, tag, or file path
+# Usage: find-solution.sh <query> [--type bug|pattern|decision] [--tag tag] [--file path]
+#
+# Searches YAML frontmatter (title, tags, files) and body text.
+# Returns paths to matching solution documents, most recent first.
+# Exit 1 if no matches found.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+SOLUTIONS_DIR="$NANOSTACK_STORE/know-how/solutions"
+
+# Parse arguments
+QUERY=""
+FILTER_TYPE=""
+FILTER_TAG=""
+FILTER_FILE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --type) FILTER_TYPE="$2"; shift 2 ;;
+    --tag) FILTER_TAG="$2"; shift 2 ;;
+    --file) FILTER_FILE="$2"; shift 2 ;;
+    *) QUERY="${QUERY:+$QUERY }$1"; shift ;;
+  esac
+done
+
+[ -z "$QUERY" ] && [ -z "$FILTER_TYPE" ] && [ -z "$FILTER_TAG" ] && [ -z "$FILTER_FILE" ] && {
+  echo "Usage: find-solution.sh <query> [--type bug|pattern|decision] [--tag tag] [--file path]" >&2
+  exit 1
+}
+
+[ ! -d "$SOLUTIONS_DIR" ] && exit 1
+
+# Find all solution files
+FILES=$(find "$SOLUTIONS_DIR" -name "*.md" -type f 2>/dev/null | sort -r)
+[ -z "$FILES" ] && exit 1
+
+MATCHES=""
+
+while IFS= read -r filepath; do
+  [ -z "$filepath" ] && continue
+  MATCH=true
+
+  # Filter by type (directory name)
+  if [ -n "$FILTER_TYPE" ]; then
+    DIR_TYPE=$(basename "$(dirname "$filepath")")
+    [ "$DIR_TYPE" != "$FILTER_TYPE" ] && MATCH=false
+  fi
+
+  # Filter by tag (search frontmatter)
+  if [ -n "$FILTER_TAG" ] && [ "$MATCH" = true ]; then
+    if ! grep -qi "tags:.*$FILTER_TAG" "$filepath" 2>/dev/null; then
+      # Also check array format
+      if ! grep -qi "\"$FILTER_TAG\"" "$filepath" 2>/dev/null; then
+        MATCH=false
+      fi
+    fi
+  fi
+
+  # Filter by file path (search frontmatter files field)
+  if [ -n "$FILTER_FILE" ] && [ "$MATCH" = true ]; then
+    if ! grep -qi "$FILTER_FILE" "$filepath" 2>/dev/null; then
+      MATCH=false
+    fi
+  fi
+
+  # Search query in title, tags, and body
+  if [ -n "$QUERY" ] && [ "$MATCH" = true ]; then
+    FOUND=false
+    # Search each query word (all must match)
+    ALL_WORDS_MATCH=true
+    for word in $QUERY; do
+      if ! grep -qi "$word" "$filepath" 2>/dev/null; then
+        ALL_WORDS_MATCH=false
+        break
+      fi
+    done
+    [ "$ALL_WORDS_MATCH" = true ] && FOUND=true
+    [ "$FOUND" = false ] && MATCH=false
+  fi
+
+  if [ "$MATCH" = true ]; then
+    MATCHES="${MATCHES:+$MATCHES
+}$filepath"
+  fi
+done <<< "$FILES"
+
+if [ -n "$MATCHES" ]; then
+  echo "$MATCHES"
+  exit 0
+else
+  exit 1
+fi

--- a/bin/save-solution.sh
+++ b/bin/save-solution.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# save-solution.sh — Save a structured solution to know-how/solutions/
+# Usage: save-solution.sh <type> <title> [tags]
+#   type: bug, pattern, or decision
+#   title: short description (used as filename)
+#   tags: comma-separated (optional)
+#
+# Creates the file with YAML frontmatter. The agent fills in the body.
+# Returns: path to the created file
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+TYPE="${1:?Usage: save-solution.sh <type> <title> [tags]}"
+TITLE="${2:?Missing title}"
+TAGS="${3:-}"
+
+# Validate type
+case "$TYPE" in
+  bug|pattern|decision) ;;
+  *) echo "error: type must be bug, pattern, or decision (got '$TYPE')" >&2; exit 1 ;;
+esac
+
+# Sanitize title for filename: lowercase, spaces to hyphens, strip special chars
+SAFE_TITLE=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed 's/[^a-z0-9-]//g' | head -c 80)
+[ -z "$SAFE_TITLE" ] && { echo "error: title produced empty filename" >&2; exit 1; }
+
+DATE=$(date +"%Y-%m-%d")
+PROJECT=$(basename "$(pwd)")
+
+# Create directory
+SOLUTIONS_DIR="$NANOSTACK_STORE/know-how/solutions/$TYPE"
+mkdir -p "$SOLUTIONS_DIR"
+
+# Check for existing file with same name (prevent overwrite)
+FILEPATH="$SOLUTIONS_DIR/$SAFE_TITLE.md"
+if [ -f "$FILEPATH" ]; then
+  echo "exists:$FILEPATH"
+  exit 0
+fi
+
+# Format tags
+TAGS_YAML="[]"
+if [ -n "$TAGS" ]; then
+  TAGS_YAML=$(echo "$TAGS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -s '.')
+fi
+
+# Write frontmatter
+cat > "$FILEPATH" << FRONTMATTER
+---
+type: $TYPE
+title: $TITLE
+date: $DATE
+project: $PROJECT
+files: []
+tags: $TAGS_YAML
+severity: medium
+---
+
+FRONTMATTER
+
+# Add body template based on type
+case "$TYPE" in
+  bug)
+    cat >> "$FILEPATH" << 'TEMPLATE'
+## Problem
+
+
+## Symptoms
+
+
+## What didn't work
+
+
+## Solution
+
+
+## Why this works
+
+
+## Prevention
+
+TEMPLATE
+    ;;
+  pattern)
+    cat >> "$FILEPATH" << 'TEMPLATE'
+## Context
+
+
+## Pattern
+
+
+## When to apply
+
+
+## Example
+
+
+## When NOT to apply
+
+TEMPLATE
+    ;;
+  decision)
+    cat >> "$FILEPATH" << 'TEMPLATE'
+## Context
+
+
+## Decision
+
+
+## Rationale
+
+
+## Alternatives considered
+
+
+## Consequences
+
+TEMPLATE
+    ;;
+esac
+
+echo "created:$FILEPATH"

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: compound
+description: Document what you learned during this sprint. Reads artifacts, writes structured solutions to know-how/solutions/. Run after /ship or after fixing a significant bug. Triggers on /compound.
+---
+
+# /compound - Knowledge Compounding
+
+After a sprint or a significant fix, extract what you learned into structured, searchable documents. Next time the agent plans or reviews, it finds these automatically.
+
+## When to run
+
+- After `/ship` completes a sprint
+- After fixing a bug that took significant investigation
+- After making an architecture decision worth remembering
+- After discovering a pattern that should be reused
+
+## Process
+
+### 1. Read the sprint artifacts
+
+Find what happened during this sprint:
+
+```bash
+bin/find-artifact.sh think 2
+bin/find-artifact.sh plan 2
+bin/find-artifact.sh review 2
+bin/find-artifact.sh qa 2
+bin/find-artifact.sh security 2
+bin/find-artifact.sh ship 2
+```
+
+Not all artifacts will exist. Read what's available. Focus on:
+- `/review` findings that were fixed (these are bugs worth documenting)
+- `/security` findings that were resolved (these are patterns worth remembering)
+- `/think` scope decisions (these are decisions worth recording)
+- `/qa` failures that were debugged (these are bugs with investigation trails)
+
+### 2. Identify what's worth capturing
+
+Not everything needs a solution document. Capture:
+- Bugs that took more than a trivial fix (the investigation is the value)
+- Patterns you want the agent to follow in future sprints
+- Architecture decisions with trade-offs that someone might question later
+
+Skip:
+- Typos, formatting, trivial fixes
+- Standard library usage (the docs are better)
+- Findings that were auto-fixed with no investigation
+
+### 3. Check for existing solutions
+
+Before creating a new document, search for related ones:
+
+```bash
+bin/find-solution.sh "relevant keywords"
+bin/find-solution.sh --tag relevant-tag
+bin/find-solution.sh --file affected/file/path
+```
+
+If a closely related solution exists:
+- **Update it** if the new information extends or corrects the existing document
+- **Create a new one** if it's a different problem that happens to share keywords
+
+Do not create duplicates. One good document beats two partial ones.
+
+### 4. Write solution documents
+
+For each significant learning, create a document:
+
+```bash
+bin/save-solution.sh <type> "<title>" "tag1,tag2,tag3"
+```
+
+Types:
+- `bug` - a problem you encountered and solved
+- `pattern` - a recurring approach worth remembering
+- `decision` - an architecture or design choice with rationale
+
+The script creates the file with YAML frontmatter and section templates. Fill in every section. Be specific:
+
+**Good:**
+```markdown
+## Problem
+Stripe webhook endpoint accepted POST without signature verification.
+stripe.webhooks.constructEvent() requires the raw request body, not parsed JSON.
+
+## Solution
+Use express.raw() middleware on the webhook route before express.json() parses it.
+```
+
+**Bad:**
+```markdown
+## Problem
+Webhook was broken.
+
+## Solution
+Fixed the webhook handler.
+```
+
+The value is in the detail. A future agent reading this needs enough context to apply the solution without re-investigating.
+
+### 5. Update frontmatter
+
+After filling in the body, update the frontmatter:
+- `files`: add the actual file paths involved
+- `severity`: adjust based on actual impact (critical, high, medium, low)
+- `tags`: add any tags that would help future search
+
+### 6. Report
+
+Print a summary of what was captured:
+
+```
+Compound: 3 solutions captured
+
+  bug/stripe-webhook-signature.md (high) - Stripe webhook missing signature verification
+  pattern/api-error-handling.md (medium) - Structured error responses with codes
+  decision/auth-clerk-over-custom.md (medium) - Chose Clerk over custom auth
+
+Total solutions in project: 12
+```
+
+## Save Artifact
+
+```bash
+bin/save-artifact.sh compound '<json with phase, summary including solutions_created, solutions_updated, total_solutions>'
+```
+
+## Next Step
+
+> Knowledge captured. These solutions will be found automatically by /nano during planning and /review during code review.
+
+## Rules
+
+- **One problem per document.** Don't combine unrelated fixes into one solution.
+- **Fill every section.** Empty sections are noise. If "What didn't work" is empty, either you fixed it on the first try (rare, skip the document) or you forgot to write it down.
+- **Use the exact file paths.** `src/api/webhooks/stripe.ts` is searchable. "The webhook file" is not.
+- **Tags are for search, not decoration.** Use terms someone would grep for: `stripe`, `webhooks`, `hmac`, not `payment-processing-integration`.
+- **Update, don't duplicate.** If bin/find-solution.sh returns a close match, update that document.
+- **The Prevention section is the highest-value section.** A bug fix helps once. A prevention rule helps every future sprint.

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -23,6 +23,7 @@ You turn validated ideas into executable steps. Every file gets named. Every ste
   - `premise_validated` → if false, flag it. Don't plan for an unvalidated premise.
 
 - Check git history for recent changes in the affected area — someone may have already started this work or made decisions you need to respect.
+- Search past solutions: run `bin/find-solution.sh` with keywords related to the technologies and files in scope. If relevant solutions exist (bugs fixed, patterns established, decisions made), reference them in the plan. Past mistakes and patterns should inform the current sprint.
 - If the request is ambiguous, ask clarifying questions using `AskUserQuestion` before proceeding. Do not guess scope.
 - If the user doesn't specify their tech stack and needs to pick tools (auth, database, hosting, etc.), check for overrides first, then fall back to defaults:
   1. Read `.nanostack/stack.json` if it exists (project-level preferences)

--- a/reference/solution-schema.md
+++ b/reference/solution-schema.md
@@ -1,0 +1,129 @@
+# Solution Document Schema
+
+Solutions persist in `.nanostack/know-how/solutions/` organized by type.
+
+## Directory structure
+
+```
+.nanostack/know-how/solutions/
+├── bug/           problems encountered and solved
+├── pattern/       recurring patterns worth remembering
+└── decision/      architecture or design decisions with rationale
+```
+
+## YAML frontmatter
+
+All solutions share these fields:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| type | Yes | `bug`, `pattern`, `decision` | Category of the solution |
+| title | Yes | string | Short description, used for search |
+| date | Yes | YYYY-MM-DD | When the solution was captured |
+| project | Yes | string | Project name (auto-detected) |
+| files | No | string[] | File paths involved |
+| tags | No | string[] | Keywords for search |
+| severity | No | `critical`, `high`, `medium`, `low` | Impact level |
+
+## Body sections by type
+
+### Bug
+
+```markdown
+## Problem
+What was wrong. One paragraph.
+
+## Symptoms
+How this manifested. What errors, what behavior.
+
+## What didn't work
+Approaches tried and discarded, with why they failed.
+
+## Solution
+What fixed it. Include code if relevant.
+
+## Why this works
+The underlying cause and why the fix addresses it.
+
+## Prevention
+How to avoid this class of problem in the future.
+```
+
+### Pattern
+
+```markdown
+## Context
+When this pattern applies.
+
+## Pattern
+The pattern itself. What to do.
+
+## When to apply
+Specific triggers or conditions.
+
+## Example
+Concrete code or configuration example.
+
+## When NOT to apply
+Conditions where this pattern would be wrong.
+```
+
+### Decision
+
+```markdown
+## Context
+What prompted this decision.
+
+## Decision
+What was decided.
+
+## Rationale
+Why this option was chosen over alternatives.
+
+## Alternatives considered
+Other options evaluated and why they were rejected.
+
+## Consequences
+What this decision means going forward. Trade-offs accepted.
+```
+
+## Search
+
+Solutions are searched by `bin/find-solution.sh`:
+
+```bash
+# Search by keyword (matches title, tags, body)
+bin/find-solution.sh "stripe webhook"
+
+# Filter by type
+bin/find-solution.sh "auth" --type bug
+
+# Filter by tag
+bin/find-solution.sh --tag security
+
+# Filter by file
+bin/find-solution.sh --file src/api/webhooks
+```
+
+All query words must match (AND logic). Search is case-insensitive.
+
+## Creating solutions
+
+Solutions are created by `bin/save-solution.sh`:
+
+```bash
+bin/save-solution.sh bug "Stripe webhook missing signature" "stripe,webhooks,security"
+```
+
+Returns `created:<path>` for new files or `exists:<path>` if a solution with the same title already exists. The agent fills in the body sections after creation.
+
+## Integration with skills
+
+### /compound (writes solutions)
+Reads sprint artifacts, identifies solved problems, creates solution documents.
+
+### /nano (reads solutions)
+Before planning, searches solutions for past knowledge related to the technologies and files in scope.
+
+### /review (reads solutions)
+Before reviewing, searches solutions related to the files changed. Checks if current code follows known resolutions.

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -30,13 +30,22 @@ Auto-suggest logic (recommend, don't enforce):
 
 Calibrate depth by diff size: **Small** (< 100 lines, quick pass) / **Medium** (100-500, full two-pass) / **Large** (500+, full + architecture).
 
-## Step 0: Read Plan Context
+## Step 0: Read Plan Context and Past Solutions
 
 Find the plan artifact and extract context for the review:
 
 ```bash
 bin/find-artifact.sh plan 2
 ```
+
+Search for past solutions related to the files being changed:
+
+```bash
+bin/find-solution.sh --file <changed-file-path>
+bin/find-solution.sh "<relevant-keywords>"
+```
+
+If past solutions exist, check whether the current code follows the documented resolutions. If it contradicts a past solution, flag it.
 
 If found, read these fields:
 - **`planned_files[]`** → used by scope drift check (below)

--- a/setup
+++ b/setup
@@ -18,7 +18,7 @@ set -e
 NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
-SKILLS=(think nano review qa security ship guard conductor)
+SKILLS=(think nano review qa security ship guard conductor compound)
 
 # Map skill name to directory (when they differ)
 skill_dir() {

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -226,4 +226,6 @@ After shipping, the sprint is complete. Tell the user:
 
 > Sprint complete. PR created. Journal generated at .nanostack/know-how/journal/.
 >
+> Run `/compound` to document what you learned. Past solutions are found automatically by /nano and /review in future sprints.
+>
 > Run `bin/analytics.sh` to see trends across sprints.


### PR DESCRIPTION
## Summary

New skill that closes the knowledge persistence gap. After a sprint or significant fix, /compound documents what you learned into structured, searchable solutions. Future sprints benefit automatically.

**New:**
- /compound skill: reads sprint artifacts, identifies solved problems, writes solution documents
- bin/save-solution.sh: creates solution docs with YAML frontmatter and body templates
- bin/find-solution.sh: search by keyword, tag, type, or file path
- reference/solution-schema.md: document format reference
- Three solution types: bug (problem/solution), pattern (reusable approach), decision (architecture choice)

**Integration:**
- /nano searches past solutions before planning
- /review checks past solutions before reviewing
- /ship suggests running /compound after shipping

**Zero breaking changes.** Projects without solutions/ work identically.

## Test results

- [x] save-solution.sh creates bug/pattern/decision with correct templates
- [x] save-solution.sh returns exists: for duplicate titles
- [x] save-solution.sh rejects invalid types
- [x] find-solution.sh finds by keyword (single and multi-word)
- [x] find-solution.sh filters by --type
- [x] find-solution.sh filters by --tag
- [x] find-solution.sh returns exit 1 on no match
- [x] find-solution.sh shows usage on no arguments
- [x] setup adds compound to skill list
- [x] setup creates compound symlink
- [x] All scripts pass bash -n syntax check