### PR TITLE
Add nanostack bin/ permission to init-project.sh

### DIFF
--- a/bin/init-project.sh
+++ b/bin/init-project.sh
@@ -48,6 +48,7 @@ if [ -f "$SETTINGS" ]; then
       "Bash(sort:*)",
       "Bash(sed:*)",
       "Bash(awk:*)",
+      "Bash(~/.claude/skills/nanostack/bin/*:*)",
       "Read(*)",
       "Write(*)",
       "Edit(*)"
@@ -86,6 +87,7 @@ else
       "Bash(sort:*)",
       "Bash(sed:*)",
       "Bash(awk:*)",
+      "Bash(~/.claude/skills/nanostack/bin/*:*)",
       "Read(*)",
       "Write(*)",
       "Edit(*)"


### PR DESCRIPTION
## Summary

`init-project.sh` creates `.claude/settings.json` with permissions for common commands but was missing `Bash(~/.claude/skills/nanostack/bin/*:*)`. Without this, nanostack scripts (save-artifact.sh, find-artifact.sh, etc.) are silently denied in don't-ask mode and the agent skips artifact saving entirely.

Found during live sprint testing: artifacts were never created because the agent couldn't execute the scripts.

Added to both the merge path (existing settings) and the create path (new settings).

## Test plan

- [x] Both code paths in init-project.sh include the nanostack permission
- [x] Permission uses wildcard pattern matching all bin/ scripts