### PR TITLE
Add parallel execution and context management

### DIFF
--- a/bin/restore-context.sh
+++ b/bin/restore-context.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# restore-context.sh — Read all completed phase checkpoints and output a condensed summary
+# Usage: restore-context.sh [--phases "preflight onboard investigate"] [--max-age-days N] [--json]
+# Default: reads all core phases from the last 30 days for the current project
+# Output: human-readable summary (default) or JSON array (--json)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+PROJECT="$(pwd)"
+MAX_AGE=30
+PHASES="think plan review qa security ship"
+JSON_OUTPUT=false
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --phases) PHASES="$2"; shift 2 ;;
+    --max-age-days) MAX_AGE="$2"; shift 2 ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+# Load custom phases from config
+CONFIG="$NANOSTACK_STORE/config.json"
+if [ -f "$CONFIG" ]; then
+  CUSTOM=$(jq -r '.custom_phases // [] | join(" ")' "$CONFIG" 2>/dev/null || echo "")
+  [ -n "$CUSTOM" ] && PHASES="$PHASES $CUSTOM"
+fi
+
+FOUND=0
+JSON_ARRAY="["
+
+for phase in $PHASES; do
+  ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" 2>/dev/null) || continue
+
+  # Check if artifact has a context_checkpoint
+  HAS_CHECKPOINT=$(jq -e '.context_checkpoint.summary' "$ARTIFACT" >/dev/null 2>&1 && echo "yes" || echo "no")
+
+  STATUS=$(jq -r '.status // "completed"' "$ARTIFACT" 2>/dev/null)
+  TIMESTAMP=$(jq -r '.timestamp // "unknown"' "$ARTIFACT" 2>/dev/null)
+
+  if [ "$HAS_CHECKPOINT" = "yes" ]; then
+    SUMMARY=$(jq -r '.context_checkpoint.summary' "$ARTIFACT")
+    KEY_FILES=$(jq -r '.context_checkpoint.key_files // [] | join(", ")' "$ARTIFACT")
+    DECISIONS=$(jq -r '.context_checkpoint.decisions_made // [] | join("; ")' "$ARTIFACT")
+    OPEN_QS=$(jq -r '.context_checkpoint.open_questions // [] | join("; ")' "$ARTIFACT")
+  else
+    # Fall back to phase summary if no checkpoint
+    SUMMARY=$(jq -r '.summary | to_entries | map("\(.key): \(.value)") | join(", ")' "$ARTIFACT" 2>/dev/null || echo "No summary")
+    KEY_FILES=""
+    DECISIONS=""
+    OPEN_QS=""
+  fi
+
+  if $JSON_OUTPUT; then
+    [ "$FOUND" -gt 0 ] && JSON_ARRAY="$JSON_ARRAY,"
+    JSON_ARRAY="$JSON_ARRAY$(jq -n \
+      --arg phase "$phase" \
+      --arg status "$STATUS" \
+      --arg timestamp "$TIMESTAMP" \
+      --arg summary "$SUMMARY" \
+      --arg key_files "$KEY_FILES" \
+      --arg decisions "$DECISIONS" \
+      --arg open_questions "$OPEN_QS" \
+      --arg has_checkpoint "$HAS_CHECKPOINT" \
+      '{phase: $phase, status: $status, timestamp: $timestamp, has_checkpoint: ($has_checkpoint == "yes"), summary: $summary, key_files: $key_files, decisions: $decisions, open_questions: $open_questions}')"
+  else
+    echo "## $phase ($STATUS)"
+    echo "$SUMMARY"
+    [ -n "$KEY_FILES" ] && echo "Files: $KEY_FILES"
+    [ -n "$DECISIONS" ] && echo "Decisions: $DECISIONS"
+    [ -n "$OPEN_QS" ] && echo "Open: $OPEN_QS"
+    echo ""
+  fi
+
+  FOUND=$((FOUND + 1))
+done
+
+if $JSON_OUTPUT; then
+  echo "$JSON_ARRAY]"
+fi
+
+if [ "$FOUND" -eq 0 ]; then
+  if $JSON_OUTPUT; then
+    echo "[]"
+  else
+    echo "No completed phase artifacts found for this project."
+  fi
+  exit 1
+fi

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# session.sh — Session lifecycle management for crash recovery and resume
+# Usage:
+#   session.sh init <type> [--issue <url>]   Create session.json for current project
+#   session.sh phase-start <phase>           Mark phase as in_progress
+#   session.sh phase-complete <phase>        Mark phase as completed
+#   session.sh resume                        Check for existing session, output resume info
+#   session.sh status                        Output current session state
+#   session.sh archive                       Archive current session
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+PROJECT="$(pwd)"
+PROJECT_NAME=$(basename "$PROJECT")
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ─── init ───────────────────────────────────────────────────
+cmd_init() {
+  local type="${1:-development}"
+  local issue_url=""
+
+  shift || true
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --issue) issue_url="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Archive existing session if present
+  if [ -f "$SESSION_FILE" ]; then
+    local old_id
+    old_id=$(jq -r '.session_id // "unknown"' "$SESSION_FILE")
+    local archive_dir="$NANOSTACK_STORE/sessions"
+    mkdir -p "$archive_dir"
+    mv "$SESSION_FILE" "$archive_dir/${old_id}.json"
+  fi
+
+  local session_id="${PROJECT_NAME}-$(date -u +%Y%m%d-%H%M%S)"
+  local repo=""
+  repo=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||') || true
+
+  jq -n \
+    --arg id "$session_id" \
+    --arg type "$type" \
+    --arg issue "$issue_url" \
+    --arg repo "$repo" \
+    --arg workspace "$PROJECT" \
+    --arg date "$NOW" \
+    '{
+      session_id: $id,
+      type: $type,
+      issue_url: (if $issue != "" then $issue else null end),
+      repo: (if $repo != "" then $repo else null end),
+      workspace: $workspace,
+      current_phase: null,
+      phase_log: [],
+      budget: {
+        max_usd: null,
+        spent_usd: 0,
+        tokens_input: 0,
+        tokens_output: 0
+      },
+      started_at: $date,
+      last_updated: $date
+    }' > "$SESSION_FILE"
+
+  echo "$SESSION_FILE"
+}
+
+# ─── phase-start ────────────────────────────────────────────
+cmd_phase_start() {
+  local phase="${1:?Usage: session.sh phase-start <phase>}"
+
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo "ERROR: no active session. Run 'session.sh init' first." >&2
+    exit 1
+  fi
+
+  jq \
+    --arg phase "$phase" \
+    --arg date "$NOW" \
+    '.current_phase = $phase |
+     .phase_log += [{
+       phase: $phase,
+       status: "in_progress",
+       started_at: $date,
+       completed_at: null,
+       artifact: null
+     }] |
+     .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
+  mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  echo "OK: $phase started"
+}
+
+# ─── phase-complete ─────────────────────────────────────────
+cmd_phase_complete() {
+  local phase="${1:?Usage: session.sh phase-complete <phase>}"
+  local artifact=""
+
+  # Find the artifact for this phase
+  artifact=$("$SCRIPT_DIR/find-artifact.sh" "$phase" 1 2>/dev/null) || true
+
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo "ERROR: no active session." >&2
+    exit 1
+  fi
+
+  jq \
+    --arg phase "$phase" \
+    --arg date "$NOW" \
+    --arg artifact "$artifact" \
+    '(.phase_log[] | select(.phase == $phase and .status == "in_progress")) |=
+       (.status = "completed" | .completed_at = $date | .artifact = (if $artifact != "" then $artifact else null end)) |
+     .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
+  mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  echo "OK: $phase completed"
+}
+
+# ─── resume ─────────────────────────────────────────────────
+cmd_resume() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo '{"resumable":false,"reason":"no_session"}'
+    exit 0
+  fi
+
+  # Check if session belongs to this project
+  local workspace
+  workspace=$(jq -r '.workspace' "$SESSION_FILE")
+  if [ "$workspace" != "$PROJECT" ]; then
+    echo '{"resumable":false,"reason":"different_project"}'
+    exit 0
+  fi
+
+  local session_id current_phase type
+  session_id=$(jq -r '.session_id' "$SESSION_FILE")
+  current_phase=$(jq -r '.current_phase // "none"' "$SESSION_FILE")
+  type=$(jq -r '.type' "$SESSION_FILE")
+
+  local completed_phases
+  completed_phases=$(jq -r '[.phase_log[] | select(.status == "completed") | .phase] | join(", ")' "$SESSION_FILE")
+
+  local last_status
+  last_status=$(jq -r '.phase_log[-1].status // "none"' "$SESSION_FILE")
+
+  local last_phase
+  last_phase=$(jq -r '.phase_log[-1].phase // "none"' "$SESSION_FILE")
+
+  jq -n \
+    --arg resumable "true" \
+    --arg session_id "$session_id" \
+    --arg type "$type" \
+    --arg current_phase "$current_phase" \
+    --arg last_phase "$last_phase" \
+    --arg last_status "$last_status" \
+    --arg completed "$completed_phases" \
+    '{
+      resumable: true,
+      session_id: $session_id,
+      type: $type,
+      current_phase: $current_phase,
+      last_phase: $last_phase,
+      last_status: $last_status,
+      completed_phases: $completed,
+      action: (if $last_status == "in_progress" then "restart_phase" else "next_phase" end)
+    }'
+}
+
+# ─── status ─────────────────────────────────────────────────
+cmd_status() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo '{"active":false}'
+    exit 0
+  fi
+
+  jq '{
+    active: true,
+    session_id: .session_id,
+    type: .type,
+    current_phase: .current_phase,
+    phases_completed: [.phase_log[] | select(.status == "completed") | .phase],
+    phases_in_progress: [.phase_log[] | select(.status == "in_progress") | .phase],
+    started_at: .started_at,
+    last_updated: .last_updated,
+    budget: .budget
+  }' "$SESSION_FILE"
+}
+
+# ─── archive ────────────────────────────────────────────────
+cmd_archive() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo "No active session to archive."
+    exit 0
+  fi
+
+  local session_id
+  session_id=$(jq -r '.session_id' "$SESSION_FILE")
+  local archive_dir="$NANOSTACK_STORE/sessions"
+  mkdir -p "$archive_dir"
+
+  jq --arg date "$NOW" '.status = "archived" | .archived_at = $date' "$SESSION_FILE" > "$archive_dir/${session_id}.json"
+  rm "$SESSION_FILE"
+
+  echo "OK: archived $session_id"
+}
+
+# ─── dispatch ───────────────────────────────────────────────
+CMD="${1:-status}"
+shift || true
+
+case "$CMD" in
+  init)           cmd_init "$@" ;;
+  phase-start)    cmd_phase_start "$@" ;;
+  phase-complete) cmd_phase_complete "$@" ;;
+  resume)         cmd_resume "$@" ;;
+  status)         cmd_status "$@" ;;
+  archive)        cmd_archive "$@" ;;
+  *)
+    echo "Usage: session.sh <init|phase-start|phase-complete|resume|status|archive>" >&2
+    exit 1
+    ;;
+esac

