### PR TITLE
Add hard budget enforcement, structured audit log, and goal context

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,19 @@ No daemon. No message queue. Just `mkdir` for atomic locking, JSON for state, sy
 
 If the agent crashes mid-sprint, `session.sh resume` detects the last session state and `restore-context.sh` reads all completed phase checkpoints. The agent skips completed phases and restarts from where it left off. Each checkpoint is a compact summary (~50 tokens) with the key findings, files and decisions from that phase.
 
+### Goal context
+
+Pass a business objective when starting a sprint:
+
+```bash
+session.sh init development --goal "Pass SOC2 audit by July"
+```
+
+The goal propagates through the resolver to every phase. `/think` uses it to frame scope decisions: "does this feature serve the goal, or is it a tangent?" `/review` uses it to prioritize findings. `/security` uses it to weight compliance-related checks. The goal is optional — sprints work fine without one.
+
 ### Budget and circuit breaker
 
-`budget.sh set --max-usd 15 --model opus-4` sets a cost limit for the sprint. At each phase transition, `budget.sh check` calculates spent vs budget. Warns at 80%, stops at 95% with partial results preserved.
+`budget.sh set --max-usd 15 --model opus-4` sets a cost limit for the sprint. At each phase transition, `budget.sh check` calculates spent vs budget. Warns at 80%. At 95%, the guard pipeline hard-blocks all non-allowlisted commands — not a suggestion the model can ignore, a wall. The agent can still run `git status` and `ls` (to save work) but can't execute anything else. Override with `NANOSTACK_SKIP_BUDGET=1`.
 
 `circuit.sh` tracks consecutive failures. After 3 failures on the same approach, the circuit opens and the agent must pivot or stop. Changing approach resets the counter.
 
@@ -240,9 +250,9 @@ If the agent crashes mid-sprint, `session.sh resume` detects the last session st
 
 AI agents make mistakes. They run `rm -rf` when they mean `rm -r`, force push to main when they mean to push to a branch, pipe untrusted URLs to shell. `/guard` catches these before they execute.
 
-### Five tiers
+### Six tiers
 
-Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through five tiers:
+Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through six tiers:
 
 **Tier 1: Allowlist.** Commands like `git status`, `ls`, `cat`, `jq` skip all checks. They can't cause damage.
 
@@ -251,6 +261,8 @@ Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude
 **Tier 2.5: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
 
 **Tier 2.75: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security and qa artifacts exist and are fresher than the latest code change. This is the enforcement that prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
+
+**Tier 2.8: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but can't execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
 
 **Tier 3: Pattern matching.** Everything else is checked against block and warn rules. 33 block rules cover mass deletion, history destruction, database drops, production deploys, remote code execution, security degradation and safety bypasses. 9 warn rules cover operations that need attention but not blocking.
 
@@ -516,6 +528,8 @@ bin/capture-learning.sh "..."  # append a learning to the knowledge base
 `token-report.sh` reads Claude Code's session logs and breaks down where tokens go. Cache-aware pricing (reads at 10%, creation at 125%). Flags runaway sessions and heavy subagents. Requires Claude Code; skips silently on other agents.
 
 `pattern-report.sh` detects patterns across sprints: which findings keep recurring, whether predicted risks materialized, which phases take the longest, and how often solutions get reused.
+
+Every sprint lifecycle event is logged to `.nanostack/audit.log` (JSONL, append-only): session init, phase start/complete with duration, artifact saves, solution creation, graduation. When a sprint goes wrong, the audit trail shows exactly what happened and when.
 
 ### Discard a bad session
 

--- a/bin/graduate.sh
+++ b/bin/graduate.sh
@@ -23,6 +23,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 
+source "$SCRIPT_DIR/lib/audit.sh"
+
 NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOLUTIONS_DIR="$NANOSTACK_STORE/know-how/solutions"
 
@@ -331,6 +333,7 @@ graduated_to: $target/SKILL.md" "$filepath" 2>/dev/null || \
         sed -i "s|^graduated_to:.*|graduated_to: $target/SKILL.md|" "$filepath" 2>/dev/null || true
     fi
 
+    audit_log "solution_graduated" "$source_ref" "$target/SKILL.md"
     echo "  ✓ $source_ref → $target/SKILL.md"
   done
 

--- a/bin/lib/audit.sh
+++ b/bin/lib/audit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# audit.sh — Append structured lifecycle events to the audit log
+# Source this file, then call: audit_log <event> <resource> [detail]
+#
+# Events: session_init, phase_start, phase_complete, artifact_saved,
+#         solution_created, solution_graduated, budget_exceeded,
+#         sprint_claim, sprint_complete
+
+audit_log() {
+  local event="$1" resource="${2:-}" detail="${3:-}"
+  local store="${NANOSTACK_STORE:-}"
+
+  # Resolve store path if not set
+  if [ -z "$store" ]; then
+    local git_root
+    git_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ -n "$git_root" ]; then
+      store="$git_root/.nanostack"
+    else
+      store="$HOME/.nanostack"
+    fi
+  fi
+
+  local log="$store/audit.log"
+  [ -d "$store" ] || return 0
+
+  printf '{"at":"%s","event":"%s","resource":"%s","detail":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$event" \
+    "$resource" \
+    "$detail" >> "$log" 2>/dev/null || true
+}

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -194,12 +194,20 @@ fi
 CONFIG_JSON="{}"
 CONFIG_FILE="$NANOSTACK_STORE/config.json"
 if [ -f "$CONFIG_FILE" ]; then
