### PR TITLE
Add budget enforcement, circuit breaker, and core optimizations

### DIFF
--- a/bin/budget.sh
+++ b/bin/budget.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# budget.sh — Token budget enforcement for sprint cost control
+# Usage:
+#   budget.sh set --max-usd 15 --model opus-4
+#   budget.sh check --input-tokens 150000 --output-tokens 30000
+#   budget.sh status
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+
+# Pricing per 1M tokens: input output
+pricing() {
+  case "$1" in
+    opus-4|opus-4-6)     echo "15.0 75.0" ;;
+    sonnet-4|sonnet-4-6) echo "3.0 15.0" ;;
+    haiku-4-5)           echo "0.80 4.0" ;;
+    gpt-4o)              echo "2.5 10.0" ;;
+    gpt-4.1)             echo "2.0 8.0" ;;
+    o3)                  echo "2.0 8.0" ;;
+    *)                   echo "3.0 15.0" ;; # default to sonnet pricing
+  esac
+}
+
+# ─── set ────────────────────────────────────────────────────
+cmd_set() {
+  local max_usd="" model="sonnet-4"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --max-usd) max_usd="$2"; shift 2 ;;
+      --model) model="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  [ -z "$max_usd" ] && { echo "Usage: budget.sh set --max-usd <amount> [--model <model>]" >&2; exit 1; }
+
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo "ERROR: no active session. Run 'session.sh init' first." >&2
+    exit 1
+  fi
+
+  jq \
+    --argjson max "$max_usd" \
+    --arg model "$model" \
+    '.budget.max_usd = $max | .budget.model = $model' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
+  mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  echo "OK: budget set to \$$max_usd ($model)"
+}
+
+# ─── check ──────────────────────────────────────────────────
+cmd_check() {
+  local input_tokens=0 output_tokens=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --input-tokens) input_tokens="$2"; shift 2 ;;
+      --output-tokens) output_tokens="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo '{"action":"continue","reason":"no_session"}'
+    exit 0
+  fi
+
+  local max_usd model prev_input prev_output
+  max_usd=$(jq -r '.budget.max_usd // "null"' "$SESSION_FILE")
+  model=$(jq -r '.budget.model // "sonnet-4"' "$SESSION_FILE")
+  prev_input=$(jq -r '.budget.tokens_input // 0' "$SESSION_FILE")
+  prev_output=$(jq -r '.budget.tokens_output // 0' "$SESSION_FILE")
+
+  # No budget set: always continue
+  if [ "$max_usd" = "null" ]; then
+    echo '{"action":"continue","reason":"no_budget_set"}'
+    exit 0
+  fi
+
+  local total_input=$((prev_input + input_tokens))
+  local total_output=$((prev_output + output_tokens))
+
+  # Calculate cost
+  local price_pair
+  price_pair=$(pricing "$model")
+  local input_price output_price
+  input_price=$(echo "$price_pair" | cut -d' ' -f1)
+  output_price=$(echo "$price_pair" | cut -d' ' -f2)
+
+  # Cost in USD: (tokens / 1M) * price_per_M
+  # Use awk for floating point
+  local spent_usd pct action reason
+  spent_usd=$(awk "BEGIN { printf \"%.2f\", ($total_input / 1000000.0) * $input_price + ($total_output / 1000000.0) * $output_price }")
+  pct=$(awk "BEGIN { printf \"%d\", ($spent_usd / $max_usd) * 100 }")
+
+  if [ "$pct" -ge 95 ]; then
+    action="stop"
+    reason="budget_exceeded"
+  elif [ "$pct" -ge 80 ]; then
+    action="warn"
+    reason="budget_warning"
+  else
+    action="continue"
+    reason=""
+  fi
+
+  # Update session with new totals
+  jq \
+    --argjson input "$total_input" \
+    --argjson output "$total_output" \
+    --argjson spent "$spent_usd" \
+    '.budget.tokens_input = $input | .budget.tokens_output = $output | .budget.spent_usd = $spent' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
+  mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  jq -n \
+    --argjson spent "$spent_usd" \
+    --argjson max "$max_usd" \
+    --argjson pct "$pct" \
+    --arg action "$action" \
+    --arg reason "$reason" \
+    --arg model "$model" \
+    '{spent_usd: $spent, max_usd: $max, pct: $pct, action: $action, reason: $reason, model: $model}'
+}
+
+# ─── status ─────────────────────────────────────────────────
+cmd_status() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    echo '{"active":false}'
+    exit 0
+  fi
+
+  jq '.budget' "$SESSION_FILE"
+}
+
+# ─── dispatch ───────────────────────────────────────────────
+CMD="${1:-status}"
+shift || true
+
+case "$CMD" in
+  set)    cmd_set "$@" ;;
+  check)  cmd_check "$@" ;;
+  status) cmd_status "$@" ;;
+  *)
+    echo "Usage: budget.sh <set|check|status>" >&2
+    exit 1
+    ;;
+esac