--- a/bin/validate-dependencies.sh
+++ b/bin/validate-dependencies.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# validate-dependencies.sh — Check that upstream phase artifacts exist before starting a phase
+# Usage: validate-dependencies.sh <phase>
+# Reads depends_on from the skill's SKILL.md frontmatter and verifies each dependency
+# has a completed artifact for the current project.
+# Exit 0 = all deps met. Exit 1 = missing dependencies (lists them).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+PHASE="${1:?Usage: validate-dependencies.sh <phase>}"
+
+# Map phase name to skill directory
+case "$PHASE" in
+  plan) SKILL_DIR="$NANOSTACK_ROOT/plan" ;;
+  build) echo "OK"; exit 0 ;; # build is implicit, no SKILL.md
+  *) SKILL_DIR="$NANOSTACK_ROOT/$PHASE" ;;
+esac
+
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+if [ ! -f "$SKILL_MD" ]; then
+  echo "OK"
+  exit 0
+fi
+
+# Extract depends_on from YAML frontmatter
+# Format: depends_on: [think, plan] or depends_on: []
+DEPS_RAW=$(sed -n '/^---$/,/^---$/p' "$SKILL_MD" | grep '^depends_on:' | head -1 | sed 's/^depends_on: *//')
+
+# Parse YAML array: [think, plan] → "think plan"
+DEPS=$(echo "$DEPS_RAW" | tr -d '[]' | tr ',' ' ' | tr -d ' ')
+
+# Handle empty deps
+if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
+  echo "OK"
+  exit 0
+fi
+
+# Re-parse with spaces preserved between items
+DEPS=$(echo "$DEPS_RAW" | tr -d '[]' | sed 's/,/ /g' | tr -s ' ')
+
+MISSING=""
+FOUND=0
+
+for dep in $DEPS; do
+  dep=$(echo "$dep" | tr -d ' ')
+  [ -z "$dep" ] && continue
+
+  if "$SCRIPT_DIR/find-artifact.sh" "$dep" 2 >/dev/null 2>&1; then
+    FOUND=$((FOUND + 1))
+  else
+    MISSING="${MISSING:+$MISSING, }$dep"
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  echo "MISSING: $MISSING" >&2
+  exit 1
+fi
+
+echo "OK"

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: compound
 description: Document what you learned during this sprint. Reads artifacts, writes structured solutions to know-how/solutions/. Run after /ship or after fixing a significant bug. Triggers on /compound.
