### PR TITLE
Fix phase gate UX: auto-setup and auto-complete

### DIFF
--- a/bin/init-project.sh
+++ b/bin/init-project.sh
@@ -14,6 +14,9 @@ echo "======================"
 echo "Project: $PROJECT_ROOT"
 echo ""
 
+# Create .nanostack directory (needed for session.json and artifacts)
+mkdir -p "$PROJECT_ROOT/.nanostack"
+
 # Create .claude directory
 mkdir -p "$CLAUDE_DIR"
 

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -47,8 +47,7 @@ if [ "${1:-}" = "--from-session" ]; then
       }
     }')
 
-  # Run the standard save logic below, then auto-complete phase
-  AUTOCOMPLETE_PHASE="$PHASE"
+  # Run the standard save logic below
   shift 3 || true
   set -- "$PHASE" "$JSON"
 fi
@@ -140,12 +139,10 @@ ENRICHED=$(echo "$ENRICHED" | jq --arg cs "$CHECKSUM" '. + {integrity: $cs}')
 echo "$ENRICHED" | jq '.' > "$FILENAME"
 echo "$FILENAME"
 
-# ─── Auto-complete phase in session if --from-session was used ──
-if [ -n "${AUTOCOMPLETE_PHASE:-}" ]; then
-  SESSION_SH="$SCRIPT_DIR/session.sh"
-  if [ -x "$SESSION_SH" ] && [ -f "$NANOSTACK_STORE/session.json" ]; then
-    # Start phase if not already in progress, then complete it
-    "$SESSION_SH" phase-start "$AUTOCOMPLETE_PHASE" >/dev/null 2>&1 || true
-    "$SESSION_SH" phase-complete "$AUTOCOMPLETE_PHASE" >/dev/null 2>&1 || true
-  fi
+# ─── Auto-complete phase in session ──────────────────────────
+# Always update session when an active session exists, regardless of save mode.
+SESSION_SH="$SCRIPT_DIR/session.sh"
+if [ -x "$SESSION_SH" ] && [ -f "$NANOSTACK_STORE/session.json" ]; then
+  "$SESSION_SH" phase-start "$PHASE" >/dev/null 2>&1 || true
+  "$SESSION_SH" phase-complete "$PHASE" >/dev/null 2>&1 || true
 fi

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -19,9 +19,17 @@ Fast path for adding a feature to an existing project. Skips the /think diagnost
 /feature Add import from JSON/CSV to restore backups
 ```
 
+## Setup
+
+Before anything else, ensure the project is configured. Run this once (skips if already done):
+
+```bash
+[ -f .claude/settings.json ] || ~/.claude/skills/nanostack/bin/init-project.sh
+```
+
 ## Session
 
-Before anything else, initialize the sprint session:
+Initialize the sprint session:
 
 ```bash
 ~/.claude/skills/nanostack/bin/session.sh init feature

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -35,9 +35,17 @@ This skill runs BEFORE `/nano`. Think answers WHAT and WHY. Plan answers HOW.
 - If the idea is genuinely strong, say so and explain WHY.
 - Never be sycophantic. But "not sycophantic" does not mean "aggressive." Direct and respectful is the target.
 
+## Setup
+
+Before anything else, ensure the project is configured. Run this once (skips if already done):
+
+```bash
+[ -f .claude/settings.json ] || ~/.claude/skills/nanostack/bin/init-project.sh
+```
+
 ## Session
 
-Before anything else, initialize the sprint session:
+Initialize the sprint session:
 
 ```bash
 ~/.claude/skills/nanostack/bin/session.sh init development


### PR DESCRIPTION
## Summary
- Auto-run `init-project.sh` on first sprint if `.claude/settings.json` missing (eliminates 45+ permission prompts)
- Auto-complete phase in session.json on ALL `save-artifact.sh` modes, not just `--from-session`
- `init-project.sh` now creates `.nanostack/` directory upfront

## Context
Found during live testing of PR #75. Two sprints ran successfully (/think --autopilot + /feature) but the user had to accept ~45 individual permission prompts because init-project.sh never ran. Session phases also stayed as "in_progress" because full JSON save mode didn't auto-complete.

## Test plan
- [x] --from-session still auto-completes (8/8 tests pass)
- [x] Full JSON mode now auto-completes
- [x] No session present: save works without error
- [x] Phase gate allows commit after full JSON saves