### PR TITLE
Add /nano-update slash command

### DIFF
--- a/commands/nano-update.md
+++ b/commands/nano-update.md
@@ -1,0 +1,12 @@
+---
+description: Update nanostack to the latest version
+allowed-tools: Bash
+---
+
+Run the nanostack upgrade script:
+
+```bash
+~/.claude/skills/nanostack/bin/upgrade.sh
+```
+
+If the upgrade pulls new commits, report what changed. If setup needs to re-run, it will do so automatically.

--- a/setup
+++ b/setup
@@ -276,6 +276,27 @@ install_claude() {
   if [ ${#renamed[@]} -gt 0 ]; then
     echo "  Renamed skills: ${renamed[*]}"
   fi
+
+  # Install commands to ~/.claude/commands/ (or .claude/commands/ for local)
+  local commands_dir
+  if [ "$LOCAL_INSTALL" -eq 1 ]; then
+    commands_dir="$(dirname "$skills_dir")/commands"
+  else
+    commands_dir="$HOME/.claude/commands"
+  fi
+  mkdir -p "$commands_dir"
+
+  local cmds=()
+  for cmd in "$SOURCE_DIR/commands"/*.md; do
+    [ -f "$cmd" ] || continue
+    local cmd_name
+    cmd_name=$(basename "$cmd")
+    ln -snf "$cmd" "$commands_dir/$cmd_name"
+    cmds+=("/${cmd_name%.md}")
+  done
+  if [ ${#cmds[@]} -gt 0 ]; then
+    echo "  Linked commands: ${cmds[*]}"
+  fi
 }
 
 # ─── OpenAI Codex ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `/nano-update` slash command that runs `bin/upgrade.sh` from within Claude Code
- Setup now symlinks `commands/*.md` to `~/.claude/commands/` (or `.claude/commands/` for local installs) so commands are discoverable

## Test plan
- [ ] Run `./setup` and verify "Linked commands: /nano-update" appears
- [ ] Run `/nano-update` in Claude Code and verify it pulls latest changes