+concurrency: write
+depends_on: [ship]
+summary: "Knowledge capture. Documents bugs, patterns, decisions from sprint artifacts."
+estimated_tokens: 250
 ---
 
 # /compound - Knowledge Compounding

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: conductor
 description: Orchestrate parallel agent sessions through a sprint. Coordinates task claiming, dependency resolution, and artifact handoff between independent agents. Triggers on /conductor, /sprint, /parallel.
+concurrency: exclusive
+depends_on: []
+summary: "Multi-agent sprint orchestrator. Atomic file ops for phase claiming and dependency resolution."
+estimated_tokens: 500
 ---
 
 # /conductor — Multi-Agent Sprint Orchestrator
@@ -94,6 +98,34 @@ conductor/bin/sprint.sh abort [phase]
 
 Release a claim without completing. Use when an agent encounters a blocker.
 
+### Batch (auto-parallelize)
+
+```bash
+conductor/bin/sprint.sh batch
+```
+
+Reads `concurrency` metadata from each skill's SKILL.md frontmatter and outputs execution batches. Consecutive `read` phases with met dependencies are grouped into parallel batches. `write` phases run one at a time. `exclusive` phases run alone.
+
+**Concurrency classification:**
+
+| Value | Meaning | Example |
+|-------|---------|---------|
+| `read` | Read-only, safe to parallelize | review, qa, security |
+| `write` | Mutates files, run serial | compound |
+| `exclusive` | Needs exclusive access (git ops) | ship, guard |
+
+**Example output:**
+
+```json
+{"batch":1,"type":"read","phases":["think"]}
+{"batch":2,"type":"read","phases":["plan"]}
+{"batch":3,"type":"write","phases":["build"]}
+{"batch":4,"type":"read","phases":["review","qa","security"]}
+{"batch":5,"type":"exclusive","phases":["ship"]}
+```
+
+Batch 4 shows review, qa, and security running in parallel — they share `concurrency: read` and all depend only on `build`.
+
 ## Filesystem Protocol
 
 ```
@@ -167,6 +199,33 @@ Dev A (claude):   /review (claims after build.done)
 Dev C (opencode):     /security (claims after build.done, parallel with review)
 Dev A (claude):   /ship (claims after review.done + security.done)
 ```
