### PR TITLE
Add universal phase gate enforcement for sprint pipelines

### DIFF
--- a/Nanostack/specs/git-dependency-wording.md
+++ b/Nanostack/specs/git-dependency-wording.md
@@ -1,0 +1,109 @@
+# Spec: Git dependency wording
+
+**Date:** 2026-04-07
+**Status:** Para implementar
+**Affects:** README.md, site /learn/getting-started/install, /framework/architecture, /learn/safety/guard
+
+---
+
+## Problema
+
+Git está listado como un requirement mas en una lista de bullets. No se explica que es la infraestructura base de nanostack. Un usuario podria pensar que git es opcional o que solo se usa para clonar el repo.
+
+En realidad, 9 scripts dependen de git para funcionar. Sin git:
+- No hay store path (artifacts se guardan relativo al git root)
+- No hay phase gate (usa `git log` para timestamps)
+- No hay scope drift (usa `git diff` para comparar plan vs realidad)
+- No hay in-project safety (usa `git rev-parse` para detectar limites del repo)
+- No hay contexto en artifacts (branch, changed files, recent commits)
+
+## Principio de wording
+
+Git no es un "requirement." Git es el runtime de nanostack. Explicar esto en una oracion, no en un parrafo. Ponerlo antes de los bullets de requirements, no dentro de ellos.
+
+---
+
+## Wording por superficie
+
+### README.md — Requirements section
+
+Antes:
+```
+### Requirements
+- macOS, Linux or Windows (Git Bash or WSL)
+- jq for artifact processing
+- Git
+- One of: Claude Code, Cursor, ...
+```
+
+Despues:
+```
+### Requirements
+
+Nanostack runs on git. Artifacts are stored relative to the git root. The phase gate uses git history to verify sprint compliance. Scope drift compares planned files against `git diff`. Guard uses the repo boundary for in-project safety. Every project that uses nanostack must be a git repository.
+
+- macOS, Linux or Windows (Git Bash or WSL)
+- [Git](https://git-scm.com/)
+- [jq](https://jqlang.github.io/jq/) for artifact processing (`brew install jq`, `apt install jq`, or `choco install jq`)
+- One of: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, Cline
+```
+
+Git moves to first position in the list. It has a link. The paragraph above explains WHY, not just WHAT.
+
+### Site: /learn/getting-started/install
+
+Agregar un callout antes de los pasos de instalacion:
+
+```
+> nanostack requires git. Not just for installation — git is the runtime.
+> Artifacts live at the git root. The phase gate reads git history.
+> Scope drift compares against git diff. Your project must be a git repo.
+```
+
+Requirements list: misma estructura que el README. Git primero, con link.
+
+### Site: /framework/architecture
+
+En la seccion "3. Scripts are the glue", la linea sobre store-path.sh ya dice:
+
+```
+1. NANOSTACK_STORE env var (explicit override)
+2. Git root .nanostack/ (project-local, default)
+3. ~/.nanostack/ (fallback if not in a git repo)
+```
+
+Agregar antes de esta lista:
+
+```
+Git is the default anchor. All scripts resolve paths relative to `git rev-parse --show-toplevel`.
+The phase gate reads `git log` for timestamp comparison. Scope drift reads `git diff`.
+Artifact context includes branch, changed files and recent commits from git state.
+The fallback (~/.nanostack/) exists but is not recommended — without git, phase gate,
+scope drift and in-project safety are disabled.
+```
+
+### Site: /learn/safety/guard
+
+En la descripcion de Tier 2 (In-project), agregar:
+
+```
+"In-project" means inside the git repository root. Guard uses `git rev-parse --show-toplevel`
+to detect the boundary. Files outside the repo go to Tier 3 pattern matching.
+Without git, Tier 2 is skipped entirely.
+```
+
+---
+
+## Donde NO agregar wording
+
+- Landing page hero: no. El hero es sobre el valor, no sobre requerimientos.
+- /examples: no. Los ejemplos asumen que ya esta instalado.
+- SKILL.md files: no. Los skills no necesitan explicar la infraestructura.
+- Social media: no, salvo que se haga un post especifico sobre la arquitectura.
+
+---
+
+## Verificacion
+
+Despues de implementar, grep por "requirement" y "install" en todas las superficies.
+Cada mencion de requerimientos debe tener git explicito con la explicacion de que es el runtime, no un dependency mas.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Nanostack is a process, not a collection of tools. The skills run in the order a
 /think → /nano → build → /review → /qa → /security → /ship
 ```
 
-Each skill feeds into the next. `/nano` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. Nothing falls through the cracks because every step knows what came before it.
+Each skill feeds into the next. `/nano` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. The phase gate enforces the pipeline: `git commit` is blocked until review, security and qa are done. Nothing falls through the cracks because every step knows what came before it, and skipping steps is not an option.
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
@@ -107,7 +107,7 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 | Skill | What it does |
 |-------|-------------|
 | `/compound` | **Knowledge** | Documents solved problems after each sprint. Three types: bug (what broke + fix), pattern (reusable approach), decision (architecture choice). `/nano` and `/review` search past solutions automatically in future sprints. |
-| `/guard` | **Safety** | Four-tier safety: allowlist, in-project bypass, phase-aware concurrency enforcement (blocks writes during read-only phases), and pattern matching with 33 block rules. Blocked commands get a safer alternative. `/freeze` locks edits to one directory. Rules in `guard/rules.json`. |
+| `/guard` | **Safety** | Five-tier safety: allowlist, in-project bypass, phase-aware concurrency (blocks writes during read-only phases), phase gate (blocks commit/push until review+security+qa pass), and pattern matching with 33 block rules. Blocked commands get a safer alternative. `/freeze` locks edits to one directory. Rules in `guard/rules.json`. |
 | `/conductor` | **Orchestrator** | Parallel agent sessions with auto-batching. `sprint.sh batch` reads skill concurrency metadata and groups parallel-safe phases. Session resume on crash. Dependency validation before each phase. No daemon, just atomic file ops. |
 | `/feature` | **Builder** | Add functionality to an existing project. Skips /think, goes straight to plan, build, review, audit, test, ship. |
 | `/nano-run` | **Onboarding** | First-time setup. Configures stack, permissions, and work preferences through a conversation. Auto-detects your project and guides your first sprint. |
@@ -194,6 +194,8 @@ Discuss the idea, approve the brief, walk away. The agent runs the full sprint:
 /nano → build → /review → /security → /qa → /ship
 ```
 
