### PR TITLE
Add think brief, sprint guide for new users, and /think --retro

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx create-nanostack
 
 One command. Detects your agents, installs everything, runs setup. Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and Antigravity.
 
-Then run `/nano-run` in your agent to configure your project through a conversation.
+Then run `/nano-run` in your agent to configure your project through a conversation. On your first sprint, `/think` shows the full pipeline so you know what comes next.
 
 Or jump straight in:
 
@@ -95,7 +95,7 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
-| `/think` | **CEO / Founder** | Three intensity modes: Founder (full pushback), Startup (challenges scope, respects pain) and Builder (minimal pushback). Six forcing questions including manual delivery test. Auto-detects non-technical users and adapts language. `--autopilot` runs the full sprint after approval. |
+| `/think` | **CEO / Founder** | Three intensity modes: Founder (full pushback), Startup (challenges scope, respects pain) and Builder (minimal pushback). Six forcing questions including manual delivery test. Auto-detects non-technical users and adapts language. `--autopilot` runs the full sprint after approval. `--retro` reflects on what shipped. Saves a shareable markdown brief. New users get a sprint guide showing the full pipeline. |
 | `/nano` | **Eng Manager** | Auto-generates product specs (Medium scope) or product + technical specs (Large scope) before implementation steps. Product standards for web (shadcn/ui), CLI/TUI (Bubble Tea, Rich, Ink, Ratatui). Stack defaults with CLI preference for beginners. |
 | `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan. Cross-references `/security` with 10 conflict precedents. |
 | `/qa` | **QA Lead** | Functional testing + Visual QA. Takes screenshots and analyzes UI against product standards. Browser, API, CLI and debug modes. WTF heuristic stops before fixes cause regressions. |
@@ -179,6 +179,64 @@ You:    /ship
 ```
 
 You said "security scanner." The agent said "you're building a prevention gate" because it listened to your pain, not your feature request. Six commands, start to shipped.
+
+## Think brief
+
+Every `/think` run saves a shareable markdown brief to `.nanostack/know-how/briefs/`. Not the JSON artifact — a clean document you can send to your team, paste into a doc, or open in Obsidian.
+
+```markdown
+# Think Brief: S3 Public Access Prevention Gate
+
+**Date:** 2026-04-12
+**Mode:** Startup
+**Scope:** Reduce
+
+## Value Proposition
+Prevent public S3 buckets from reaching production.
+
+## Target User
+Platform team — they got paged for the incident.
+
+## Narrowest Wedge
+One rule: block S3 public access pre-deploy.
+
+## Key Risk
+False positives blocking legitimate public assets (CDN, static sites).
+
+## Premise
+Validated — scanner finds problems after they exist, gate prevents them.
+```
+
+The brief answers: what are we building, for whom, why this scope, and what could go wrong. Share it before writing code.
+
+## Retro
+
+After a sprint, use `/think --retro` to reflect on what shipped:
+
+```
+You:    /think --retro
+
+Agent:  Reading sprint data...
+
+        Sprint Retro
+
+        Shipped: S3 public access gate (4 files, PR #42)
+
+        Right problem? Yes — prevention, not detection. The gate
+        blocked 2 misconfigs in staging within 24 hours of deploy.
+
+        Surprises: /security found the gate itself had no rate
+        limiting. Fixed in the sprint but wasn't in the plan.
+
+        Recurring: This is the third sprint with missing rate
+        limiting findings. Consider adding it to /review's
+        graduated rules.
+
+        Recommendation: Next sprint should add IAM role scope
+        checks — same gate pattern, broader coverage.
+```
+
+Retro reads the sprint journal, compound solutions, and pattern report. It applies the same forcing questions to what was built, not what will be built. It doesn't start a new sprint — it's standalone reflection.
 
 ## Autopilot
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Prevent public S3 buckets from reaching production.
 ## Target User
 Platform team — they got paged for the incident.
 
