### PR TITLE
Add local mode for non-git users

### DIFF
--- a/bin/lib/git-context.sh
+++ b/bin/lib/git-context.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# git-context.sh — Detect git availability for local mode adaptation
+# Source this file, then call: detect_git_mode
+# Returns: "full" (git + remote), "local-git" (git, no remote), "local" (no git)
+
+detect_git_mode() {
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "local"
+    return 0
+  fi
+  if git remote get-url origin >/dev/null 2>&1; then
+    echo "full"
+    return 0
+  fi
+  echo "local-git"
+}

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -27,6 +27,8 @@ If the output shows `"active":false`, create a session:
 
 Then run `session.sh phase-start plan`.
 
+**Local mode:** Run `source bin/lib/git-context.sh && detect_git_mode`. If result is `local`, adapt language: "implementation plan" → "paso a paso", "files to modify" → "archivos que vamos a crear", "architecture checkpoint" → skip (overkill for non-technical users). Present the plan as a simple numbered list of what you'll build, not a spec document. Same rigor, accessible words.
+
 ## Process
 
 ### 1. Understand the Request

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -34,6 +34,14 @@ Auto-suggest logic (recommend, don't enforce):
 
 Calibrate depth by diff size: **Small** (< 100 lines, quick pass) / **Medium** (100-500, full two-pass) / **Large** (500+, full + architecture).
 
+## Local Mode
+
+Run `source bin/lib/git-context.sh && detect_git_mode`. If `local` (no git):
+- **File source:** use `context_checkpoint.key_files` from the plan artifact instead of git diff. If no plan artifact, list files in the project directory.
+- **Skip:** scope drift check (no diff to compare), PR preview.
+- **Language:** replace "diff", "branch", "PR" with plain terms. "Revisé N archivos. Encontré X cosas:" instead of "Diff: N files, X findings." Explain each finding in plain language — what's wrong, why it matters, and whether you can fix it.
+- **Everything else stays the same:** two passes (structural + adversarial), severity levels, auto-fix vs ask.
+
 ## Step 0: Read Plan Context and Past Solutions
 
 Find the plan artifact and extract context for the review:

--- a/review/bin/suggest-security.sh
+++ b/review/bin/suggest-security.sh
@@ -4,8 +4,17 @@
 # If so, suggest running /security
 set -e
 
-# Get changed files
-CHANGED=$(git diff --name-only --cached 2>/dev/null; git diff --name-only 2>/dev/null)
+# Detect git context
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../bin/lib/git-context.sh" 2>/dev/null || true
+GIT_MODE=$(detect_git_mode 2>/dev/null || echo "local")
+
+# Get changed files (git or find fallback)
+if [ "$GIT_MODE" = "local" ]; then
+  CHANGED=$(find . -maxdepth 3 -type f -not -path '*/node_modules/*' -not -path '*/.nanostack/*' -not -path '*/.git/*' -not -path '*/.DS_Store' 2>/dev/null)
+else
+  CHANGED=$(git diff --name-only --cached 2>/dev/null; git diff --name-only 2>/dev/null)
+fi
 
 # Check for security-sensitive patterns
 SENSITIVE_PATTERNS="auth|login|password|token|secret|\.env|middleware|permission|role|session|jwt|oauth|payment|billing|stripe|crypto|encrypt|Dockerfile|docker-compose|\.github/workflows|k8s|terraform|infra"

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -15,6 +15,26 @@ hooks:
 
 You get code from "done" to "verified in production" in one pass. You own the full pipeline: pre-flight, PR, CI, deploy, verification. If something breaks after merge, you rollback first and debug second.
 
+## Local Mode
+
+Run `source bin/lib/git-context.sh && detect_git_mode`.
+
+**If `local` (no git repo):** Skip the entire PR/CI/deploy flow below. Instead:
+1. Run `ship/bin/quality-check.sh` (already works without git).
+2. Verify files from the plan exist and are non-empty.
+3. Detect project type and show how to use the result:
+   - HTML → "Abrí index.html en tu navegador (doble click en el archivo)"
+   - Python → "Corré: python3 main.py"
+   - Node → "Corré: npm start y abrí localhost:3000"
+   - Other → "Tu proyecto está en [ruta completa]"
+4. If the user wants to publish: suggest drag-and-drop hosting (Netlify, Vercel). Walk through it step by step.
+5. Save artifact and run compound as normal.
+Never mention PR, CI, branch, merge, deploy, or rollback. Output: "Listo. Para verlo: [comando]."
+
+**If `local-git` (git, no remote):** Run pre-ship check and quality check. Skip PR/CI/deploy. Suggest `git tag` for versioning. Output: "Listo. Commit: [hash]."
+
+**If `full`:** Continue with the normal process below.
+
 ## Process
 
 ### 1. Pre-flight Check

--- a/ship/bin/pre-ship-check.sh
+++ b/ship/bin/pre-ship-check.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # pre-ship-check.sh — PreToolUse hook for /ship
 # Before creating a PR, verify basic hygiene
+# In local mode (no git), skips git checks gracefully
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../bin/lib/git-context.sh" 2>/dev/null || true
+GIT_MODE=$(detect_git_mode 2>/dev/null || echo "local")
+
+if [ "$GIT_MODE" = "local" ]; then
+  echo "LOCAL_MODE"
+  exit 0
+fi
 
 WARNINGS=""
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -78,6 +78,8 @@ Determine the mode from the user's description:
 
 **How to detect the mode:** If the user describes a personal pain ("I have this problem," "I need to..."), default to Startup or Builder. If the user pitches an idea for others ("I want to build X for Y market"), default to Startup. Only use Founder mode when the user asks for it or the context is clearly a high-stakes venture decision.
 
+**Local mode language:** Run `source bin/lib/git-context.sh && detect_git_mode`. If the result is `local` (no git repo), the user is likely non-technical. Adapt your language throughout the entire sprint: replace jargon with plain language. "Narrowest wedge" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs.
+
 ### Phase 1.5: Search Before Building
 
 Read `think/references/search-before-building.md` and follow the instructions before running the diagnostic.


### PR DESCRIPTION
## Summary

- Auto-detect git context and adapt the entire sprint for users working in local folders without git
- `bin/lib/git-context.sh` detects three modes: `full` (git + remote), `local-git` (git, no remote), `local` (no git)
- Skills adapt language for non-technical users: same rigor, simpler words
- Zero changes to the existing git workflow. Detection is runtime, not config.

## Why

The fastest growing segment using AI coding agents are non-developers: founders, operators, professionals building things with Cursor or Claude Code in local folders. They've never opened a terminal. The sprint flow (think, plan, build, review, ship) works for them, but review assumes git diff and ship assumes PR creation.

**Example:** A user building a landing page in `~/Desktop/my-project/`. After the build:
- Before: `/ship` says "Create a PR" → confusion. What's a PR?
- After: `/ship` says "Listo. Para verla: abrí index.html en tu navegador."

## What changes per skill

| Skill | Mode full (git + remote) | Mode local (no git) |
|-------|-------------------------|---------------------|
| /think | Unchanged | Same questions, plain language ("what's the minimum you need?" vs "narrowest wedge") |
| /nano | Unchanged | "Step by step" vs "implementation plan", skip architecture checkpoint |
| /review | Unchanged | Files from plan artifact instead of git diff, plain language findings |
| /ship | Unchanged | "Open your file" instead of PR, skip CI/deploy/rollback |
| /security, /qa, /guard, /compound | Unchanged | Unchanged |

## Files changed (7)

- `bin/lib/git-context.sh` — new: `detect_git_mode()` function (15 lines)
- `think/SKILL.md` — add local language note after mode detection
- `plan/SKILL.md` — add local language note after session setup
- `review/SKILL.md` — add Local Mode section before Step 0
- `review/bin/suggest-security.sh` — find-based fallback when git unavailable
- `ship/SKILL.md` — add Local Mode section before Process
- `ship/bin/pre-ship-check.sh` — graceful LOCAL_MODE skip

## Test plan

- [ ] `detect_git_mode` in git+remote dir → `full`
- [ ] `detect_git_mode` in git-only dir → `local-git`
- [ ] `detect_git_mode` in no-git dir → `local`
- [ ] `suggest-security.sh` in no-git dir with auth.js → `SECURITY_SENSITIVE`
- [ ] `pre-ship-check.sh` in no-git dir → `LOCAL_MODE`
- [ ] All scripts work unchanged in full mode (no regression)
- [ ] `tests/run.sh` → 44/44 pass