+
+## Phase Protocol
+
+Every phase transition follows this protocol. The agent executes these steps at every boundary — they are mandatory, not optional.
+
+### Pre-phase (before starting a new phase)
+
+1. Check for existing session: `bin/session.sh resume`
+   - If resumable and user confirms, restore context via `bin/restore-context.sh`
+   - If no session exists, create one: `bin/session.sh init <type>`
+2. Validate upstream dependencies: `bin/validate-dependencies.sh <phase>`
+   - If MISSING, stop and report which dependencies are not met
+3. Update session: `bin/session.sh phase-start <phase>`
+
+### Post-phase (after completing a phase)
+
+1. Save artifact with `context_checkpoint` via `bin/save-artifact.sh`
+   - The `context_checkpoint` must include: `summary`, `key_files`, `decisions_made`, `open_questions`
+   - No artifact is saved without `context_checkpoint` populated
+2. Update session: `bin/session.sh phase-complete <phase>`
+3. If context is running low, the agent reads the checkpoint summary instead of replaying full conversation
+
+### Session resume (on crash recovery)
+
+1. `bin/session.sh resume` detects the last session state
+2. `bin/restore-context.sh` reads all completed phase checkpoints
+3. Skip completed phases, restart the in-progress phase from scratch
 
 ## Gotchas
 

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -265,6 +265,97 @@ cmd_clean() {
   echo "OK: cleaned archived sprints older than 7 days"
 }
 