-## Narrowest Wedge
+## Starting Point
 One rule: block S3 public access pre-deploy.
 
 ## Key Risk

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -38,7 +38,7 @@ Then run `session.sh phase-start plan`.
   ~/.claude/skills/nanostack/bin/resolve.sh plan
   ```
   The output is JSON with `upstream_artifacts` (think artifact path if recent), `solutions` (ranked matches), and `config`. Use what's relevant:
-  - If a think artifact exists, read it and extract: `key_risk` → add to Risks. `narrowest_wedge` → scope constraint. `out_of_scope` → pre-populate Out of Scope. `scope_mode` → if "reduce," plan smallest version. `premise_validated` → if false, flag it.
+  - If a think artifact exists, read it and extract: `key_risk` → add to Risks. `narrowest_wedge` (starting point) → scope constraint. `out_of_scope` → pre-populate Out of Scope. `scope_mode` → if "reduce," plan smallest version. `premise_validated` → if false, flag it.
   - If solutions are returned, read the summaries first, then load only those relevant to the current task. Past mistakes and patterns should inform the sprint.
 
   **If think artifact is missing but /think ran** (you can see a Think Summary in the conversation above), recover it now:

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: think
-description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Supports --autopilot to run the full sprint automatically after approval. Triggers on /think, /office-hours, /ceo-review.
+description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Supports --autopilot to run the full sprint automatically after approval. Use --retro after a sprint to reflect on what shipped. Triggers on /think, /office-hours, /ceo-review.
 concurrency: read
 depends_on: []
 summary: "Strategic product thinking. Challenges assumptions, finds narrowest valuable wedge, validates premise before planning."
@@ -42,6 +42,66 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 ```bash
 [ -f .claude/settings.json ] || ~/.claude/skills/nanostack/bin/init-project.sh
 ```
+
+## Retro Mode
+
+If the user said `/think --retro` or `/think retro` or "retrospective", run the retrospective process instead of the normal diagnostic. **Do not initialize a new session.** Retro looks backward at what was shipped, not forward at what to build.
+
+### Retro Process
+
+**1. Gather sprint data:**
+
+```bash
+~/.claude/skills/nanostack/bin/resolve.sh compound
+~/.claude/skills/nanostack/bin/pattern-report.sh --json
+```
+
+Also read the most recent sprint journal if one exists:
+
+```bash
+ls -t .nanostack/know-how/journal/*.md 2>/dev/null | head -1
+```
+
+If no sprint data exists (no artifacts, no journal, no sessions), tell the user: "No sprint data found. Run a sprint first, then come back with `/think --retro`." Stop here.
+
+**2. Retro diagnostic — four questions:**
+
+Apply the same rigor as the forward-looking diagnostic, but to what was shipped:
+
+| # | Question | What to read |
+|---|----------|-------------|
+| 1 | **Did we solve the right problem?** Re-read the think artifact's value proposition. Does the shipped code actually address it, or did scope drift change the product? | Think artifact + ship artifact |
+| 2 | **What surprised us?** Which review/security/qa findings were unexpected? Which risks from the plan materialized and which didn't? | Review + security + qa artifacts, pattern-report risk accuracy |
+| 3 | **What's recurring?** Are the same findings showing up across sprints? If pattern-report shows a tag appearing 3+ times, that's a systemic issue, not a one-off. | pattern-report.sh recurring findings |
+| 4 | **What should the next sprint be?** Based on what was shipped, what was deferred, and what broke — what's the highest-value next thing? | Out-of-scope from plan, unresolved findings, deferred risks |
+
+**3. Retro output:**
+
+```
+## Sprint Retro
+
+**Sprint:** <session ID or date>
+**Shipped:** <what was built, one sentence>
+
+**Right problem?** <yes/no — and why>
+**Surprises:** <unexpected findings or outcomes>
+**Recurring patterns:** <systemic issues from pattern-report>
+**Recommendation:** The next sprint should be: <specific, actionable>
+```
+
+Save the retro as a brief:
+
+```bash
+mkdir -p .nanostack/know-how/briefs
+```
+
+Write to `.nanostack/know-how/briefs/YYYY-MM-DD-retro.md` with the retro output above.
+
+**Do not continue to /nano.** Retro is a standalone reflection, not a sprint kickoff. If the user wants to act on the recommendation, they start a new `/think` or `/think --autopilot` with the suggested next sprint.
+
+**End of retro mode.** The sections below are for the normal forward-looking /think process.
+
+---
 
 ## Session
 
@@ -161,17 +221,75 @@ Immediately after writing the Think Summary — before anything else, before pre
 
 This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action.
 
-**Next phase.**
+### Phase 6.5: Think Brief (shareable)
 
-If `--autopilot` was used (or the user said "autopilot", "run everything", "ship it end to end"):
+Save a clean markdown brief to `.nanostack/know-how/briefs/`. This is a human-readable version of the Think Summary that the user can share with their team, open in Obsidian, or paste into a doc.
+
+Write the brief file directly (do not use save-artifact.sh — this is a markdown doc, not a JSON artifact):
+
+```bash
+mkdir -p .nanostack/know-how/briefs
+```
+
+Write a file named `YYYY-MM-DD-<slug>.md` (slug from the value proposition) with this format:
+
+```markdown
+# Think Brief: <value proposition short title>
+
+**Date:** YYYY-MM-DD
+**Mode:** Startup / Builder / Founder
+**Scope:** Expand / Hold / Reduce
+
+## Value Proposition
+<one sentence>
+
+## Target User
+<who specifically, and why they'd use a broken v1>
+
+## Narrowest Wedge
+<the smallest thing that delivers value>
+
+## Key Risk
+<the one thing most likely to make this fail>
+
+## What We Decided NOT to Build
+<out of scope items from the diagnostic>
+
+## Premise
+<validated or not — and the argument that tested it>
+```
+
+Keep it under 20 lines. No filler, no headers without content. Skip sections that don't apply (e.g., skip "What We Decided NOT to Build" if nothing was excluded).
+
+### Phase 7: Next Step
+
+**If `--autopilot` was used** (or the user said "autopilot", "run everything", "ship it end to end"):
 
 > Autopilot active. Proceeding with the full sprint: /nano, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
 
 Then proceed directly to `/nano` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
 
-Otherwise:
+**Otherwise, check if this is an early sprint** (first or second for this project):
 
-> Ready for `/nano`. Say `/nano` to create the implementation plan, or adjust the brief first.
+```bash
+ls .nanostack/sessions/ 2>/dev/null | wc -l
+```
+
+If 0 or 1 archived sessions (new user), show the sprint guide:
+
+> Your brief is ready. Here's the full sprint:
+>
+> 1. `/nano` — I turn this into concrete steps with file names and risks
+> 2. Build the feature
+> 3. `/review` — two-pass code review (structure + adversarial edge cases)
+> 4. `/security` — OWASP audit + secrets scan
+> 5. `/ship` — PR, CI verification, sprint journal
+>
+> Or say `/think --autopilot` next time and I run everything after you approve the brief.
+
+If 2+ archived sessions (returning user), keep it short:
+
+> Ready for `/nano`. Say `/nano` to plan, or adjust the brief first.
 
 Wait for the user to invoke `/nano`.
 
@@ -182,3 +300,5 @@ Wait for the user to invoke `/nano`.
 - **/think produces a brief, not a plan.** If you're writing implementation steps, hand off to /nano.
 - **Calibrate intensity by mode.** Founder pushes hard. Builder respects stated pain.
 - **"Fix this bug" doesn't need six forcing questions.** Skip to the brief when the user already knows what they want.
