### PR TITLE
Prevent agents from initializing git repo during /nano-update

### DIFF
--- a/commands/nano-update.md
+++ b/commands/nano-update.md
@@ -10,3 +10,5 @@ Run the nanostack upgrade script:
 ```
 
 If the upgrade pulls new commits, report what changed. If setup needs to re-run, it will do so automatically.
+
+Do NOT initialize a git repository if one does not exist. The upgrade script handles both git clone and npx installations automatically.


### PR DESCRIPTION
## Summary
- Add explicit instruction in `/nano-update` command to not initialize a git repository
- Agents were attempting `git init` on npx installations that lack `.git`, which is unnecessary since `upgrade.sh` already handles both install methods

## Test plan
- [ ] Run `/nano-update` on an npx installation and verify the agent runs `upgrade.sh` without attempting `git init`