+# ─── batch ──────────────────────────────────────────────────
+# Read concurrency metadata from SKILL.md files and output execution batches.
+# Phases with concurrency=read and all deps met run in parallel.
+# Phases with concurrency=write run serial, one at a time.
+# Phases with concurrency=exclusive run serial, no other phases.
+cmd_batch() {
+  local sprint_dir
+  sprint_dir=$(find_sprint) || { echo "ERROR: no active sprint" >&2; exit 1; }
+
+  local nanostack_root
+  nanostack_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+  # Get concurrency for a phase from its SKILL.md frontmatter
+  get_concurrency() {
+    local phase="$1"
+    local skill_md=""
+    case "$phase" in
+      plan) skill_md="$nanostack_root/plan/SKILL.md" ;;
+      build) echo "write"; return ;;
+      *) skill_md="$nanostack_root/$phase/SKILL.md" ;;
+    esac
+    if [ -n "$skill_md" ] && [ -f "$skill_md" ]; then
+      local conc
+      conc=$(sed -n '/^---$/,/^---$/p' "$skill_md" | grep '^concurrency:' | head -1 | sed 's/^concurrency: *//')
+      echo "${conc:-write}"
+    else
+      echo "write"
+    fi
+  }
+
+  local phases
+  phases=$(jq -r '.phases[].name' "$sprint_dir/sprint.json")
+
+  # Partition into execution batches
+  # Track all phases scheduled in prior batches (considered "will be done")
+  local batch_num=0
+  local current_batch=""
+  local current_type=""
+  local scheduled=""
+
+  for phase in $phases; do
+    # Skip completed phases (but track them as available)
+    if [ -f "$sprint_dir/$phase/done" ]; then
+      scheduled="$scheduled $phase"
+      continue
+    fi
+
+    # Check if deps are met (done on disk OR scheduled in a prior batch)
+    local deps_met=true
+    local deps
+    deps=$(jq -r --arg p "$phase" '.phases[] | select(.name == $p) | .depends_on[]' "$sprint_dir/sprint.json" 2>/dev/null)
+    for dep in $deps; do
+      if [ ! -f "$sprint_dir/$dep/done" ]; then
+        # Check if dep is scheduled in a prior batch (not current — current runs in parallel)
+        if ! echo "$scheduled" | grep -qw "$dep" 2>/dev/null; then
+          deps_met=false
+          break
+        fi
+      fi
+    done
+
+    local conc
+    conc=$(get_concurrency "$phase")
+
+    if [ "$conc" = "read" ] && [ "$current_type" = "read" ] && [ "$deps_met" = true ]; then
+      # Extend current read batch
+      current_batch="$current_batch $phase"
+    else
+      # Flush previous batch
+      if [ -n "$current_batch" ]; then
+        batch_num=$((batch_num + 1))
+        local phase_json
+        phase_json=$(echo "$current_batch" | tr ' ' '\n' | grep -v '^$' | jq -R . | paste -sd, -)
+        echo "{\"batch\":$batch_num,\"type\":\"$current_type\",\"phases\":[$phase_json]}"
+        # Mark flushed phases as scheduled
+        scheduled="$scheduled $current_batch"
+      fi
+      current_batch="$phase"
+      current_type="$conc"
+    fi
+  done
+
+  # Flush last batch
+  if [ -n "$current_batch" ]; then
+    batch_num=$((batch_num + 1))
+    local phase_json
+    phase_json=$(echo "$current_batch" | tr ' ' '\n' | grep -v '^$' | jq -R . | paste -sd, -)
+    echo "{\"batch\":$batch_num,\"type\":\"$current_type\",\"phases\":[$phase_json]}"
+  fi
+}
+
 # ─── dispatch ────────────────────────────────────────────────
 CMD="${1:-status}"
 shift || true