+- **Always save the brief file.** The markdown brief in `.nanostack/know-how/briefs/` is as important as the JSON artifact. Users share briefs with their team.
+- **--retro is standalone.** It does not start a new sprint or invoke /nano. It's a reflection, not a kickoff.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: think
-description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the narrowest valuable wedge. Supports --autopilot to run the full sprint automatically after approval. Use --retro after a sprint to reflect on what shipped. Triggers on /think, /office-hours, /ceo-review.
+description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the smallest starting point. Supports --autopilot to run the full sprint automatically after approval. Use --retro after a sprint to reflect on what shipped. Triggers on /think, /office-hours, /ceo-review.
 concurrency: read
 depends_on: []
-summary: "Strategic product thinking. Challenges assumptions, finds narrowest valuable wedge, validates premise before planning."
+summary: "Strategic product thinking. Challenges assumptions, finds the smallest starting point, validates premise before planning."
 estimated_tokens: 450
 ---
 
@@ -135,7 +135,7 @@ Understand the landscape, then determine the mode.
 
 **If the user didn't provide an idea or problem** (e.g. they just said `/think` or `/think --autopilot` with no context), simply ask in your response: "What do you want to build?" Do NOT use `AskUserQuestion` for this. Just ask in plain text and wait for their reply.
 