--- a/bin/circuit.sh
+++ b/bin/circuit.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# circuit.sh — Circuit breaker to prevent infinite retry loops
+# Usage:
+#   circuit.sh fail --tag "hypothesis-xss" [--max 3]
+#   circuit.sh success
+#   circuit.sh status
+#   circuit.sh reset
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+CIRCUIT_FILE="$NANOSTACK_STORE/circuit.json"
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Initialize circuit file if missing
+ensure_circuit() {
+  if [ ! -f "$CIRCUIT_FILE" ]; then
+    jq -n '{consecutive_failures: 0, max_failures: 3, state: "closed", last_tag: null, history: []}' > "$CIRCUIT_FILE"
+  fi
+}
+
+# ─── fail ───────────────────────────────────────────────────
+cmd_fail() {
+  local tag="" max=3
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --tag) tag="$2"; shift 2 ;;
+      --max) max="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  [ -z "$tag" ] && { echo "Usage: circuit.sh fail --tag <tag> [--max N]" >&2; exit 1; }
+
+  ensure_circuit
+
+  local last_tag
+  last_tag=$(jq -r '.last_tag // ""' "$CIRCUIT_FILE")
+
+  # New tag = pivot detected, reset counter
+  if [ "$last_tag" != "$tag" ] && [ -n "$last_tag" ]; then
+    jq --arg tag "$tag" --argjson max "$max" --arg date "$NOW" \
+      '.consecutive_failures = 1 | .last_tag = $tag | .max_failures = $max | .state = "closed" |
+       .history = (.history + [{"tag": $tag, "at": $date, "type": "fail"}] | .[-20:])' \
+      "$CIRCUIT_FILE" > "${CIRCUIT_FILE}.tmp"
+    mv "${CIRCUIT_FILE}.tmp" "$CIRCUIT_FILE"
+  else
+    jq --arg tag "$tag" --argjson max "$max" --arg date "$NOW" \
+      '.consecutive_failures += 1 | .last_tag = $tag | .max_failures = $max |
+       .history = (.history + [{"tag": $tag, "at": $date, "type": "fail"}] | .[-20:]) |
+       if .consecutive_failures >= .max_failures then .state = "open" else . end' \
+      "$CIRCUIT_FILE" > "${CIRCUIT_FILE}.tmp"
+    mv "${CIRCUIT_FILE}.tmp" "$CIRCUIT_FILE"
+  fi
+
+  # Output current state
+  local state consecutive
+  state=$(jq -r '.state' "$CIRCUIT_FILE")
+  consecutive=$(jq -r '.consecutive_failures' "$CIRCUIT_FILE")
+
+  jq -n \
+    --arg state "$state" \
+    --argjson consecutive "$consecutive" \
+    --argjson max "$max" \
+    --arg tag "$tag" \
+    '{state: $state, consecutive: $consecutive, max: $max, tag: $tag} |
+     if $state == "open" then . + {message: "\($max) consecutive failures on \($tag). Pivot or stop."} else . end'
+}
+
+# ─── success ────────────────────────────────────────────────
+cmd_success() {
+  ensure_circuit
+
+  jq --arg date "$NOW" \
+    '.consecutive_failures = 0 | .state = "closed" |
+     .history = (.history + [{"tag": .last_tag, "at": $date, "type": "success"}] | .[-20:])' \
+    "$CIRCUIT_FILE" > "${CIRCUIT_FILE}.tmp"
+  mv "${CIRCUIT_FILE}.tmp" "$CIRCUIT_FILE"
+
+  echo '{"state":"closed","consecutive":0}'
+}
+
+# ─── status ─────────────────────────────────────────────────
+cmd_status() {
+  ensure_circuit
+  jq '{state, consecutive_failures, max_failures, last_tag}' "$CIRCUIT_FILE"
+}
+
+# ─── reset ──────────────────────────────────────────────────
+cmd_reset() {
+  jq -n '{consecutive_failures: 0, max_failures: 3, state: "closed", last_tag: null, history: []}' > "$CIRCUIT_FILE"
+  echo '{"state":"closed","consecutive":0}'
+}
+
+# ─── dispatch ───────────────────────────────────────────────
+CMD="${1:-status}"
+shift || true
+
+case "$CMD" in
+  fail)    cmd_fail "$@" ;;
+  success) cmd_success "$@" ;;
+  status)  cmd_status "$@" ;;
+  reset)   cmd_reset "$@" ;;
+  *)
+    echo "Usage: circuit.sh <fail|success|status|reset>" >&2
+    exit 1
+    ;;
+esac

