### PR TITLE
Think recovery, session sync on read, security re-audit optimization

### DIFF
--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -29,6 +29,28 @@ done | sort -r | head -1)
 
 [ -n "$RESULT" ] || exit 1
 
+# ─── Session sync: register phase if session is active ──────
+# When a downstream skill reads an artifact, ensure the producing
+# phase is registered in the session. Covers cases where the model
+# saved the artifact but didn't call session.sh directly.
+# NOTE: Only calls phase-start, NOT phase-complete (which would
+# recurse back to find-artifact.sh and hang). The phase stays
+# "in_progress" until save-artifact.sh completes it.
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+if [ -f "$SESSION_FILE" ]; then
+  # Check if phase already in session (avoid unnecessary jq calls)
+  PHASE_EXISTS=$(jq -r --arg p "$PHASE" \
+    '[.phase_log[] | select(.phase == $p)] | length' \
+    "$SESSION_FILE" 2>/dev/null)
+  PHASE_EXISTS="${PHASE_EXISTS:-0}"
+  if [ "$PHASE_EXISTS" -eq 0 ]; then
+    SESSION_SH="$SCRIPT_DIR/session.sh"
+    if [ -x "$SESSION_SH" ]; then
+      "$SESSION_SH" phase-start "$PHASE" >/dev/null 2>&1 || true
+    fi
+  fi
+fi
+
 # Verify artifact integrity if requested
 if [ "$VERIFY" = true ]; then
   STORED_HASH=$(jq -r '.integrity // ""' "$RESULT" 2>/dev/null)

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -42,6 +42,12 @@ Then run `session.sh phase-start plan`.
   - `scope_mode` → if /think said "reduce," plan the smallest version. If "expand," plan bigger.
   - `premise_validated` → if false, flag it. Don't plan for an unvalidated premise.
 
+  **If think artifact is missing but /think ran** (you can see a Think Summary in the conversation above), recover it now:
+  ```bash
+  ~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: <from summary>. Scope: <from summary>. Wedge: <from summary>. Risk: <from summary>. Premise: <from summary>.'
+  ```
+  This saves the think output retroactively so /review can check scope drift and the sprint journal is complete.
+
 - Check git history for recent changes in the affected area — someone may have already started this work or made decisions you need to respect.
 - Search past solutions: run `~/.claude/skills/nanostack/bin/find-solution.sh` with keywords related to the technologies and files in scope. The output shows ranked summaries with title, severity, tags and files. Read the summaries first, then load only the solutions relevant to the current task. Past mistakes and patterns should inform the current sprint.
 - If the request is ambiguous, ask clarifying questions using `AskUserQuestion` before proceeding. Do not guess scope.

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -255,6 +255,15 @@ After the security audit is complete and the artifact is saved:
 > - `/qa` to test that everything works (if not done yet)
 > - `/ship` to create the PR (after review, security and qa pass)
 
+## After Fixes
+
+When the model or user fixes security findings, do NOT re-run the full audit. Instead:
+
+- **CRITICAL/HIGH fixes:** Re-audit only the affected files and the specific vulnerability class. Verify the fix resolves the finding. Save a new artifact.
+- **MEDIUM/LOW fixes:** Verify the specific fix by reading the changed code. No re-audit needed. Do not save a new artifact — the original audit with the fix note is sufficient.
+
+Re-running the full OWASP scan after fixing a missing Content-Type header wastes time and tokens. Target the verification.
+
 ## Gotchas
 
 - **If you find zero vulnerabilities, say so.** A clean audit is a valid result. Don't manufacture findings to justify the scan.


### PR DESCRIPTION
## Summary
- **/nano recovers missing think artifact.** If /think ran but didn't save (common on simple tasks), /nano saves it retroactively from the Think Summary in context.
- **find-artifact.sh syncs session.** When a skill reads an artifact, the producing phase is auto-registered in session.json. Only calls phase-start (not phase-complete) to avoid infinite recursion with session.sh.
- **Security re-audit optimization.** After fixing LOW/MEDIUM findings, verify the specific fix only. Full re-audit only for CRITICAL/HIGH. Reduces security overhead from 2-3 runs to 1-2 per sprint.

## Context
From live testing: think artifact consistently missing on simple tasks, session.json missing phases that had artifacts, security running full audit 2-3 times per sprint.

## Test plan
- [x] find-artifact registers unknown phase in session (7/7 tests)
- [x] Idempotent: multiple finds create 1 entry
- [x] Completed phases not re-added
- [x] External artifacts (saved without save-artifact.sh) sync on read
- [x] No infinite recursion between find-artifact ↔ session.sh
- [x] Works without active session