+The phase gate enforces the pipeline. Even if the agent judges a task as "simple" and tries to skip review or security, `git commit` is blocked until all phases have fresh artifacts. No instructions to follow — the hook stops the commit.
+
 Autopilot only stops if:
 - `/review` finds blocking issues that need your decision
 - `/security` finds critical or high vulnerabilities
@@ -238,15 +240,17 @@ If the agent crashes mid-sprint, `session.sh resume` detects the last session st
 
 AI agents make mistakes. They run `rm -rf` when they mean `rm -r`, force push to main when they mean to push to a branch, pipe untrusted URLs to shell. `/guard` catches these before they execute.
 
-### Four tiers
+### Five tiers
 
-Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through four tiers:
+Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through five tiers:
 
 **Tier 1: Allowlist.** Commands like `git status`, `ls`, `cat`, `jq` skip all checks. They can't cause damage.
 
 **Tier 2: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
 
 **Tier 2.5: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
+
+**Tier 2.75: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security and qa artifacts exist and are fresher than the latest code change. This is the enforcement that prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
 
 **Tier 3: Pattern matching.** Everything else is checked against block and warn rules. 33 block rules cover mass deletion, history destruction, database drops, production deploys, remote code execution, security degradation and safety bypasses. 9 warn rules cover operations that need attention but not blocking.
 