--- a/bin/find-solution.sh
+++ b/bin/find-solution.sh
@@ -130,6 +130,23 @@ while IFS= read -r filepath; do
       fi
     fi
 
+    # Staleness: penalize if referenced files no longer exist
+    if [ -n "$FM_FILES" ] && [ "$FM_FILES" != "[]" ]; then
+      STALE_FILES=0
+      TOTAL_FILES=0
+      for ref_file in $(echo "$FM_FILES" | tr -d '[]"' | tr ',' ' '); do
+        ref_file=$(echo "$ref_file" | tr -d ' ' | sed 's/:.*$//')  # strip line numbers
+        [ -z "$ref_file" ] && continue
+        TOTAL_FILES=$((TOTAL_FILES + 1))
+        [ ! -f "$ref_file" ] && STALE_FILES=$((STALE_FILES + 1))
+      done
+      if [ "$TOTAL_FILES" -gt 0 ] && [ "$STALE_FILES" -eq "$TOTAL_FILES" ]; then
+        SCORE=$((SCORE - 3))  # all files gone: heavy penalty
+      elif [ "$STALE_FILES" -gt 0 ]; then
+        SCORE=$((SCORE - 1))  # some files gone: light penalty
+      fi
+    fi
+
     RESULTS="${RESULTS}${SCORE}|${filepath}|${TITLE}|${SEVERITY}|${DATE}|${TAGS}|${FM_FILES}|${TYPE_DIR}
 "
   fi

--- a/bin/restore-context.sh
+++ b/bin/restore-context.sh
@@ -12,6 +12,7 @@ PROJECT="$(pwd)"
 MAX_AGE=30
 PHASES="think plan review qa security ship"
 JSON_OUTPUT=false
+TOKEN_BUDGET=0  # 0 = no budget, load full artifacts
 
 # Parse arguments
 while [ $# -gt 0 ]; do
@@ -19,6 +20,7 @@ while [ $# -gt 0 ]; do
     --phases) PHASES="$2"; shift 2 ;;
     --max-age-days) MAX_AGE="$2"; shift 2 ;;
     --json) JSON_OUTPUT=true; shift ;;
+    --budget) TOKEN_BUDGET="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
@@ -28,6 +30,33 @@ CONFIG="$NANOSTACK_STORE/config.json"
 if [ -f "$CONFIG" ]; then
   CUSTOM=$(jq -r '.custom_phases // [] | join(" ")' "$CONFIG" 2>/dev/null || echo "")
   [ -n "$CUSTOM" ] && PHASES="$PHASES $CUSTOM"
