### PR TITLE
Add /nano-run for conversational onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ git clone https://github.com/garagon/nanostack.git ~/.claude/skills/nanostack
 cd ~/.claude/skills/nanostack && ./setup
 ```
 
-That's it. Now try this:
+Open Claude Code in your project and run `/nano-run`. It configures your stack, permissions, and preferences through a conversation and guides your first sprint.
+
+Or jump straight in:
 
 ```
 You:    I need to add notifications to my app. Users keep missing
@@ -106,6 +108,7 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 | `/compound` | **Knowledge** | Documents solved problems after each sprint. Three types: bug (what broke + fix), pattern (reusable approach), decision (architecture choice). `/nano` and `/review` search past solutions automatically in future sprints. |
 | `/guard` | **Safety** | Four-tier safety: allowlist, in-project bypass, phase-aware concurrency enforcement (blocks writes during read-only phases), and pattern matching with 28 block rules. Blocked commands get a safer alternative. `/freeze` locks edits to one directory. Rules in `guard/rules.json`. |
 | `/conductor` | **Orchestrator** | Parallel agent sessions with auto-batching. `sprint.sh batch` reads skill concurrency metadata and groups parallel-safe phases. Session resume on crash. Dependency validation before each phase. No daemon, just atomic file ops. |
+| `/nano-run` | **Onboarding** | First-time setup. Configures stack, permissions, and work preferences through a conversation. Auto-detects your project and guides your first sprint. |
 
 ### Intensity modes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 | `/feature` | Add a feature to an existing project. Skips /think, goes straight to plan → build → review → security → qa → ship. | — | `feature/SKILL.md` |
 | `/conductor` | Orchestrate parallel agent sessions through a sprint. Coordinate task claiming and artifact handoff. | `start` `claim` `complete` `status` | `conductor/bin/sprint.sh` |
 | `/nano-run` | First-time setup. Configures stack, permissions, and preferences conversationally. Guides first sprint. | — | `start/SKILL.md` |
+| `/nano-help` | Quick reference for all nanostack commands and how to use them. | — | `help/SKILL.md` |
 
 ## Workflow Order
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 | `/guard` | When working near production, destructive operations, or sensitive systems. | — | `guard/bin/check-dangerous.sh` |
 | `/feature` | Add a feature to an existing project. Skips /think, goes straight to plan → build → review → security → qa → ship. | — | `feature/SKILL.md` |
 | `/conductor` | Orchestrate parallel agent sessions through a sprint. Coordinate task claiming and artifact handoff. | `start` `claim` `complete` `status` | `conductor/bin/sprint.sh` |
+| `/nano-run` | First-time setup. Configures stack, permissions, and preferences conversationally. Guides first sprint. | — | `start/SKILL.md` |
 
 ## Workflow Order
 

--- a/help/SKILL.md
+++ b/help/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: nano-help
+description: Quick reference for all nanostack commands. Shows available skills, what each one does, and how to use them. Triggers on /nano-help.
+concurrency: read
+depends_on: []
+summary: "Help and quick reference for nanostack skills."
+estimated_tokens: 100
+---
+
+# /nano-help — Quick Reference
+
+Show the user a concise overview of nanostack. No walls of text. Organized by what they want to do.
+
+## Response
+
+Print this directly:
+
+```
+Nanostack Skills
+================
+
+Getting started:
+  /nano-run          First-time setup. Configures your project conversationally.
+
+The sprint (run in order):
+  /think             Challenge the idea before building. Scope decisions.
+  /nano              Plan the implementation. Files, steps, risks.
+  build              You or the agent writes the code.
+  /review            Two-pass code review. Scope drift detection.
+  /security          OWASP Top 10 + STRIDE audit. Graded A-F.
+  /qa                Test it. Browser, API, CLI, or debug.
+  /ship              Create PR, verify CI, generate sprint journal.
+
+Shortcuts:
+  /think --autopilot Run the full sprint automatically after approval.
+  /feature <desc>    Add a feature with plan → build → review → security → qa → ship.
+
+After shipping:
+  /compound          Document what you learned. Future sprints find it automatically.
+
+Safety:
+  /guard             Block dangerous commands. /freeze locks edits to one directory.
+
+Team:
+  /conductor         Parallel sprints across multiple agents/terminals.
+
+Modes (for /review, /security, /qa):
+  --quick            Only the obvious. For small changes.
+  --standard         Default. For normal work.
+  --thorough         Flag everything. For auth, payments, infra.
+
+Update:
+  /nano-update       Pull latest version of nanostack.
+```
+
+If the user asks about a specific skill, invoke it: use Skill tool with the skill name. Don't explain the skill yourself — let the skill's own SKILL.md handle it.