-  # Extract just the fields skills care about
   CONFIG_JSON=$(jq -c '{
     intensity: (.preferences.default_intensity // "standard"),
     conflict_precedence: (.preferences.conflict_precedence // "security"),
     detected_stack: (.detected // [])
   }' "$CONFIG_FILE" 2>/dev/null) || CONFIG_JSON="{}"
+fi
+
+# ─── 6. Load goal from session ─────────────────────────────
+
+GOAL="null"
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+if [ -f "$SESSION_FILE" ]; then
+  SESSION_GOAL=$(jq -r '.goal // ""' "$SESSION_FILE" 2>/dev/null)
+  [ -n "$SESSION_GOAL" ] && GOAL="\"$SESSION_GOAL\""
 fi
 
 # ─── Output ─────────────────────────────────────────────────
@@ -211,11 +219,13 @@ jq -n \
   --argjson precedents "$PRECEDENTS_JSON" \
   --argjson diarizations "$DIARIZATIONS_JSON" \
   --argjson config "$CONFIG_JSON" \
+  --argjson goal "$GOAL" \
   '{
     phase: $phase,
     upstream_artifacts: $artifacts,
     solutions: $solutions,
     conflict_precedents: $precedents,
     diarizations: $diarizations,
-    config: $config
+    config: $config,
+    goal: $goal
   }'

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -13,6 +13,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/audit.sh"
 
 # ─── Session mode: build JSON from git state + summary ──────
 if [ "${1:-}" = "--from-session" ]; then
@@ -137,6 +138,7 @@ CHECKSUM=$(echo "$ENRICHED" | jq -Sc '.' | shasum -a 256 | cut -d' ' -f1)
 ENRICHED=$(echo "$ENRICHED" | jq --arg cs "$CHECKSUM" '. + {integrity: $cs}')
 
 echo "$ENRICHED" | jq '.' > "$FILENAME"
+audit_log "artifact_saved" "$PHASE" "$(basename "$FILENAME")"
 echo "$FILENAME"
 
 # ─── Auto-complete phase in session ──────────────────────────

--- a/bin/save-solution.sh
+++ b/bin/save-solution.sh
@@ -11,6 +11,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/audit.sh"
 
 TYPE="${1:?Usage: save-solution.sh <type> <title> [tags]}"
 TITLE="${2:?Missing title}"
@@ -133,4 +134,5 @@ TEMPLATE
     ;;
 esac
 
+audit_log "solution_created" "$TYPE" "$SAFE_TITLE"
 echo "created:$FILEPATH"

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -11,6 +11,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/audit.sh"
 
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 PROJECT="$(pwd)"
@@ -22,12 +23,14 @@ cmd_init() {
   local type="${1:-development}"
   local issue_url=""
   local autopilot="false"
+  local goal=""
 
   shift || true
   while [ $# -gt 0 ]; do
     case "$1" in
       --issue) issue_url="$2"; shift 2 ;;
       --autopilot) autopilot="true"; shift ;;
+      --goal) goal="$2"; shift 2 ;;
       *) shift ;;
     esac
   done
@@ -49,6 +52,7 @@ cmd_init() {
     --arg id "$session_id" \
     --arg type "$type" \
     --arg issue "$issue_url" \
+    --arg goal "$goal" \
     --arg repo "$repo" \
     --arg workspace "$PROJECT" \
     --arg date "$NOW" \
@@ -57,6 +61,7 @@ cmd_init() {
       session_id: $id,
       type: $type,
       issue_url: (if $issue != "" then $issue else null end),
+      goal: (if $goal != "" then $goal else null end),
       repo: (if $repo != "" then $repo else null end),
       workspace: $workspace,
       current_phase: null,
@@ -74,6 +79,7 @@ cmd_init() {
       last_updated: $date
     }' > "$SESSION_FILE"
 
+  audit_log "session_init" "$session_id" "$type"
   echo "$SESSION_FILE"
 }
 
@@ -115,6 +121,7 @@ cmd_phase_start() {
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
+  audit_log "phase_start" "$phase"
   echo "OK: $phase started"
 }
 
@@ -192,6 +199,7 @@ cmd_phase_complete() {
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
+  audit_log "phase_complete" "$phase" "${duration}s"
   echo "OK: $phase completed"
 }
 

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -6,6 +6,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 source "$SCRIPT_DIR/bin/lib/store-path.sh"
+source "$SCRIPT_DIR/bin/lib/audit.sh"
 
 CONDUCTOR_DIR="$NANOSTACK_STORE/conductor"
 PROJECT="$(pwd)"
@@ -157,6 +158,7 @@ cmd_claim() {
     exit 1
   }
 
+  audit_log "sprint_claim" "$phase" "$agent"
   echo "OK"
 }
 