@@ -275,9 +366,10 @@ case "$CMD" in
   complete) cmd_complete "$@" ;;
   abort)    cmd_abort "$@" ;;
   status)   cmd_status "$@" ;;
+  batch)    cmd_batch "$@" ;;
   clean)    cmd_clean "$@" ;;
   *)
-    echo "Usage: sprint.sh <start|claim|complete|abort|status|clean>" >&2
+    echo "Usage: sprint.sh <start|claim|complete|abort|status|batch|clean>" >&2
     exit 1
     ;;
 esac

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: guard
 description: Use when working near production, sensitive systems, or destructive operations. Activates on-demand safety hooks that block dangerous commands. Supports modes — careful (warn), freeze (block writes outside scope), unfreeze (remove restrictions). Triggers on /guard, /careful, /freeze, /unfreeze.
+concurrency: exclusive
+depends_on: []
+summary: "Safety guardrails. Blocks dangerous commands near production or sensitive systems."
+estimated_tokens: 200
 hooks:
   PreToolUse:
     - matcher: Bash

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: nano
 description: Use when starting non-trivial work (touching 3+ files, new features, refactors, bug investigations). Produces a scoped, actionable implementation plan before any code is written. Triggers on /nano.
+concurrency: read
+depends_on: [think]
+summary: "Implementation planning. Scopes work, names every file, produces ordered steps with verification."
+estimated_tokens: 400
 ---
 
 # /nano — Implementation Planning

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: qa
 description: Use to verify that code works correctly — browser-based testing with Playwright, native app testing with computer use, CLI testing, API testing, or root-cause debugging. Supports --quick, --standard, --thorough modes. Triggers on /qa.