--- a/help/SKILL.md
+++ b/help/SKILL.md
@@ -16,41 +16,44 @@ Show the user a concise overview of nanostack. No walls of text. Organized by wh
 Print this directly:
 
 ```
-Nanostack Skills
-================
+nanostack
+Make your AI agent think first.
 
 Getting started:
-  /nano-run          First-time setup. Configures your project conversationally.
+  /nano-run              First-time setup. Configures your project conversationally.
+  /nano-help             You are here.
 
-The sprint (run in order):
-  /think             Challenge the idea before building. Scope decisions.
-  /nano              Plan the implementation. Files, steps, risks.
-  build              You or the agent writes the code.
-  /review            Two-pass code review. Scope drift detection.
-  /security          OWASP Top 10 + STRIDE audit. Graded A-F.
-  /qa                Test it. Browser, API, CLI, or debug.
-  /ship              Create PR, verify CI, generate sprint journal.
+The sprint:
+  /think                 Challenge the scope before building.
+  /nano                  Plan the implementation. Files, steps, risks.
+  build                  You or the agent writes the code.
+  /review                Two-pass code review. Scope drift detection.
+  /security              OWASP Top 10 + STRIDE audit. Graded A-F.
+  /qa                    Test it. Browser, API, CLI, or debug.
+  /ship                  Create PR, verify CI, generate sprint journal.
 
 Shortcuts:
-  /think --autopilot Run the full sprint automatically after approval.
-  /feature <desc>    Add a feature with plan → build → review → security → qa → ship.
+  /think --autopilot     Full sprint. Think, plan, build, review, audit, test, ship.
+  /feature <description> Add a feature to an existing project with full sprint.
 
 After shipping:
-  /compound          Document what you learned. Future sprints find it automatically.
+  /compound              Save what you learned. Future sprints find it automatically.
 
 Safety:
-  /guard             Block dangerous commands. /freeze locks edits to one directory.
+  /guard                 Block dangerous commands. /freeze locks edits to a scope.
 
 Team:
-  /conductor         Parallel sprints across multiple agents/terminals.
+  /conductor             Parallel sprints across multiple agents or terminals.
 
 Modes (for /review, /security, /qa):
-  --quick            Only the obvious. For small changes.
-  --standard         Default. For normal work.
-  --thorough         Flag everything. For auth, payments, infra.
+  --quick                Small changes. Only the obvious.
+  --standard             Default. Normal work.
+  --thorough             Auth, payments, infra. Flag everything.
 
 Update:
-  /nano-update       Pull latest version of nanostack.
+  /nano-update           Pull latest version.
+
+github.com/garagon/nanostack
 ```
 
 If the user asks about a specific skill, invoke it: use Skill tool with the skill name. Don't explain the skill yourself — let the skill's own SKILL.md handle it.

--- a/setup
+++ b/setup
@@ -18,12 +18,13 @@ set -e
 NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
-SKILLS=(think nano review qa security ship guard conductor compound feature)
+SKILLS=(think nano review qa security ship guard conductor compound feature nano-run)
 
 # Map skill name to directory (when they differ)
 skill_dir() {
   case "$1" in
     nano) echo "plan" ;;
+    nano-run) echo "start" ;;
     *) echo "$1" ;;
   esac
 }
@@ -469,6 +470,7 @@ w_ship=$(skill_public_name "ship")
 w_guard=$(skill_public_name "guard")
 echo "Workflow: /$w_think → /$w_nano → build → /$w_review → /$w_qa → /$w_security → /$w_ship"
 echo "Safety:   /$w_guard (activate on-demand)"
+echo "Start:    /nano-run (first-time setup)"
 echo ""
 echo "Per-project setup (run once in each project):"
 echo "  ~/.claude/skills/nanostack/bin/init-project.sh"

--- a/setup
+++ b/setup
@@ -18,13 +18,14 @@ set -e
 NANOSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$NANOSTACK_DIR")"
-SKILLS=(think nano review qa security ship guard conductor compound feature nano-run)
+SKILLS=(think nano review qa security ship guard conductor compound feature nano-run nano-help)
 
 # Map skill name to directory (when they differ)
 skill_dir() {
   case "$1" in
     nano) echo "plan" ;;
     nano-run) echo "start" ;;