+fi
+
+# If budget is set, estimate total upstream size and decide mode
+CHECKPOINT_ONLY=false
+if [ "$TOKEN_BUDGET" -gt 0 ]; then
+  TOTAL_ESTIMATED=0
+  for phase in $PHASES; do
+    ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" 2>/dev/null) || continue
+    # Read estimated_tokens from the skill's SKILL.md, fall back to artifact size estimate
+    NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+    SKILL_MD=""
+    case "$phase" in
+      plan) SKILL_MD="$NANOSTACK_ROOT/plan/SKILL.md" ;;
+      build) ;;
+      *) SKILL_MD="$NANOSTACK_ROOT/$phase/SKILL.md" ;;
+    esac
+    EST=0
+    if [ -n "$SKILL_MD" ] && [ -f "$SKILL_MD" ]; then
+      EST=$(sed -n '/^---$/,/^---$/p' "$SKILL_MD" | grep '^estimated_tokens:' | head -1 | sed 's/^estimated_tokens: *//')
+    fi
+    [ -z "$EST" ] || [ "$EST" = "0" ] && EST=300
+    TOTAL_ESTIMATED=$((TOTAL_ESTIMATED + EST))
+  done
+
+  if [ "$TOTAL_ESTIMATED" -gt "$TOKEN_BUDGET" ]; then
+    CHECKPOINT_ONLY=true
+  fi
 fi
 
 FOUND=0
@@ -42,13 +71,19 @@ for phase in $PHASES; do
   STATUS=$(jq -r '.status // "completed"' "$ARTIFACT" 2>/dev/null)
   TIMESTAMP=$(jq -r '.timestamp // "unknown"' "$ARTIFACT" 2>/dev/null)
 
-  if [ "$HAS_CHECKPOINT" = "yes" ]; then
+  if [ "$CHECKPOINT_ONLY" = true ] && [ "$HAS_CHECKPOINT" = "yes" ]; then
+    # Budget exceeded: checkpoint only
+    SUMMARY=$(jq -r '.context_checkpoint.summary' "$ARTIFACT")
+    KEY_FILES=$(jq -r '.context_checkpoint.key_files // [] | join(", ")' "$ARTIFACT")
+    DECISIONS=$(jq -r '.context_checkpoint.decisions_made // [] | join("; ")' "$ARTIFACT")
+    OPEN_QS=$(jq -r '.context_checkpoint.open_questions // [] | join("; ")' "$ARTIFACT")
+  elif [ "$HAS_CHECKPOINT" = "yes" ] && [ "$CHECKPOINT_ONLY" != true ]; then
     SUMMARY=$(jq -r '.context_checkpoint.summary' "$ARTIFACT")
     KEY_FILES=$(jq -r '.context_checkpoint.key_files // [] | join(", ")' "$ARTIFACT")
     DECISIONS=$(jq -r '.context_checkpoint.decisions_made // [] | join("; ")' "$ARTIFACT")
     OPEN_QS=$(jq -r '.context_checkpoint.open_questions // [] | join("; ")' "$ARTIFACT")
   else
-    # Fall back to phase summary if no checkpoint
+    # No checkpoint: fall back to phase summary
     SUMMARY=$(jq -r '.summary | to_entries | map("\(.key): \(.value)") | join(", ")' "$ARTIFACT" 2>/dev/null || echo "No summary")
     KEY_FILES=""
     DECISIONS=""

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -21,11 +21,13 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 cmd_init() {
   local type="${1:-development}"
   local issue_url=""
+  local autopilot="false"
 
   shift || true
   while [ $# -gt 0 ]; do
     case "$1" in
       --issue) issue_url="$2"; shift 2 ;;
+      --autopilot) autopilot="true"; shift ;;
       *) shift ;;
     esac
   done