+concurrency: read
+depends_on: [build]
+summary: "QA testing. Browser, native, API, CLI, or debug modes. Finds and fixes bugs with atomic commits."
+estimated_tokens: 450
 ---
 
 # /qa — Quality Assurance & Debugging

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -18,6 +18,34 @@ All artifacts share this base structure:
 }
 ```
 
+## Context Checkpoint
+
+Every artifact can include a `context_checkpoint` — a self-contained summary that lets the agent reconstruct phase state without replaying the full conversation. This prevents context overflow on long workflows (8+ phases).
+
+```json
+{
+  "context_checkpoint": {
+    "summary": "One-paragraph summary of what this phase discovered or produced.",
+    "key_files": ["path/to/file.ts:142", "path/to/other.ts:87"],
+    "decisions_made": [
+      "Chose approach X over Y because Z"
+    ],
+    "open_questions": []
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `summary` | string | What this phase found or produced. Should be self-sufficient — readable without prior context. |
+| `key_files` | string[] | Files central to this phase's work, with line numbers where relevant. |
+| `decisions_made` | string[] | Choices made during this phase, with reasoning. Critical for downstream phases. |
+| `open_questions` | string[] | Unresolved items. Empty array if none. |
+
+**When to populate:** At the end of every phase, BEFORE starting the next. The agent writes the checkpoint as part of `save-artifact.sh` output.
+
+**When to read:** Use `bin/restore-context.sh` to read all completed checkpoints at once — produces a condensed summary under 500 tokens.
+
 ## Schema per phase
 
 ### /think

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: review
 description: Use after writing code to get a thorough code review. Runs two passes — structural correctness then adversarial edge-case hunting. Scales depth by diff size. Supports --quick, --standard, --thorough modes. Triggers on /review.
+concurrency: read
+depends_on: [build]
+summary: "Two-pass code review. Structural correctness then adversarial edge-case hunting. Scope drift detection."
+estimated_tokens: 400
 hooks:
   PostToolUse:
     - matcher: Bash

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: security
 description: Use before shipping to production. Performs OWASP Top 10 audit and STRIDE threat modeling against the codebase. Supports --quick, --standard, --thorough modes. Also use when the user asks to check security, audit code, or review for vulnerabilities. Triggers on /security.
+concurrency: read
+depends_on: [build]
+summary: "Security audit. OWASP A01-A10, STRIDE threat modeling, secrets scan, dependency audit."
+estimated_tokens: 450
 ---
 
 # /security — Security Audit

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: ship
 description: Use when code is ready to ship — creates PRs, merges, deploys, and verifies. Handles the full PR-to-production pipeline. Triggers on /ship.
+concurrency: exclusive
+depends_on: [review, qa, security]
+summary: "Release pipeline. PR creation, CI monitoring, post-deploy verification, rollback plan."
+estimated_tokens: 350
 hooks:
   PreToolUse:
     - matcher: Bash

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: think
 description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Supports --autopilot to run the full sprint automatically after approval. Triggers on /think, /office-hours, /ceo-review.
+concurrency: read
+depends_on: []
+summary: "Strategic product thinking. Challenges assumptions, finds narrowest valuable wedge, validates premise before planning."
+estimated_tokens: 450
 ---
 
 # /think — Strategic Product Thinking


### PR DESCRIPTION
## Summary

- **Concurrency classification**: All 9 SKILL.md files now declare `concurrency` (read|write|exclusive) and `depends_on`. New `sprint.sh batch` command reads metadata and auto-groups parallel-safe phases — review+qa+security batch together after build.
- **Context checkpointing**: New `context_checkpoint` schema in artifacts (summary, key_files, decisions_made, open_questions). New `bin/restore-context.sh` reads all checkpoints and outputs condensed summary under 500 tokens.
- **Session resume**: New `bin/session.sh` manages session lifecycle (init, phase-start, phase-complete, resume, archive). Detects crashed sessions and resumes from last in-progress phase.
- **Deferred skill loading**: `summary` and `estimated_tokens` fields in all frontmatter enable manifest-only loading (~5-8K token savings on initial prompt).
- **Phase transition hooks**: New `bin/validate-dependencies.sh` for pre-phase dependency checks. Phase Protocol documented in conductor/SKILL.md (pre-phase, post-phase, resume conventions).

## Test plan

- [x] `session.sh init` creates valid session.json with all fields
- [x] `session.sh phase-start/phase-complete` updates phase_log correctly
- [x] `session.sh resume` detects resumable sessions with correct action
- [x] `session.sh archive` moves to sessions/ directory
- [x] `save-artifact.sh` accepts and preserves context_checkpoint in artifacts
- [x] `restore-context.sh` reads checkpoints (text + JSON output modes)
- [x] `validate-dependencies.sh` returns OK when deps met, MISSING when not
- [x] `sprint.sh batch` groups review+qa+security into single parallel batch
- [x] `sprint.sh batch` skips completed phases and shows only remaining work
- [x] `sprint.sh batch` compatible with macOS bash 3.x (no associative arrays)
- [x] All existing scripts unaffected