+    nano-help) echo "help" ;;
     *) echo "$1" ;;
   esac
 }

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: nano-run
+description: First-time setup and guided sprint. Configures stack, permissions, and work preferences conversationally. Run once after installing nanostack. Triggers on /nano-run.
+concurrency: exclusive
+depends_on: []
+summary: "Onboarding. Detects stack, configures project, guides first sprint."
+estimated_tokens: 300
+---
+
+# /nano-run — Get Started
+
+You are a friendly onboarding guide. Your job is to configure nanostack for this user and help them run their first sprint. No jargon, no docs, just conversation.
+
+## Step 1: Detect state
+
+Check if this project already has nanostack configured:
+
+```bash
+~/.claude/skills/nanostack/bin/init-config.sh
+```
+
+**If config exists:** This project is already set up. Ask: "What do you want to do?" and offer:
+1. Start a new project → use Skill tool: skill="think"
+2. Add a feature → use Skill tool: skill="feature"
+3. Reconfigure stack → continue to Step 2
+
+**If no config:** Continue to Step 2.
+
+## Step 2: Configure
+
+Ask the user one question at a time in plain language:
+
+**Question 1:** "What type of projects do you build?"
+1. Web apps
+2. APIs and backend services
+3. CLI tools and scripts
+4. Mobile
+5. Not sure yet
+
+**Question 2:** Check if there's a project open. Read package.json, go.mod, requirements.txt, or equivalent. If detected, show what you found and ask if it's correct. If nothing detected, set defaults based on Question 1.
+
+Run the configuration:
+
+```bash
+~/.claude/skills/nanostack/bin/init-stack.sh
+~/.claude/skills/nanostack/bin/init-project.sh
+```
+
+**Question 3:** "How do you prefer to work?"
+1. Automatic — I describe what I want and the agent does everything
+2. Step by step — I review each phase before continuing
+3. Let's try something simple first
+
+Save the preference in .nanostack/config.json under `preferences.workflow_mode` ("autopilot" or "manual").
+
+## Step 3: First sprint
+
+After configuration, guide the user into their first sprint.
+
+If they chose "automatic" or "try something simple":
+
+> You're all set. Tell me what you want to build or change in your project and I'll take it from there.
+
+When they describe something, invoke the appropriate skill:
+- New project or big scope → use Skill tool: skill="think", args="--autopilot"
+- Feature on existing project → use Skill tool: skill="feature"
+
+If they chose "step by step":
+
+> You're all set. When you're ready, describe what you want to build. I'll walk you through each step:
+>
+> 1. We think about the scope (/think)
+> 2. We plan the implementation (/nano)
+> 3. We build it
+> 4. We review, audit, and test (/review, /security, /qa)
+> 5. We ship it (/ship)
+>
+> You control the pace. Tell me when you're ready.
+
+When they describe something, invoke: use Skill tool: skill="think"
+
+## Rules
+
+- One question at a time. Never dump all questions at once.
+- Plain language. No "SKILL.md", no "artifact", no "frontmatter".
+- If the user seems confused, simplify further.
+- If the user already knows what they want ("just add dark mode"), skip to the sprint.
+- Auto-detect everything you can. Only ask what you can't detect.

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -76,6 +76,8 @@ If they chose "step by step":
 > 5. We ship it (/ship)
 >
 > You control the pace. Tell me when you're ready.
+>
+> Tip: for adding features to an existing project, try `/feature` — it skips the scope discussion and goes straight to planning.
 
 When they describe something, invoke: use Skill tool: skill="think"
 


### PR DESCRIPTION
## Summary

New `/nano-run` skill for first-time setup. Configures stack, permissions, and work preferences through a conversation instead of manual script execution and README reading.

The flow:
1. Detects if project is already configured
2. Asks what type of projects the user builds (one question at a time)
3. Auto-detects stack from package.json/go.mod/requirements.txt
4. Runs init-project.sh and init-stack.sh internally
5. Asks work preference (autopilot vs step-by-step)
6. Guides the first sprint via Skill tool invocations

No breaking changes. All existing skills unchanged. Names stay as-is.

## Files

- `start/SKILL.md` — new skill (88 lines)
- `setup` — added nano-run to SKILLS array and skill_dir mapping
- `SKILL.md` — added /nano-run to skill table

## Test plan

- [x] 44 existing tests pass
- [x] Setup creates `~/.claude/skills/nano-run` → `nanostack/start` symlink
- [x] All other symlinks unchanged
- [x] No namespace changes, no breaking changes