### PR TITLE
Add know-how doctor and strengthen compiled truth rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ After shipping, run `/compound` to document what you learned:
 
 Next sprint, `/nano` automatically searches past solutions before planning. `/review` checks if current code follows documented resolutions. Solutions that reference files no longer on disk are ranked lower automatically.
 
-Solutions evolve over time. Each time `/compound` confirms a solution was applied, it increments `applied_count`, marks it `validated`, and appends a History entry. The rewritable sections (Problem, Solution, Prevention) get updated with new information. The History section is append-only evidence of how the understanding evolved. Validated solutions rank higher in search than untested ones.
+Solutions evolve over time. Each time `/compound` confirms a solution was applied, it increments `applied_count`, marks it `validated`, and rewrites the compiled truth (Problem, Solution, Prevention) to reflect the current best understanding. The History section is append-only evidence of how that understanding evolved. Validated solutions rank higher in search than untested ones.
 
 Search manually:
 
@@ -580,12 +580,15 @@ bin/token-report.sh            # token consumption per session and subagent
 bin/token-report.sh --all      # all projects with cost breakdown
 bin/pattern-report.sh          # recurring issues, risk accuracy, phase bottlenecks
 bin/graduate.sh --status       # graduation budget: rules per skill vs caps
+bin/doctor.sh                  # know-how health: stale, unused, unvalidated solutions
 bin/capture-learning.sh "..."  # append a learning to the knowledge base
 ```
 
 `token-report.sh` reads Claude Code's session logs and breaks down where tokens go. Cache-aware pricing (reads at 10%, creation at 125%). Flags runaway sessions and heavy subagents. Requires Claude Code; skips silently on other agents.
 
 `pattern-report.sh` detects patterns across sprints: which findings keep recurring, whether predicted risks materialized, which phases take the longest, and how often solutions get reused.
+
+`doctor.sh` checks know-how health: solutions referencing deleted files (stale), solutions never applied after 60 days (unused), solutions unvalidated after 90 days. Scores 0-10, reports issues, and `--fix` auto-removes stale entries. Run it periodically to keep the knowledge base clean.
 
 Every sprint lifecycle event is logged to `.nanostack/audit.log` (JSONL, append-only): session init, phase start/complete with duration, artifact saves, solution creation, graduation. When a sprint goes wrong, the audit trail shows exactly what happened and when.
 

--- a/bin/doctor.sh
+++ b/bin/doctor.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# doctor.sh — Know-how health check
+# Diagnoses the .nanostack/know-how/ directory for stale, unused,
+# or orphaned knowledge. Inspired by gbrain's dream cycle.
+#
+# Usage:
+#   doctor.sh              Human-readable report
+#   doctor.sh --json       Machine-readable output
+#   doctor.sh --fix        Auto-fix safe issues (remove stale refs, prune empty)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+SOLUTIONS_DIR="$NANOSTACK_STORE/know-how/solutions"
+DIARIZE_DIR="$NANOSTACK_STORE/know-how/diarizations"
+BRIEFS_DIR="$NANOSTACK_STORE/know-how/briefs"
+# Journal dir reserved for future checks
+
+JSON_OUTPUT=false
+FIX_MODE=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_OUTPUT=true ;;
+    --fix) FIX_MODE=true ;;
+  esac
+done
+
+NOW_EPOCH=$(date +%s 2>/dev/null || echo 0)
+SIXTY_DAYS=$((60 * 86400))
+NINETY_DAYS=$((90 * 86400))
+
+# ─── Helpers ────────────────────────────────────────────────
+
+# Cross-platform date-to-epoch (macOS + Linux)
+date_to_epoch() {
+  local d="$1"
+  if command -v gdate >/dev/null 2>&1; then
+    gdate -d "$d" +%s 2>/dev/null || echo 0
+  elif date -j -f "%Y-%m-%d" "$d" +%s >/dev/null 2>&1; then
+    date -j -f "%Y-%m-%d" "$d" +%s
+  else
+    date -d "$d" +%s 2>/dev/null || echo 0
+  fi
+}
+
+get_field() {
+  local file="$1" field="$2"
+  sed -n '/^---$/,/^---$/p' "$file" | grep -i "^${field}:" | head -1 | sed "s/^${field}: *//i"
+}
+
+# ─── Counters ───────────────────────────────────────────────
+
+TOTAL_SOLUTIONS=0
+STALE_SOLUTIONS=0
+UNUSED_SOLUTIONS=0
+UNVALIDATED_SOLUTIONS=0
+GRADUATION_CANDIDATES=0
+STALE_DIARIZATIONS=0
+TOTAL_DIARIZATIONS=0
+TOTAL_BRIEFS=0
+
+STALE_LIST=""
+UNUSED_LIST=""
+UNVALIDATED_LIST=""
+STALE_DIAR_LIST=""
+
+# ─── 1. Solution health ────────────────────────────────────
+
+if [ -d "$SOLUTIONS_DIR" ]; then
+  while IFS= read -r filepath; do
+    [ -z "$filepath" ] && continue
+    TOTAL_SOLUTIONS=$((TOTAL_SOLUTIONS + 1))
+
+    DATE=$(get_field "$filepath" "date")
+    VALIDATED=$(get_field "$filepath" "validated")
+    APPLIED=$(get_field "$filepath" "applied_count")
+    FM_FILES=$(get_field "$filepath" "files")
+    GRADUATED=$(get_field "$filepath" "graduated")
+    TYPE_DIR=$(basename "$(dirname "$filepath")")
+    BASENAME=$(basename "$filepath")
+
+    # Check stale: all referenced files gone
+    if [ -n "$FM_FILES" ] && [ "$FM_FILES" != "[]" ]; then
+      ALL_GONE=true
+      HAS_FILES=false
+      for ref_file in $(echo "$FM_FILES" | tr -d '[]"' | tr ',' ' '); do
+        ref_file=$(echo "$ref_file" | tr -d ' ' | sed 's/:.*$//')
+        [ -z "$ref_file" ] && continue
+        HAS_FILES=true
+        [ -f "$ref_file" ] && { ALL_GONE=false; break; }
+      done
+      if [ "$HAS_FILES" = true ] && [ "$ALL_GONE" = true ]; then
+        STALE_SOLUTIONS=$((STALE_SOLUTIONS + 1))
+        STALE_LIST="$STALE_LIST\n  $TYPE_DIR/$BASENAME — all referenced files deleted"
+      fi
+    fi
+
+    # Check unused: applied_count=0 and older than 60 days
+    APPLIED_NUM="${APPLIED:-0}"
+    if [ "$APPLIED_NUM" = "0" ] && [ -n "$DATE" ]; then
+      DOC_EPOCH=$(date_to_epoch "$DATE")
+      if [ "$DOC_EPOCH" -gt 0 ] && [ $((NOW_EPOCH - DOC_EPOCH)) -gt "$SIXTY_DAYS" ]; then
+        UNUSED_SOLUTIONS=$((UNUSED_SOLUTIONS + 1))
+        UNUSED_LIST="$UNUSED_LIST\n  $TYPE_DIR/$BASENAME — never applied, $(( (NOW_EPOCH - DOC_EPOCH) / 86400 )) days old"
+      fi
+    fi
+
+    # Check unvalidated: validated=false and older than 90 days
+    if [ "$VALIDATED" != "true" ] && [ -n "$DATE" ]; then
+      DOC_EPOCH=$(date_to_epoch "$DATE")
+      if [ "$DOC_EPOCH" -gt 0 ] && [ $((NOW_EPOCH - DOC_EPOCH)) -gt "$NINETY_DAYS" ]; then
+        UNVALIDATED_SOLUTIONS=$((UNVALIDATED_SOLUTIONS + 1))
+        UNVALIDATED_LIST="$UNVALIDATED_LIST\n  $TYPE_DIR/$BASENAME — unvalidated, $(( (NOW_EPOCH - DOC_EPOCH) / 86400 )) days old"
+      fi
+    fi
+
+    # Check graduation candidates
+    if [ "$GRADUATED" != "true" ] && [ "${APPLIED_NUM:-0}" -ge 3 ] && [ "$VALIDATED" = "true" ]; then
+      GRADUATION_CANDIDATES=$((GRADUATION_CANDIDATES + 1))
+    fi
+
+  done < <(find "$SOLUTIONS_DIR" -name "*.md" -type f 2>/dev/null | sort)
+fi
+
+# ─── 2. Diarization health ─────────────────────────────────
+
+if [ -d "$DIARIZE_DIR" ]; then
+  for dfile in "$DIARIZE_DIR"/*.md; do
+    [ -f "$dfile" ] || continue
+    TOTAL_DIARIZATIONS=$((TOTAL_DIARIZATIONS + 1))
+
+    D_DATE=$(get_field "$dfile" "date")
+    D_SUBJECT=$(get_field "$dfile" "subject")
+
+    if [ -n "$D_DATE" ]; then
+      D_EPOCH=$(date_to_epoch "$D_DATE")
+      AGE_DAYS=0
+      [ "$D_EPOCH" -gt 0 ] && AGE_DAYS=$(( (NOW_EPOCH - D_EPOCH) / 86400 ))
+
+      # Check if subject files were modified after diarization date
+      if [ -n "$D_SUBJECT" ]; then
+        TOUCHED=false
+        if [ -d "$D_SUBJECT" ]; then
+          LATEST_MOD=$(find "$D_SUBJECT" -type f -newer "$dfile" 2>/dev/null | head -1)
+          [ -n "$LATEST_MOD" ] && TOUCHED=true
+        elif [ -f "$D_SUBJECT" ]; then
+          [ "$D_SUBJECT" -nt "$dfile" ] && TOUCHED=true
+        fi
+        if [ "$TOUCHED" = true ]; then
+          STALE_DIARIZATIONS=$((STALE_DIARIZATIONS + 1))
+          STALE_DIAR_LIST="$STALE_DIAR_LIST\n  $(basename "$dfile") — subject modified since last diarization (${AGE_DAYS}d old)"
+        fi
+      fi
+    fi
+  done
+fi
+
+# ─── 3. Brief health ───────────────────────────────────────
+
+if [ -d "$BRIEFS_DIR" ]; then
+  TOTAL_BRIEFS=$(find "$BRIEFS_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+fi
+
+# ─── 4. Score ───────────────────────────────────────────────
+
+ISSUES=$((STALE_SOLUTIONS + UNUSED_SOLUTIONS + UNVALIDATED_SOLUTIONS + STALE_DIARIZATIONS))
+if [ "$TOTAL_SOLUTIONS" -eq 0 ]; then
+  SCORE="N/A"
+  GRADE="no data"
+elif [ "$ISSUES" -eq 0 ]; then
+  SCORE="10/10"
+  GRADE="healthy"
+elif [ "$ISSUES" -le 2 ]; then
+  SCORE="8/10"
+  GRADE="good"
+elif [ "$ISSUES" -le 5 ]; then
+  SCORE="6/10"
+  GRADE="needs attention"
+else
+  SCORE="4/10"
+  GRADE="unhealthy"
+fi
+
+# ─── Output ─────────────────────────────────────────────────
+
+if $JSON_OUTPUT; then
+  jq -n \
+    --arg score "$SCORE" \
+    --arg grade "$GRADE" \
+    --argjson total_solutions "$TOTAL_SOLUTIONS" \
+    --argjson stale "$STALE_SOLUTIONS" \
+    --argjson unused "$UNUSED_SOLUTIONS" \
+    --argjson unvalidated "$UNVALIDATED_SOLUTIONS" \
+    --argjson graduation_candidates "$GRADUATION_CANDIDATES" \
+    --argjson total_diarizations "$TOTAL_DIARIZATIONS" \
+    --argjson stale_diarizations "$STALE_DIARIZATIONS" \
+    --argjson total_briefs "$TOTAL_BRIEFS" \
+    --argjson issues "$ISSUES" \
+    '{
+      score: $score,
+      grade: $grade,
+      solutions: { total: $total_solutions, stale: $stale, unused: $unused, unvalidated: $unvalidated, graduation_candidates: $graduation_candidates },
+      diarizations: { total: $total_diarizations, stale: $stale_diarizations },
+      briefs: { total: $total_briefs },
+      issues: $issues
+    }'
+  exit 0
+fi
+
+echo ""
+echo "Know-how Health: $SCORE ($GRADE)"
+echo "════════════════════════════════"
+echo ""
+echo "  Solutions: $TOTAL_SOLUTIONS total"
+
+if [ "$STALE_SOLUTIONS" -gt 0 ]; then
+  echo "  Stale ($STALE_SOLUTIONS): all referenced files deleted"
+  printf "$STALE_LIST\n"
+fi
+
+if [ "$UNUSED_SOLUTIONS" -gt 0 ]; then
+  echo "  Unused ($UNUSED_SOLUTIONS): never applied, 60+ days old"
+  printf "$UNUSED_LIST\n"
+fi
+
+if [ "$UNVALIDATED_SOLUTIONS" -gt 0 ]; then
+  echo "  Unvalidated ($UNVALIDATED_SOLUTIONS): not validated, 90+ days old"
+  printf "$UNVALIDATED_LIST\n"
+fi
+
+if [ "$GRADUATION_CANDIDATES" -gt 0 ]; then
+  echo "  Ready to graduate: $GRADUATION_CANDIDATES (run graduate.sh)"
+fi
+
+if [ "$TOTAL_SOLUTIONS" -gt 0 ] && [ "$STALE_SOLUTIONS" -eq 0 ] && [ "$UNUSED_SOLUTIONS" -eq 0 ] && [ "$UNVALIDATED_SOLUTIONS" -eq 0 ]; then
+  echo "  All solutions healthy."
+fi
+
+echo ""
+echo "  Diarizations: $TOTAL_DIARIZATIONS total"
+if [ "$STALE_DIARIZATIONS" -gt 0 ]; then
+  echo "  Stale ($STALE_DIARIZATIONS): subject modified since last run"
+  printf "$STALE_DIAR_LIST\n"
+elif [ "$TOTAL_DIARIZATIONS" -gt 0 ]; then
+  echo "  All diarizations current."
+fi
+
+echo ""
+echo "  Briefs: $TOTAL_BRIEFS total"
+
+echo ""
+
+# ─── Fix mode ───────────────────────────────────────────────
+
+if $FIX_MODE && [ "$ISSUES" -gt 0 ]; then
+  echo "Fixes applied:"
+
+  # Remove stale solutions (all files gone = solution is noise)
+  if [ "$STALE_SOLUTIONS" -gt 0 ] && [ -d "$SOLUTIONS_DIR" ]; then
+    while IFS= read -r filepath; do
+      [ -z "$filepath" ] && continue
+      FM_FILES=$(get_field "$filepath" "files")
+      [ -z "$FM_FILES" ] || [ "$FM_FILES" = "[]" ] && continue
+      ALL_GONE=true
+      for ref_file in $(echo "$FM_FILES" | tr -d '[]"' | tr ',' ' '); do
+        ref_file=$(echo "$ref_file" | tr -d ' ' | sed 's/:.*$//')
+        [ -z "$ref_file" ] && continue
+        [ -f "$ref_file" ] && { ALL_GONE=false; break; }
+      done
+      if [ "$ALL_GONE" = true ]; then
+        echo "  Removed stale: $(basename "$(dirname "$filepath")")/$(basename "$filepath")"
+        rm -f "$filepath"
+      fi
+    done < <(find "$SOLUTIONS_DIR" -name "*.md" -type f 2>/dev/null)
+  fi
+
+  echo ""
+fi

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -63,12 +63,12 @@ If a closely related solution exists:
 Do not create duplicates. One good document beats two partial ones.
 
 **When updating an existing solution, evolve it:**
-1. Update the rewritable sections (Problem, Solution, Prevention, etc.) if the new information improves them
+1. **Rewrite the compiled truth.** Read the current Problem, Solution, and Prevention sections. Do they reflect what you know NOW, or what you knew when the document was created? If the new sprint changed your understanding, rewrite these sections completely — don't append to them. The compiled truth must always reflect the current best understanding, not a history of partial fixes.
 2. Increment `applied_count` in the frontmatter
 3. Set `validated: true` and `last_validated` to today's date
 4. Append a `### YYYY-MM-DD — Context` entry to the `## History` section at the bottom, documenting what happened in this sprint and what changed
 