-**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, wedge and risk. The user chose autopilot because they want speed, not a conversation.
+**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, starting point and risk. The user chose autopilot because they want speed, not a conversation.
 
 Determine the mode from the user's description:
 
@@ -146,7 +146,7 @@ Determine the mode from the user's description:
 
 **How to detect the mode:** If the user describes a personal pain ("I have this problem," "I need to..."), default to Startup or Builder. If the user pitches an idea for others ("I want to build X for Y market"), default to Startup. Only use Founder mode when the user asks for it or the context is clearly a high-stakes venture decision.
 
-**Local mode language:** Run `source bin/lib/git-context.sh && detect_git_mode`. If the result is `local` (no git repo), the user is likely non-technical. Adapt your language throughout the entire sprint: replace jargon with plain language. "Narrowest wedge" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs. Do NOT expose internal labels like "Phase 1", "Phase 1.5", "Startup mode", or "Builder mode" — these are your internal process, not something the user needs to see. Just do the work naturally.
+**Local mode language:** Run `source bin/lib/git-context.sh && detect_git_mode`. If the result is `local` (no git repo), the user is likely non-technical. Adapt your language throughout the entire sprint: replace jargon with plain language. "Starting point" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs. Do NOT expose internal labels like "Phase 1", "Phase 1.5", "Startup mode", or "Builder mode" — these are your internal process, not something the user needs to see. Just do the work naturally.
 
 ### Phase 1.5: Search Before Building
 
@@ -156,7 +156,7 @@ Read `think/references/search-before-building.md` and follow the instructions be
 
 #### Startup Mode — Six Forcing Questions
 
-Read `think/references/forcing-questions.md` and cover all six: Demand Reality, Status Quo, Desperate Specificity, Narrowest Wedge, Observation & Surprise, Future-Fit. Adapt order to conversation flow.
+Read `think/references/forcing-questions.md` and cover all six: Demand Reality, Status Quo, Desperate Specificity, Starting Point, Observation & Surprise, Future-Fit. Adapt order to conversation flow.
 
 Synthesize: What is the **one sentence** value proposition that survives all six questions?
 
@@ -183,7 +183,7 @@ Challenge the fundamental premise:
 
 > "The thing we haven't questioned is whether {{the core assumption}} is actually true."
 
-Apply CEO cognitive patterns from `think/references/cognitive-patterns.md` (Inversion, Customer Obsession, 10x vs 10%, Narrowest Wedge).
+Apply CEO cognitive patterns from `think/references/cognitive-patterns.md` (Inversion, Customer Obsession, 10x vs 10%, Starting Point).
 
 Then **argue the opposite**: construct the strongest case this should NOT be built. If the opposite argument is stronger, say so. If the original holds, it's battle-tested.
 
@@ -193,10 +193,10 @@ Based on the diagnostic, recommend one of four scope modes:
 
 | Mode | When to use | Behavior |
 |------|-------------|----------|
-| **Expand** | Strong demand signal, clear wedge, high conviction | Dream big. What's the full vision? |
+| **Expand** | Strong demand signal, clear starting point, high conviction | Dream big. What's the full vision? |
 | **Selective expand** | Good idea but some risk | Hold core scope + add 1-2 high-value extras |
 | **Hold** | Solid plan, no reason to change | Bulletproof the current scope |
-| **Reduce** | Weak demand signal, unclear wedge, too broad | Strip to absolute essentials |
+| **Reduce** | Weak demand signal, unclear starting point, too broad | Strip to absolute essentials |
 
 ### Phase 6: Handoff to /nano
 