--- a/README.md
+++ b/README.md
@@ -347,9 +347,11 @@ Requires [Git for Windows](https://git-scm.com/downloads/win) which includes Git
 
 ### Requirements
 
-- macOS, Linux or Windows (Git Bash or WSL)
+Nanostack runs on git. Artifacts are stored relative to the git root. The phase gate uses git history to verify sprint compliance. Scope drift compares planned files against `git diff`. Guard uses the repo boundary for in-project safety. Every project that uses nanostack must be a git repository.
+
+- [Git](https://git-scm.com/)
 - [jq](https://jqlang.github.io/jq/) for artifact processing (`brew install jq`, `apt install jq`, or `choco install jq`)
-- Git
+- macOS, Linux or Windows (Git Bash or WSL)
 - One of: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, Cline
 
 ## The Zen of Nanostack

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -144,6 +144,8 @@ echo "$FILENAME"
 if [ -n "${AUTOCOMPLETE_PHASE:-}" ]; then
   SESSION_SH="$SCRIPT_DIR/session.sh"
   if [ -x "$SESSION_SH" ] && [ -f "$NANOSTACK_STORE/session.json" ]; then
-    "$SESSION_SH" phase-complete "$AUTOCOMPLETE_PHASE" 2>/dev/null || true
+    # Start phase if not already in progress, then complete it
+    "$SESSION_SH" phase-start "$AUTOCOMPLETE_PHASE" >/dev/null 2>&1 || true
+    "$SESSION_SH" phase-complete "$AUTOCOMPLETE_PHASE" >/dev/null 2>&1 || true
   fi
 fi

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -1,12 +1,57 @@
 #!/usr/bin/env bash
 # save-artifact.sh — Save a skill artifact to .nanostack/<phase>/
-# Usage: save-artifact.sh <phase> <json-string>
-# Example: save-artifact.sh review '{"phase":"review","summary":{"blocking":0}}'
+# Usage:
+#   save-artifact.sh <phase> <json-string>              (full mode)
+#   save-artifact.sh --from-session <phase> <summary>   (simplified mode)
+#
+# Full mode: pass complete JSON with phase, summary, context_checkpoint.
+# Session mode: reads phase from session, builds JSON from git state + summary string.
+#   Auto-calls session.sh phase-complete after saving.
+#
 # Validates JSON has required fields before saving. Fails on invalid input.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+
+# ─── Session mode: build JSON from git state + summary ──────
+if [ "${1:-}" = "--from-session" ]; then
+  PHASE="${2:?Usage: save-artifact.sh --from-session <phase> <summary>}"
+  SUMMARY_TEXT="${3:?Missing summary argument}"
+
+  PROJECT="$(pwd)"
+  BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+  # Build context checkpoint from git state
+  CHANGED_FILES=$(git diff --name-only HEAD 2>/dev/null | head -20 | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  STAGED_FILES=$(git diff --cached --name-only 2>/dev/null | head -20 | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  RECENT_COMMITS=$(git log --oneline -5 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo "[]")
+
+  JSON=$(jq -n \
+    --arg phase "$PHASE" \
+    --arg summary "$SUMMARY_TEXT" \
+    --arg project "$PROJECT" \
+    --arg branch "$BRANCH" \
+    --argjson changed "$CHANGED_FILES" \
+    --argjson staged "$STAGED_FILES" \
+    --argjson commits "$RECENT_COMMITS" \
+    '{
+      phase: $phase,
+      summary: $summary,
+      context_checkpoint: {
+        summary: $summary,
+        key_files: ($changed + $staged | unique),
+        recent_commits: $commits,
+        decisions_made: [],
+        open_questions: []
+      }
+    }')
+
+  # Run the standard save logic below, then auto-complete phase
+  AUTOCOMPLETE_PHASE="$PHASE"
+  shift 3 || true
+  set -- "$PHASE" "$JSON"
+fi
 
 PHASE="${1:?Usage: save-artifact.sh <phase> <json>}"
 JSON="${2:?Missing JSON argument}"
@@ -94,3 +139,11 @@ ENRICHED=$(echo "$ENRICHED" | jq --arg cs "$CHECKSUM" '. + {integrity: $cs}')
 
 echo "$ENRICHED" | jq '.' > "$FILENAME"
 echo "$FILENAME"
+
+# ─── Auto-complete phase in session if --from-session was used ──
+if [ -n "${AUTOCOMPLETE_PHASE:-}" ]; then
+  SESSION_SH="$SCRIPT_DIR/session.sh"
+  if [ -x "$SESSION_SH" ] && [ -f "$NANOSTACK_STORE/session.json" ]; then
+    "$SESSION_SH" phase-complete "$AUTOCOMPLETE_PHASE" 2>/dev/null || true
+  fi
+fi

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -19,6 +19,16 @@ Fast path for adding a feature to an existing project. Skips the /think diagnost
 /feature Add import from JSON/CSV to restore backups
 ```
 
+## Session
+
+Before anything else, initialize the sprint session:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh init feature
+```
+
+Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
+
 ## Process
 
 You are an orchestrator. You invoke each skill in sequence using the Skill tool. Do NOT implement the skill logic yourself — invoke the skill and let it run.

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -126,6 +126,18 @@ if [ -f "$STORE_PATH_SH" ]; then
   fi
 fi
 
+# ─── Tier 2.75: Sprint phase gate ──────────────────────────
+# If a sprint is active, block git commit/push until review, security, qa are done.
+PHASE_GATE="$(dirname "$0")/phase-gate.sh"
+if [ -x "$PHASE_GATE" ]; then
+  GATE_OUTPUT=$("$PHASE_GATE" "$CMD" 2>&1) || {
+    echo "$GATE_OUTPUT"
+    exit 1
+  }
+  # Print warnings (exit 0 with output = advisory)
+  [ -n "$GATE_OUTPUT" ] && echo "$GATE_OUTPUT"
+fi
+
 # ─── Tier 3: Pattern matching ───────────────────────────────
 
 # Check block rules first

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# phase-gate.sh — Universal sprint phase enforcement
+# Blocks git commit/push when a sprint is active and required phases are incomplete.
+# Called from check-dangerous.sh as Tier 2.75.
+#
+# Sprint detection (two methods, hard then soft):
+#   1. session.json exists for this project with phases started → BLOCK on missing
+#   2. Recent plan artifact exists but no session → WARN (advisory)
+#
+# Exit 0 = allow, Exit 1 = blocked
+set -euo pipefail
+
+CMD="${1:-}"
+
+# Only intercept git commit and git push
+case "$CMD" in
+  *git\ commit*|*git\ push*) ;;
+  *) exit 0 ;;
+esac
+
+# Explicit bypass
+if [ "${NANOSTACK_SKIP_GATE:-}" = "1" ]; then
+  exit 0
+fi
+
+# ─── Resolve paths ──────────────────────────────────────────
+GUARD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+NANOSTACK_ROOT="$(cd "$GUARD_DIR/.." && pwd)"
+STORE_PATH_SH="$NANOSTACK_ROOT/bin/lib/store-path.sh"
+
+[ -f "$STORE_PATH_SH" ] || exit 0
+source "$STORE_PATH_SH"
+
+FIND_ARTIFACT="$NANOSTACK_ROOT/bin/find-artifact.sh"
+SESSION_SH="$NANOSTACK_ROOT/bin/session.sh"
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+PROJECT="$(pwd)"
+REQUIRED_PHASES="review security qa"
+
+# ─── Reference timestamp: latest code change ────────────────
+last_code_timestamp() {
+  local ts
+  ts=$(git log -1 --format=%ct 2>/dev/null || echo 0)
+  if [ "$ts" -eq 0 ]; then
+    # No commits yet — use newest source file
+    ts=$(find . -maxdepth 3 \( -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.html' -o -name '*.css' -o -name '*.sh' \) 2>/dev/null \
+      | head -20 | xargs stat -f %m 2>/dev/null | sort -rn | head -1 || echo 0)
+  fi
+  echo "$ts"
+}
+
+# ─── Check if required phase artifacts are fresh ────────────
+# Returns space-separated list of missing phases
+check_phases() {
+  local last_change="$1"
+  local missing=""
+
+  for phase in $REQUIRED_PHASES; do
+    local artifact
+    artifact=$("$FIND_ARTIFACT" "$phase" 1 2>/dev/null) || {
+      missing="${missing:+$missing }$phase"
+      continue
+    }
+    # Verify artifact belongs to this project
+    if ! jq -e --arg p "$PROJECT" '.project == $p' "$artifact" >/dev/null 2>&1; then
+      missing="${missing:+$missing }$phase"
+      continue
+    fi
+    # Verify artifact is newer than last code change
+    local artifact_time
+    artifact_time=$(stat -f %m "$artifact" 2>/dev/null || stat -c %Y "$artifact" 2>/dev/null || echo 0)
+    if [ "$artifact_time" -lt "$last_change" ]; then
+      missing="${missing:+$missing }$phase"
+    fi
+  done
+
+  echo "$missing"
+}
+
+# ─── Print block message ───────────────────────────────────
+print_block() {
+  local missing="$1"
+  echo "BLOCKED [PHASE-GATE] Sprint phases incomplete: $(echo "$missing" | tr ' ' ', ')"
+  echo ""
+  echo "A sprint is active. Complete these phases before committing:"
+  for phase in $missing; do
+    case "$phase" in
+      review)   echo "  /review   — Code review" ;;
+      security) echo "  /security — Security audit" ;;
+      qa)       echo "  /qa       — Testing" ;;
+    esac
+  done
+  echo ""
+  echo "To bypass (non-sprint commit): NANOSTACK_SKIP_GATE=1 git commit ..."
+}
+
+print_warning() {
+  local missing="$1"
+  echo "WARNING [PHASE-GATE] Sprint detected but phases incomplete: $(echo "$missing" | tr ' ' ', ')"
+  echo ""
+  echo "A plan artifact exists for this project. Consider running:"
+  for phase in $missing; do
+    case "$phase" in
+      review)   echo "  /review   — Code review" ;;
+      security) echo "  /security — Security audit" ;;
+      qa)       echo "  /qa       — Testing" ;;
+    esac
+  done
+  echo ""
+  echo "Proceeding anyway (no active session). Use /feature or /think --autopilot for enforced sprints."
+}
+
+# ─── Method 1: Session-based detection (hard enforcement) ───
+if [ -f "$SESSION_FILE" ]; then
+  SESSION_PROJECT=$(jq -r '.workspace // ""' "$SESSION_FILE" 2>/dev/null)
+
+  if [ "$SESSION_PROJECT" = "$PROJECT" ]; then
+    # Skip if sprint is already shipped (completed)
+    SHIP_DONE=$(jq -r '[.phase_log[] | select(.phase == "ship" and .status == "completed")] | length' "$SESSION_FILE" 2>/dev/null || echo "0")
+    if [ "$SHIP_DONE" -gt 0 ]; then
+      exit 0
+    fi
+
+    # Skip if no phases have started (session just initialized)
+    PHASES_STARTED=$(jq -r '.phase_log | length' "$SESSION_FILE" 2>/dev/null || echo "0")
+    if [ "$PHASES_STARTED" -eq 0 ]; then
+      exit 0
+    fi
+
+    # Active sprint — enforce
+    LAST_CHANGE=$(last_code_timestamp)
+    MISSING=$(check_phases "$LAST_CHANGE")
+
+    if [ -n "$MISSING" ]; then
+      print_block "$MISSING"
+
+      # Audit
+      if [ -d "$(dirname "$NANOSTACK_STORE/audit.log")" ]; then
+        echo "{\"at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"event\":\"phase-gate-block\",\"missing\":\"$MISSING\",\"cmd\":$(echo "$CMD" | jq -Rs .)}" >> "$NANOSTACK_STORE/audit.log" 2>/dev/null || true
+      fi
+
+      exit 1
+    fi
+
+    # All phases complete
+    exit 0
+  fi
+fi
+
+# ─── Method 2: Artifact-based detection (soft enforcement) ──
+if [ -x "$FIND_ARTIFACT" ]; then
+  PLAN_ARTIFACT=$("$FIND_ARTIFACT" plan 1 2>/dev/null) || true
+
+  if [ -n "$PLAN_ARTIFACT" ]; then
+    PLAN_PROJECT=$(jq -r '.project // ""' "$PLAN_ARTIFACT" 2>/dev/null)
+
+    if [ "$PLAN_PROJECT" = "$PROJECT" ]; then
+      LAST_CHANGE=$(last_code_timestamp)
+      MISSING=$(check_phases "$LAST_CHANGE")
+
+      if [ -n "$MISSING" ]; then
+        # Soft enforcement: warn but allow
+        print_warning "$MISSING"
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# No sprint detected
+exit 0

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -11,6 +11,22 @@ estimated_tokens: 400
 
 You turn validated ideas into executable steps. Every file gets named. Every step gets a verification. Every unknown gets surfaced. The plan is a contract: if it says 4 files, the PR should touch 4 files.
 