-The History section is append-only. The sections above it are rewritable. This way solutions get better with each sprint while preserving the evidence trail of how the understanding evolved.
+**Compiled truth is rewritten. Timeline is appended.** The sections above History always reflect the latest understanding. The History section is the immutable evidence trail of how that understanding evolved. If old information was wrong, rewrite the compiled truth — don't leave stale text. The History entry records what changed and why.
 
 ### 4. Write solution documents
 


### PR DESCRIPTION
## Summary

Two patterns from gbrain's dream cycle, adapted to nanostack's file-based architecture:

- **Know-how doctor** (`bin/doctor.sh`): health check for `.nanostack/know-how/`. Diagnoses stale solutions (referenced files deleted), unused solutions (never applied, 60+ days old), unvalidated solutions (90+ days), and surfaces graduation candidates. Scores 0-10 with grade. Three modes: human-readable, `--json`, `--fix` (auto-removes stale entries). Cross-platform date parsing (macOS BSD + Linux).

- **Compiled truth rule**: strengthened in compound/SKILL.md. When updating a solution, the rewritable sections (Problem, Solution, Prevention) must be rewritten to reflect the current best understanding, not appended to. The History section is the immutable evidence trail. Matches gbrain's strict "compiled truth is rewritten, timeline is appended" pattern.

## Test plan

- [x] 44/44 existing tests pass
- [x] `bash -n` syntax check
- [x] Zero shellcheck errors
- [x] doctor.sh with no data: score N/A, no crash
- [x] doctor.sh with stale solution: detected, reported
- [x] doctor.sh with unused solution: detected (60+ days, applied_count=0)
- [x] doctor.sh with unvalidated solution: detected (90+ days)
- [x] doctor.sh with healthy solution: no false positive
- [x] doctor.sh --fix: removes stale, re-scores correctly
- [x] doctor.sh --json: valid JSON output
- [x] macOS date parsing works (date -j -f fallback)
- [x] README code fences balanced
- [x] compound/SKILL.md code fences balanced