@@ -50,6 +52,7 @@ cmd_init() {
     --arg repo "$repo" \
     --arg workspace "$PROJECT" \
     --arg date "$NOW" \
+    --argjson autopilot "$autopilot" \
     '{
       session_id: $id,
       type: $type,
@@ -57,6 +60,9 @@ cmd_init() {
       repo: (if $repo != "" then $repo else null end),
       workspace: $workspace,
       current_phase: null,
+      next_phase: null,
+      autopilot: $autopilot,
+      stop_conditions_met: [],
       phase_log: [],
       budget: {
         max_usd: null,
@@ -110,12 +116,52 @@ cmd_phase_complete() {
     exit 1
   fi
 
+  # Calculate next phase from default sequence
+  local next=""
+  case "$phase" in
+    think) next="plan" ;;
+    plan)  next="build" ;;
+    build) next="review" ;;
+    review)
+      # Check if qa and security are done
+      local qa_done sec_done
+      qa_done=$(jq -r '[.phase_log[] | select(.phase == "qa" and .status == "completed")] | length' "$SESSION_FILE")
+      sec_done=$(jq -r '[.phase_log[] | select(.phase == "security" and .status == "completed")] | length' "$SESSION_FILE")
+      if [ "$qa_done" -gt 0 ] && [ "$sec_done" -gt 0 ]; then next="ship"
+      elif [ "$qa_done" -gt 0 ]; then next="security"
+      else next="qa"
+      fi
+      ;;
+    qa)
+      local rev_done sec_done
+      rev_done=$(jq -r '[.phase_log[] | select(.phase == "review" and .status == "completed")] | length' "$SESSION_FILE")
+      sec_done=$(jq -r '[.phase_log[] | select(.phase == "security" and .status == "completed")] | length' "$SESSION_FILE")
+      if [ "$rev_done" -gt 0 ] && [ "$sec_done" -gt 0 ]; then next="ship"
+      elif [ "$rev_done" -gt 0 ]; then next="security"
+      else next="review"
+      fi
+      ;;
+    security)
+      local rev_done qa_done
+      rev_done=$(jq -r '[.phase_log[] | select(.phase == "review" and .status == "completed")] | length' "$SESSION_FILE")
+      qa_done=$(jq -r '[.phase_log[] | select(.phase == "qa" and .status == "completed")] | length' "$SESSION_FILE")
+      if [ "$rev_done" -gt 0 ] && [ "$qa_done" -gt 0 ]; then next="ship"
+      elif [ "$rev_done" -gt 0 ]; then next="qa"
+      else next="review"
+      fi
+      ;;
+    ship) next="compound" ;;
+    compound) next="" ;;
+  esac
+
   jq \
     --arg phase "$phase" \
     --arg date "$NOW" \
     --arg artifact "$artifact" \
+    --arg next "$next" \
     '(.phase_log[] | select(.phase == $phase and .status == "in_progress")) |=
        (.status = "completed" | .completed_at = $date | .artifact = (if $artifact != "" then $artifact else null end)) |
+     .next_phase = (if $next != "" then $next else null end) |
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
@@ -137,10 +183,12 @@ cmd_resume() {
     exit 0
   fi
 
-  local session_id current_phase type
+  local session_id current_phase type autopilot next_phase
   session_id=$(jq -r '.session_id' "$SESSION_FILE")
   current_phase=$(jq -r '.current_phase // "none"' "$SESSION_FILE")
   type=$(jq -r '.type' "$SESSION_FILE")
+  autopilot=$(jq -r '.autopilot // false' "$SESSION_FILE")
+  next_phase=$(jq -r '.next_phase // "none"' "$SESSION_FILE")
 
   local completed_phases
   completed_phases=$(jq -r '[.phase_log[] | select(.status == "completed") | .phase] | join(", ")' "$SESSION_FILE")
@@ -159,11 +207,15 @@ cmd_resume() {
     --arg last_phase "$last_phase" \
     --arg last_status "$last_status" \
     --arg completed "$completed_phases" \
+    --argjson autopilot "$autopilot" \
+    --arg next_phase "$next_phase" \
     '{
       resumable: true,
       session_id: $session_id,
       type: $type,
+      autopilot: $autopilot,
       current_phase: $current_phase,
+      next_phase: $next_phase,
       last_phase: $last_phase,
       last_status: $last_status,
       completed_phases: $completed,

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -82,6 +82,50 @@ if [ -n "$PROJECT_ROOT" ]; then
   esac
 fi
 
+# ─── Tier 2.5: Phase-aware concurrency enforcement ─────────
+# If a session is active and the current phase is read-only,
+# block write operations to prevent race conditions in parallel execution.
+GUARD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+NANOSTACK_ROOT="$(cd "$GUARD_DIR/.." && pwd)"
+STORE_PATH_SH="$NANOSTACK_ROOT/bin/lib/store-path.sh"
+
+if [ -f "$STORE_PATH_SH" ]; then
+  source "$STORE_PATH_SH"
+  SESSION_CHECK="$NANOSTACK_STORE/session.json"
+
+  if [ -f "$SESSION_CHECK" ]; then
+    CURRENT_PHASE=$(jq -r '.current_phase // ""' "$SESSION_CHECK" 2>/dev/null)
+
+    if [ -n "$CURRENT_PHASE" ]; then
+      # Get concurrency from skill frontmatter
+      SKILL_CONC=""
+      case "$CURRENT_PHASE" in
+        plan) SKILL_MD="$NANOSTACK_ROOT/plan/SKILL.md" ;;
+        build) SKILL_MD="" ;;
+        *) SKILL_MD="$NANOSTACK_ROOT/$CURRENT_PHASE/SKILL.md" ;;
+      esac
+
+      if [ -n "${SKILL_MD:-}" ] && [ -f "$SKILL_MD" ]; then
+        SKILL_CONC=$(sed -n '/^---$/,/^---$/p' "$SKILL_MD" | grep '^concurrency:' | head -1 | sed 's/^concurrency: *//')
+      fi
+
+      # Block writes during read-only phases
+      if [ "$SKILL_CONC" = "read" ]; then
+        case "$CMD" in
+          *rm\ *|*mv\ *|*cp\ *|*mkdir\ *|*touch\ *|*chmod\ *|*git\ add*|*git\ commit*|*git\ push*|*git\ reset*)
+            echo "BLOCKED [PHASE] Write operation during read-only phase '$CURRENT_PHASE'"
+            echo "Category: concurrency-safety"
+            echo "Command: $CMD"
+            echo ""
+            echo "Phase '$CURRENT_PHASE' has concurrency=read. Write operations are blocked to prevent race conditions in parallel execution. Report as a finding instead of auto-fixing."
+            exit 1
+            ;;
+        esac
+      fi
+    fi
+  fi
+fi
+
 # ─── Tier 3: Pattern matching ───────────────────────────────
 
 # Check block rules first


