### PR TITLE
Re-run setup on upgrade when commands/ change

### DIFF
--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -50,7 +50,7 @@ git --no-pager log --oneline "$BEFORE".."$AFTER"
 
 # Check if setup needs re-run (new skills or setup changes)
 CHANGED=$(git diff --name-only "$BEFORE".."$AFTER")
-if echo "$CHANGED" | grep -qE '^setup$|/agents/openai\.yaml$'; then
+if echo "$CHANGED" | grep -qE '^setup$|^commands/|/agents/openai\.yaml$'; then
   echo ""
   echo "Setup changed. Re-running..."
   ./setup


### PR DESCRIPTION
## Summary
- `upgrade.sh` now detects changes in `commands/` directory and re-runs `./setup` to install new slash commands
- Previously only re-ran setup when the `setup` file itself changed, so new commands added via upgrade were not installed

## Test plan
- [ ] Add a new command to `commands/`, commit, and run `upgrade.sh` from a stale install
- [ ] Verify "Setup changed. Re-running..." appears and the command gets symlinked