### PR TITLE
Harden guard Tier 2 path resolution with realpath

### DIFF
--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -67,7 +67,7 @@ if [ -n "$PROJECT_ROOT" ]; then
         esac
         # If it looks like a path and exists or starts with project root
         if [ -e "$token" ] || [[ "$token" == /* ]]; then
-          REAL_PATH=$(cd "$(dirname "$token" 2>/dev/null)" 2>/dev/null && pwd)/$(basename "$token") 2>/dev/null || REAL_PATH="$token"
+          REAL_PATH=$(realpath "$token" 2>/dev/null) || REAL_PATH="$token"
           case "$REAL_PATH" in
             "$PROJECT_ROOT"*) ;; # in project
             *) ALL_IN_PROJECT=false ;;


### PR DESCRIPTION
## Summary
- Replace fragile `dirname/basename` subshell with `realpath` in guard Tier 2 in-project detection
- Fixes edge case where `dirname` failing silently could resolve to cwd, potentially letting out-of-project paths pass as in-project
- Conservative fallback (`|| REAL_PATH="$token"`) preserved

## Context
Found during security audit. Low impact (Tier 2 already excludes pipes/chains, and auto-pass requires `/` or `./` in command), but worth hardening.

## Test plan
- [ ] Verify guard still allows in-project file operations
- [ ] Verify guard blocks out-of-project file operations
- [ ] Confirm `realpath` availability on macOS and Linux targets