### PR DESCRIPTION
## Summary

5 core optimizations for sprint resilience and cost control:

- **Context budget**: `restore-context.sh --budget <tokens>` auto-decides whether to load full artifacts or checkpoint summaries based on total upstream token estimate
- **Autopilot persistence**: session.json now tracks `autopilot`, `next_phase`, and `stop_conditions_met`. Survives crashes. `phase-complete` calculates the next phase from the dependency graph.
- **Staleness check**: `find-solution.sh` penalizes solutions that reference files no longer on disk. All files gone = -3 score. Some files gone = -1. Solutions are never deleted, just ranked lower.
- **Budget enforcement**: new `bin/budget.sh` with set/check/status commands. Pricing table for opus-4, sonnet-4, haiku-4.5, gpt-4o, o3. Warns at 80%, stops at 95%. Updates session.json budget fields.
- **Circuit breaker**: new `bin/circuit.sh` with fail/success/status/reset. Tracks consecutive failures by tag. 3 failures = open circuit. New tag (pivot) resets counter. Success resets counter.
- **Guard phase-aware**: check-dangerous.sh reads current phase concurrency from SKILL.md. Blocks write operations (rm, mv, git commit, git push) during read-only phases to prevent race conditions in parallel execution.

## Test plan

- [x] `session.sh init --autopilot` persists autopilot=true in session.json
- [x] `session.sh phase-complete think` sets next_phase=plan
- [x] `session.sh phase-complete plan` sets next_phase=build
- [x] `session.sh resume` includes autopilot and next_phase fields
- [x] `budget.sh set --max-usd 15 --model opus-4` persists budget config
- [x] `budget.sh check` with 30% spent returns action=continue
- [x] `budget.sh check` with 130% spent returns action=stop
- [x] `circuit.sh fail` increments consecutive counter
- [x] `circuit.sh fail` x3 opens circuit with message
- [x] `circuit.sh fail` with new tag resets counter (pivot)
- [x] `circuit.sh success` resets counter
- [x] Guard blocks `git commit` during review phase (concurrency=read)
- [x] Guard allows `git status` during review phase
- [x] `restore-context.sh --budget 200` triggers checkpoint-only mode
- [x] `find-solution.sh` staleness check penalizes missing files
- [x] All existing scripts unaffected (backward compatible)