@@ -205,6 +207,7 @@ cmd_complete() {
     [ -f "$sprint_dir/$p/done" ] || { all_done=false; break; }
   done
 
+  audit_log "sprint_complete" "$phase" "$agent"
   echo "OK"
 }
 

--- a/guard/bin/budget-gate.sh
+++ b/guard/bin/budget-gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# budget-gate.sh — Hard budget enforcement in the guard pipeline
+# Called by check-dangerous.sh at Tier 2.8.
+# If a sprint budget is set and >= 95% spent, block ALL commands.
+# Exit 0 = within budget (or no budget set). Exit 1 = blocked.
+set -euo pipefail
+
+GUARD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+NANOSTACK_ROOT="$(cd "$GUARD_DIR/.." && pwd)"
+BUDGET_SH="$NANOSTACK_ROOT/bin/budget.sh"
+
+# Skip if no budget script
+[ -x "$BUDGET_SH" ] || exit 0
+
+# Skip if explicitly overridden
+[ -n "${NANOSTACK_SKIP_BUDGET:-}" ] && exit 0
+
+RESULT=$("$BUDGET_SH" check 2>/dev/null) || exit 0
+ACTION=$(echo "$RESULT" | jq -r '.action // "continue"' 2>/dev/null) || exit 0
+
+if [ "$ACTION" = "stop" ]; then
+  SPENT=$(echo "$RESULT" | jq -r '.spent_usd // "?"')
+  MAX=$(echo "$RESULT" | jq -r '.max_usd // "?"')
+  PCT=$(echo "$RESULT" | jq -r '.pct // "?"')
+  echo "BLOCKED [BUDGET] Sprint budget exceeded (${PCT}%)"
+  echo "Category: cost-control"
+  echo "Spent: \$${SPENT} / \$${MAX}"
+  echo ""
+  echo "Save your work and stop. To override: NANOSTACK_SKIP_BUDGET=1"
+  exit 1
+fi

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -139,6 +139,18 @@ if [ -x "$PHASE_GATE" ]; then
   [ -n "$GATE_OUTPUT" ] && echo "$GATE_OUTPUT"
 fi
 
+# ─── Tier 2.8: Budget gate ────────────────────────────────────
+# If a sprint budget is set and exceeded, block ALL commands.
+if [ -z "${NANOSTACK_SKIP_BUDGET:-}" ]; then
+  BUDGET_GATE="$(dirname "$0")/budget-gate.sh"
+  if [ -x "$BUDGET_GATE" ]; then
+    BGATE_OUTPUT=$("$BUDGET_GATE" 2>&1) || {
+      echo "$BGATE_OUTPUT"
+      exit 1
+    }
+  fi
+fi
+
 # ─── Tier 3: Pattern matching ───────────────────────────────
 # 1 jq call extracts all patterns. 1 combined grep for fast pre-check.
 # Only loop individual patterns if the pre-check hits.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -57,6 +57,14 @@ If the user said `--autopilot`, `autopilot`, `run everything`, or `ship it end t
 ~/.claude/skills/nanostack/bin/session.sh init development --autopilot
 ```
 
+If the user provides a high-level goal (business objective, deadline, strategic context), pass it:
+
+```bash
+~/.claude/skills/nanostack/bin/session.sh init development --goal "Pass SOC2 audit by July"
+```
+
+The goal propagates through the resolver to every phase. Use it to frame scope decisions: "does this feature serve the goal, or is it a tangent?"
+
 Then run `session.sh phase-start think`.
 
 ## Process


### PR DESCRIPTION
## Summary

Three patterns from Paperclip's control plane, implemented within nanostack's zero-dependency architecture:

- **Hard budget enforcement** (`guard/bin/budget-gate.sh`): wired into guard at Tier 2.8. When sprint budget hits 95%, ALL Bash commands are blocked — not a warning the model can ignore, a hard stop like `rm -rf /`. Override: `NANOSTACK_SKIP_BUDGET=1`.

- **Structured audit log** (`bin/lib/audit.sh`): shared `audit_log` function integrated into 6 lifecycle scripts. Logs session_init, phase_start, phase_complete, artifact_saved, solution_created, solution_graduated, sprint_claim, sprint_complete. Append-only JSONL to `.nanostack/audit.log`.

- **Goal context**: `session.sh init` accepts `--goal "Pass SOC2 by July"`. Goal propagates through `resolve.sh` to every phase. `/think` documents goal usage for framing scope decisions.

## Test plan

- [x] 44/44 existing tests pass
- [x] `bash -n` syntax check on all 10 modified files
- [x] Zero new shellcheck warnings
- [x] Budget gate: no session = pass, `ls` = pass, `rm -rf /` = blocked by guard (not budget)
- [x] Resolver outputs goal field when session has `--goal` set
- [x] Audit log captures structured JSONL events with timestamp, event, resource, detail
- [x] Session init with `--goal` stores goal in session.json and logs session_init to audit