+## Session
+
+If no active session exists, initialize one:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh status
+```
+
+If the output shows `"active":false`, create a session:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh init development
+```
+
+Then run `session.sh phase-start plan`.
+
 ## Process
 
 ### 1. Understand the Request
@@ -131,10 +147,13 @@ After the user approves, do these two steps in order:
 **Step 1: Save the artifact.** Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh plan '<json with phase, summary including planned_files array, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session plan 'N files planned: file1, file2, ... Key decisions: X, Y.'
 ```
 
-The `planned_files` list is critical — `/review` uses it for scope drift detection.
+Or pass full JSON for richer detail (recommended — `/review` uses `planned_files` for scope drift):
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh plan '<json with phase, summary including planned_files array, context_checkpoint>'
+```
 
 **Step 2: Build and proceed.**
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -194,7 +194,12 @@ Report progress as you go. After each test group (happy path, error states, edge
 After completing all tests, save the artifact. Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh qa '<json with phase, mode, summary including wtf_likelihood, findings, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session qa 'N tests passed, M failed. WTF likelihood: low/medium/high.'
+```
+
+Or pass full JSON for richer detail:
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh qa '<json with phase, mode, summary including wtf_likelihood, findings, context_checkpoint>'
 ```
 
 ## Mode Summary

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -131,7 +131,12 @@ When a conflict is detected, mark it inline:
 After completing both passes and conflict detection, save the artifact. Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh review '<json with phase, mode, summary, scope_drift, findings, conflicts, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session review 'N findings (X blocking). Scope drift: none/detected. Conflicts: none/N.'
+```
+
+Or pass full JSON for richer detail:
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh review '<json with phase, mode, summary, scope_drift, findings, conflicts, context_checkpoint>'
 ```
 
 ## Mode Summary

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -222,7 +222,12 @@ In `--thorough` mode, document conflicts AND flag as BLOCKING until user confirm
 After completing the audit and conflict detection, save the artifact. Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh security '<json with phase, mode, summary, findings, conflicts, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session security 'N findings (X critical). OWASP: covered A01-A10. Conflicts: none/N.'
+```
+
+Or pass full JSON for richer detail:
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh security '<json with phase, mode, summary, findings, conflicts, context_checkpoint>'
 ```
 
 ## Mode Summary

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -186,7 +186,13 @@ After shipping, do these steps in order:
 **Step 1: Save the artifact.** Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh ship '<json with phase, summary including pr_number, pr_url, title, status, ci_passed, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session ship 'PR #N: title. Status: merged/open. CI: passed/failed.'
+~/.claude/skills/nanostack/bin/sprint-journal.sh
+```
+
+Or pass full JSON for richer detail:
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh ship '<json with phase, summary including pr_number, pr_url, title, status, ci_passed, context_checkpoint>'
 ~/.claude/skills/nanostack/bin/sprint-journal.sh
 ```
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -35,6 +35,22 @@ This skill runs BEFORE `/nano`. Think answers WHAT and WHY. Plan answers HOW.
 - If the idea is genuinely strong, say so and explain WHY.
 - Never be sycophantic. But "not sycophantic" does not mean "aggressive." Direct and respectful is the target.
 
+## Session
+
+Before anything else, initialize the sprint session:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh init development
+```
+
+If the user said `--autopilot`, `autopilot`, `run everything`, or `ship it end to end`:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh init development --autopilot
+```
+
+Then run `session.sh phase-start think`.
+
 ## Process
 
 ### Phase 1: Context Gathering
@@ -157,7 +173,12 @@ After producing the Think Summary, do these two steps in order:
 **Step 1: Save the artifact.** Run this command now — do not skip it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh think '<json with phase, summary including value_proposition, scope_mode, target_user, narrowest_wedge, key_risk, premise_validated, context_checkpoint including summary, key_files, decisions_made, open_questions>'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: X. Scope: Y. Wedge: Z. Risk: W. Premise: validated/not.'
+```
+
+Or pass full JSON for richer detail:
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh think '<json with phase, summary including value_proposition, scope_mode, target_user, narrowest_wedge, key_risk, premise_validated, context_checkpoint>'
 ```
 
 **Step 2: Next phase.**


### PR DESCRIPTION
## Summary

Solves three known issues where the model skips pipeline phases on simple tasks:

- **Phase gate** (`guard/bin/phase-gate.sh`): Universal hook that blocks `git commit`/`git push` when a sprint is active and review/security/qa artifacts are missing or stale. Integrates as Tier 2.75 in check-dangerous.sh. Two detection modes — hard enforcement via session.json, soft warning via plan artifact presence. Bypass with `NANOSTACK_SKIP_GATE=1`.

- **Simplified artifact saving** (`save-artifact.sh --from-session`): Builds artifact JSON from git state + a summary string. Auto-calls `session.sh phase-complete`. Reduces model friction from "construct complex JSON" to "pass a one-line summary".

- **Auto-session init**: think, nano, and feature SKILL.md files now create a sprint session at start, activating the phase gate for the rest of the sprint.

## How it works

```
Model starts /feature
  → session.sh init feature (auto-create)
  → invokes /nano, /review, /security, /qa
  → save-artifact.sh --from-session (low friction)
  → git commit
    → check-dangerous.sh → phase-gate.sh
      → session active? → artifacts fresh? → ALLOW/BLOCK
```

If the model tries to skip review/security/qa and commit directly: **BLOCKED**.

## Test plan
- [x] phase-gate.sh exits 0 on non-git commands
- [x] phase-gate.sh exits 0 when no session exists
- [x] phase-gate.sh exits 1 (BLOCK) when session active + phases missing
- [x] phase-gate.sh exits 0 (ALLOW) when all artifacts present
- [x] NANOSTACK_SKIP_GATE=1 bypass works
- [x] save-artifact.sh --from-session creates valid artifact with integrity checksum
- [x] save-artifact.sh --from-session auto-calls phase-complete
- [x] Integration: check-dangerous.sh calls phase-gate.sh correctly