### PR TITLE
Improve sprint flow: auto-compound, autonomous /feature, idempotent sessions

### DIFF
--- a/bin/session.sh
+++ b/bin/session.sh
@@ -86,6 +86,16 @@ cmd_phase_start() {
     exit 1
   fi
 
+  # Idempotent: skip if phase already completed or in progress
+  local existing
+  existing=$(jq -r --arg p "$phase" \
+    '[.phase_log[] | select(.phase == $p and (.status == "completed" or .status == "in_progress"))] | length' \
+    "$SESSION_FILE" 2>/dev/null || echo "0")
+  if [ "$existing" -gt 0 ]; then
+    echo "OK: $phase already in log"
+    return 0
+  fi
+
   local epoch
   epoch=$(date +%s)
 

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -39,7 +39,7 @@ Then run `session.sh phase-start plan`. This activates the phase gate — `git c
 
 ## Process
 
-You are an orchestrator. You invoke each skill in sequence using the Skill tool. Do NOT implement the skill logic yourself — invoke the skill and let it run.
+You are an autonomous orchestrator. You run the entire sprint without stopping between phases. Do NOT wait for user input between steps. Do NOT ask "should I continue?" or "ready for review?". Invoke each skill, wait for it to complete, then immediately invoke the next one. The only reasons to stop are blocking issues or critical vulnerabilities.
 
 ### Step 1: Context
 
@@ -55,43 +55,37 @@ Read the checkpoint summaries. If no artifacts exist, read the codebase directly
 
 ### Step 2: Plan
 
-Invoke the nano skill using the Skill tool. Pass the feature description as context:
-
 ```
 Use Skill tool: skill="nano"
 ```
 
-Wait for /nano to complete. It will save its own artifact.
+Wait for /nano to complete. It saves its own artifact. Then immediately build.
 
 ### Step 3: Build
 
-After /nano completes and the user approves the plan, build the feature.
+Build the feature. Do not ask for approval. The plan was the contract.
 
-### Step 4: Review
+### Step 4: Review → Step 5: Security → Step 6: QA
 
-After build completes, invoke the review skill:
+Run all three in sequence without stopping:
 
 ```
 Use Skill tool: skill="review"
 ```
-
-Wait for /review to complete. It saves its own artifact. If blocking issues found, fix them before continuing.
-
-### Step 5: Security
+If blocking issues: fix them, then continue. Between steps show one line:
+`Feature: review complete. Running /security...`
 
 ```
 Use Skill tool: skill="security"
 ```
-
-Wait for /security to complete. If critical findings, fix before continuing.
-
-### Step 6: QA
+If critical findings: fix them, then continue.
+`Feature: security complete. Running /qa...`
 
 ```
 Use Skill tool: skill="qa"
 ```
-
-Wait for /qa to complete. If tests fail, fix before continuing.
+If tests fail: fix them, then continue.
+`Feature: qa complete. Running /ship...`
 
 ### Step 7: Ship
 
@@ -99,12 +93,13 @@ Wait for /qa to complete. If tests fail, fix before continuing.
 Use Skill tool: skill="ship"
 ```
 
-/ship commits, creates PR if remote exists, generates sprint journal, and shows the result with next feature suggestions.
+/ship commits, creates PR if remote exists, generates sprint journal, runs /compound, and shows the result with next feature suggestions.
 
 ## Rules
 
+- **Do not stop between phases.** This is the most important rule. Plan → build → review → security → qa → ship runs as one continuous flow. No pauses, no questions, no confirmations.
 - Each skill is invoked via the Skill tool, not implemented inline.
 - Each skill saves its own artifact. You do not save artifacts — the skills do.
-- Between steps, show brief status: `Feature: review complete. Running /security...`
-- Stop the sequence if any skill finds blocking issues or critical vulnerabilities.
+- Between steps, show one line of status: `Feature: review complete. Running /security...`
+- Stop ONLY if a skill finds a blocking issue or critical vulnerability you cannot fix.
 - If the feature already exists in the codebase, tell the user and suggest alternatives.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -294,4 +294,10 @@ Example:
 > - `/feature Add weekly and monthly streak counters`
 > - `/feature Add categories to organize habits by area`
 >
-> Run `/compound` to save what you learned from this sprint.
+After presenting the summary and next steps, automatically run compound to capture learnings:
+
+```
+Use Skill tool: skill="compound"
+```
+
+Do not ask. Do not skip. Compound reads the sprint artifacts and saves solutions for future sprints.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -176,20 +176,15 @@ Produce a clear brief for the next phase:
 **Premise validated:** {{yes/no — and why}}
 ```
 
-After producing the Think Summary, do these two steps in order:
-
-**Step 1: Save the artifact.** Run this command now — do not skip it:
+Immediately after writing the Think Summary — before anything else, before presenting next steps — save the artifact:
 
 ```bash
 ~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: X. Scope: Y. Wedge: Z. Risk: W. Premise: validated/not.'
 ```
 
-Or pass full JSON for richer detail:
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh think '<json with phase, summary including value_proposition, scope_mode, target_user, narrowest_wedge, key_risk, premise_validated, context_checkpoint>'
-```
+This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action.
 
-**Step 2: Next phase.**
+**Next phase.**
 
 If `--autopilot` was used (or the user said "autopilot", "run everything", "ship it end to end"):
 


### PR DESCRIPTION
## Summary
- **/ship auto-runs /compound** after sprint journal. No manual invocation needed.
- **/feature runs autonomously.** Plan → build → review → security → qa → ship without stopping between phases. Instructions now explicitly say "do not stop between phases."
- **session.sh phase-start is idempotent.** Calling it on a completed or in-progress phase is a no-op. Fixes duplicate entries in phase_log.
- **Think artifact save moved earlier.** Immediately after Think Summary, not a separate step the model can skip.

## Context
Found during two live test sprints on a clean project (md2html CLI). The sprint ran to completion but with friction:
- User had to manually run /compound after each sprint
- /feature paused between phases waiting for user input
- session.json showed duplicate "plan: completed" entries
- Think artifact was not saved (model stopped before reaching the save instruction)

## Test plan
- [x] session.sh phase-start called 3x creates 1 entry
- [x] phase-start after complete doesn't duplicate
- [x] Two save-artifact calls create 1 session entry
- [x] Full sprint has clean phase_log (no duplicates)
- [x] Phase gate still allows after all phases