@@ -208,7 +208,7 @@ Produce a clear brief for the next phase:
 **Value proposition:** {{one sentence}}
 **Scope mode:** {{Expand / Selective expand / Hold / Reduce}}
 **Target user:** {{who specifically}}
-**Narrowest wedge:** {{the smallest thing that delivers value}}
+**Starting point:** {{the smallest thing that delivers value}}
 **Key risk:** {{the one thing most likely to make this fail}}
 **Premise validated:** {{yes/no — and why}}
 ```
@@ -216,7 +216,7 @@ Produce a clear brief for the next phase:
 Immediately after writing the Think Summary — before anything else, before presenting next steps — save the artifact:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: X. Scope: Y. Wedge: Z. Risk: W. Premise: validated/not.'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: X. Scope: Y. Starting point: Z. Risk: W. Premise: validated/not.'
 ```
 
 This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action.
@@ -246,7 +246,7 @@ Write a file named `YYYY-MM-DD-<slug>.md` (slug from the value proposition) with
 ## Target User
 <who specifically, and why they'd use a broken v1>
 
-## Narrowest Wedge
+## Starting Point
 <the smallest thing that delivers value>
 
 ## Key Risk

--- a/think/references/forcing-questions.md
+++ b/think/references/forcing-questions.md
@@ -63,22 +63,22 @@ If nobody would use a broken v1, your v1 scope is wrong. Either narrow the audie
 
 ---
 
-## 4. Narrowest Wedge
+## 4. Starting Point
 
 **The question:** "What is the absolute minimum version that delivers the core value — and nothing else?"
 
 **How to find it:**
 1. List everything the product could do
 2. Cross out everything that isn't in the critical path of the one core value
-3. What's left? That's your wedge.
+3. What's left? That's your starting point.
 4. Now cross out half of what's left. Can it still work? If yes, you haven't narrowed enough.
 
 **Calibration:**
-- If your wedge takes more than 2 weeks to build, it's too wide
-- If your wedge has more than 3 features, it's too wide
-- If your wedge serves more than 1 user persona, it's too wide
+- If your starting point takes more than 2 weeks to build, it's too wide
+- If your starting point has more than 3 features, it's too wide
+- If your starting point serves more than 1 user persona, it's too wide
 
-**The test:** Can you describe the wedge in one sentence without using the word "and"?
+**The test:** Can you describe the starting point in one sentence without using the word "and"?
 
 **Manual delivery test:** Could you deliver this wedge by hand to one person today? No code, just you doing the work. If you can't describe the manual process (trigger, steps, tools, what you deliver), you don't understand the problem well enough to automate it. Build the process first, then the product.
 


### PR DESCRIPTION
## Summary

Three improvements to /think, the most popular skill based on user feedback:

- **Shareable think brief**: every /think saves a clean markdown doc to `.nanostack/know-how/briefs/`. Users can share it with their team, open in Obsidian, or paste into a doc. Format: value proposition, target user, narrowest wedge, key risk, premise validation. No JSON, no jargon.

- **Sprint guide for new users**: on the first 1-2 sprints, /think shows the full pipeline after the Think Summary (`/nano → build → /review → /security → /ship`). Returning users (2+ archived sessions) get the short "Ready for `/nano`" prompt. Detected via `ls .nanostack/sessions/ | wc -l`.

- **`/think --retro`**: retrospective mode that reads sprint journal, compound solutions, and pattern-report. Four questions: did we solve the right problem? what surprised us? what's recurring? what should the next sprint be? Saves a retro brief to `.nanostack/know-how/briefs/`. Standalone — doesn't start a new sprint or invoke /nano.

README updated with Think brief section (with example), Retro section (with example conversation), and sprint guide mention in Quick start.

## Test plan

- [x] 44/44 existing tests pass
- [x] think/SKILL.md code fences balanced (26 fences)
- [x] think/SKILL.md frontmatter valid (--- delimiters, name, description)
- [x] All scripts referenced in think/SKILL.md exist on disk
- [x] resolve.sh all phases still produce valid JSON
- [x] pattern-report.sh --json still works
- [x] README code fences balanced (70 fences)
- [x] --retro documented in skill description field (resolver routing)