### PR TITLE
Add failure capture, confidence scoring, and journey memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Agent:  Reading sprint data...
         checks — same gate pattern, broader coverage.
 ```
 
-Retro reads the sprint journal, compound solutions, and pattern report. It applies the same forcing questions to what was built, not what will be built. It doesn't start a new sprint — it's standalone reflection.
+Retro reads the sprint journal, compound solutions, pattern report, and git metrics (`bin/sprint-metrics.sh` — commits, lines changed, cycle time per phase). It applies the same forcing questions to what was built, not what will be built. It doesn't start a new sprint — it's standalone reflection.
 
 ## Autopilot
 
@@ -593,6 +593,7 @@ bin/token-report.sh --all      # all projects with cost breakdown
 bin/pattern-report.sh          # recurring issues, risk accuracy, phase bottlenecks
 bin/graduate.sh --status       # graduation budget: rules per skill vs caps
 bin/doctor.sh                  # know-how health: stale, unused, unvalidated solutions
+bin/sprint-metrics.sh          # git stats + cycle time per phase (used by /think --retro)
 bin/capture-learning.sh "..."  # append a learning to the knowledge base
 ```
 

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ bin/token-report.sh --all      # all projects with cost breakdown
 bin/pattern-report.sh          # recurring issues, risk accuracy, phase bottlenecks
 bin/graduate.sh --status       # graduation budget: rules per skill vs caps
 bin/doctor.sh                  # know-how health: stale, unused, unvalidated solutions
-bin/sprint-metrics.sh          # git stats + cycle time per phase (used by /think --retro)
+bin/sprint-metrics.sh          # git stats + cycle time per phase (used by /think --retro and /nano)
 bin/capture-learning.sh "..."  # append a learning to the knowledge base
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Validated — scanner finds problems after they exist, gate prevents them.
 
 The brief answers: what are we building, for whom, why this scope, and what could go wrong. Share it before writing code.
 
+On your second sprint onward, `/think` reads your last 3 briefs and the latest retro. Instead of starting from zero, it opens with context: "Last sprints: webhook signature gate, IAM role checks. The retro recommended rate limiting. What are we working on next?"
+
 ## Retro
 
 After a sprint, use `/think --retro` to reflect on what shipped:
@@ -522,7 +524,7 @@ After shipping, run `/compound` to document what you learned:
 
 Next sprint, `/nano` automatically searches past solutions before planning. `/review` checks if current code follows documented resolutions. Solutions that reference files no longer on disk are ranked lower automatically.
 
-Solutions evolve over time. Each time `/compound` confirms a solution was applied, it increments `applied_count`, marks it `validated`, and rewrites the compiled truth (Problem, Solution, Prevention) to reflect the current best understanding. The History section is append-only evidence of how that understanding evolved. Validated solutions rank higher in search than untested ones.
+Solutions evolve over time. Each time `/compound` confirms a solution was applied, it increments `applied_count`, marks it `validated`, adjusts `confidence` (1-10 scale: +2 if it worked perfectly, -2 if it failed), and rewrites the compiled truth (Problem, Solution, Prevention) to reflect the current best understanding. The History section is append-only evidence of how that understanding evolved. Solutions are ranked by confidence, validation status, severity, and recency — high-confidence proven solutions surface first.
 
 Search manually:
 
@@ -532,6 +534,16 @@ bin/find-solution.sh --type bug              # by type
 bin/find-solution.sh --tag security          # by tag
 bin/find-solution.sh --file src/api/webhooks # by file
 ```
+
+### Failure capture
+
+`/compound` captures what worked. Failures get captured too — automatically, without waiting for a successful ship.
+
+```bash
+bin/capture-failure.sh review "scope-drift.sh failed" "manual file comparison" "save plan artifact first"
+```
+
+Appends to `.nanostack/know-how/learnings/failures.jsonl`. Every skill can call this when something goes wrong: CLI errors, wrong approaches, project quirks. Next sprint, the same mistake is avoided. No `/compound` needed, no success needed — just log and move on.
 
 ### Skill graduation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -116,6 +116,11 @@ Per-skill configs (`security/config.json`, `guard/config.json`) store skill-spec
 
 - **Read before acting.** Every skill must read the relevant code/diff/config before producing output. Never analyze blind.
 - **Boil the lake, not the ocean.** When completeness costs minutes more than shortcuts, do the complete thing. When it costs days, don't.
+- **Log failures, not just successes.** When something goes wrong during a skill (script error, wrong approach, unexpected project behavior), capture it:
+  ```bash
+  ~/.claude/skills/nanostack/bin/capture-failure.sh <skill> "<what went wrong>" "<what was tried>" "<what fixed it>"
+  ```
+  Failures compound into knowledge. Next sprint, the same mistake is avoided. This does not require /compound or a successful ship — just log and move on.
 
 ## Proactive Triggers
 

--- a/bin/capture-failure.sh
+++ b/bin/capture-failure.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# capture-failure.sh — Log a failure for future sprints to learn from
+# Unlike /compound (which captures successes after ship), this captures
+# what went wrong — CLI errors, wrong approaches, project quirks.
+#
+# Usage: capture-failure.sh <skill> <error> [approach] [resolution]
+#   skill:      which skill was running (review, security, qa, etc.)
+#   error:      what went wrong (one line)
+#   approach:   what was tried (optional)
+#   resolution: what fixed it or what to try next (optional)
+#
+# Appends to .nanostack/know-how/learnings/failures.jsonl (append-only).
+# No compound needed. No success needed. Just log and move on.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/audit.sh"
+
+SKILL="${1:?Usage: capture-failure.sh <skill> <error> [approach] [resolution]}"
+ERROR="${2:?Missing error description}"
+APPROACH="${3:-}"
+RESOLUTION="${4:-}"
+
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+PROJECT=$(basename "$(pwd)")
+
+FAILURES_DIR="$NANOSTACK_STORE/know-how/learnings"
+FAILURES_FILE="$FAILURES_DIR/failures.jsonl"
+
+mkdir -p "$FAILURES_DIR"
+
+jq -nc \
+  --arg date "$DATE" \
+  --arg skill "$SKILL" \
+  --arg error "$ERROR" \
+  --arg approach "$APPROACH" \
+  --arg resolution "$RESOLUTION" \
+  --arg project "$PROJECT" \
+  '{
+    date: $date,
+    skill: $skill,
+    error: $error,
+    approach: (if $approach != "" then $approach else null end),
+    resolution: (if $resolution != "" then $resolution else null end),
+    project: $project
+  }' >> "$FAILURES_FILE"
+
+audit_log "failure_captured" "$SKILL" "$ERROR"
+echo "Captured in $FAILURES_FILE"

--- a/bin/find-solution.sh
+++ b/bin/find-solution.sh
@@ -145,6 +145,14 @@ while IFS= read -r filepath; do
       SCORE=$((SCORE + BONUS))
     fi
 
+    # Confidence bonus: scale by confidence (1-10, default 5)
+    CONFIDENCE=$(get_field "$filepath" "confidence")
+    if [ -n "$CONFIDENCE" ] && [ "$CONFIDENCE" != "0" ]; then
+      # Confidence 5 = neutral (+0), 8 = +3, 10 = +5, 2 = -3
+      CONF_BONUS=$((CONFIDENCE - 5))
+      SCORE=$((SCORE + CONF_BONUS))
+    fi
+
     # Unvalidated penalty: -1 if >60 days old and never validated
     if [ "$VALIDATED" != "true" ] && [ -n "$DATE" ]; then
       DOC_EPOCH_V=$($DATE_CMD -d "$DATE" +%s 2>/dev/null || echo 0)

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -210,6 +210,16 @@ if [ -f "$SESSION_FILE" ]; then
   [ -n "$SESSION_GOAL" ] && GOAL="\"$SESSION_GOAL\""
 fi
 
+# ─── 7. Load sprint metrics (plan + compound phases) ───────
+
+METRICS_JSON="null"
+if [ "$PHASE" = "plan" ] || [ "$PHASE" = "compound" ]; then
+  METRICS_SH="$SCRIPT_DIR/sprint-metrics.sh"
+  if [ -x "$METRICS_SH" ]; then
+    METRICS_JSON=$("$METRICS_SH" 2>/dev/null) || METRICS_JSON="null"
+  fi
+fi
+
 # ─── Output ─────────────────────────────────────────────────
 
 jq -n \
@@ -220,6 +230,7 @@ jq -n \
   --argjson diarizations "$DIARIZATIONS_JSON" \
   --argjson config "$CONFIG_JSON" \
   --argjson goal "$GOAL" \
+  --argjson metrics "$METRICS_JSON" \
   '{
     phase: $phase,
     upstream_artifacts: $artifacts,
@@ -227,5 +238,6 @@ jq -n \
     conflict_precedents: $precedents,
     diarizations: $diarizations,
     config: $config,
-    goal: $goal
+    goal: $goal,
+    sprint_metrics: $metrics
   }'

--- a/bin/save-solution.sh
+++ b/bin/save-solution.sh
@@ -57,6 +57,7 @@ project: $PROJECT
 files: []
 tags: $TAGS_YAML
 severity: medium
+confidence: 5
 validated: false
 last_validated: null
 applied_count: 0

--- a/bin/sprint-metrics.sh
+++ b/bin/sprint-metrics.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# sprint-metrics.sh — Deterministic git + session metrics for /think --retro
+# Outputs JSON with lines changed, commits, files touched, cycle time, phase durations.
+# No model judgment. Just data.
+#
+# Usage: sprint-metrics.sh [--days N]
+#   --days N: look back N days (default: 7)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+DAYS=7
+for arg in "$@"; do
+  case "$arg" in
+    --days) shift; DAYS="${1:-7}"; shift ;;
+  esac
+done
+
+# ─── Git metrics ────────────────────────────────────────────
+
+COMMITS=0
+LINES_ADDED=0
+LINES_REMOVED=0
+FILES_CHANGED=0
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  COMMITS=$(git log --oneline --since="${DAYS} days ago" 2>/dev/null | wc -l | tr -d ' ')
+
+  DIFFSTAT=$(git log --since="${DAYS} days ago" --format= --numstat 2>/dev/null | awk '
+    { added += $1; removed += $2; files++ }
+    END { printf "%d %d %d", added, removed, files }
+  ' 2>/dev/null) || DIFFSTAT="0 0 0"
+
+  LINES_ADDED=$(echo "$DIFFSTAT" | awk '{print $1}')
+  LINES_REMOVED=$(echo "$DIFFSTAT" | awk '{print $2}')
+  FILES_CHANGED=$(echo "$DIFFSTAT" | awk '{print $3}')
+fi
+
+# ─── Session cycle time ────────────────────────────────────
+
+TOTAL_DURATION=0
+SLOWEST_PHASE=""
+SLOWEST_DURATION=0
+PHASE_DURATIONS="{}"
+
+# Read from most recent archived session + current session
+SESSIONS=""
+[ -f "$NANOSTACK_STORE/session.json" ] && SESSIONS="$NANOSTACK_STORE/session.json"
+if [ -d "$NANOSTACK_STORE/sessions" ]; then
+  LATEST_ARCHIVED=$(ls -t "$NANOSTACK_STORE/sessions"/*.json 2>/dev/null | head -1)
+  [ -n "$LATEST_ARCHIVED" ] && SESSIONS="$LATEST_ARCHIVED $SESSIONS"
+fi
+
+if [ -n "$SESSIONS" ]; then
+  # Read the most recent session with completed phases
+  for sf in $SESSIONS; do
+    [ -f "$sf" ] || continue
+    HAS_COMPLETED=$(jq -r '[.phase_log[]? | select(.status=="completed")] | length' "$sf" 2>/dev/null)
+    [ "${HAS_COMPLETED:-0}" -gt 0 ] || continue
+
+    PHASE_DURATIONS=$(jq -c '[.phase_log[]? | select(.status=="completed" and .duration_seconds > 0) | {(.phase): .duration_seconds}] | add // {}' "$sf" 2>/dev/null) || PHASE_DURATIONS="{}"
+
+    TOTAL_DURATION=$(jq -r '[.phase_log[]? | select(.status=="completed") | .duration_seconds // 0] | add // 0' "$sf" 2>/dev/null) || TOTAL_DURATION=0
+
+    SLOWEST=$(jq -r '.phase_log[] | select(.status=="completed" and .duration_seconds > 0) | "\(.duration_seconds) \(.phase)"' "$sf" 2>/dev/null | sort -rn | head -1)
+    if [ -n "$SLOWEST" ]; then
+      SLOWEST_DURATION=$(echo "$SLOWEST" | awk '{print $1}')
+      SLOWEST_PHASE=$(echo "$SLOWEST" | awk '{print $2}')
+    fi
+
+    break  # Use the most recent session with data
+  done
+fi
+
+# ─── Output ─────────────────────────────────────────────────
+
+jq -n \
+  --argjson days "$DAYS" \
+  --argjson commits "$COMMITS" \
+  --argjson lines_added "$LINES_ADDED" \
+  --argjson lines_removed "$LINES_REMOVED" \
+  --argjson files_changed "$FILES_CHANGED" \
+  --argjson total_duration "$TOTAL_DURATION" \
+  --arg slowest_phase "$SLOWEST_PHASE" \
+  --argjson slowest_duration "$SLOWEST_DURATION" \
+  --argjson phase_durations "$PHASE_DURATIONS" \
+  '{
+    period_days: $days,
+    git: {
+      commits: $commits,
+      lines_added: $lines_added,
+      lines_removed: $lines_removed,
+      files_changed: $files_changed
+    },
+    cycle_time: {
+      total_seconds: $total_duration,
+      slowest_phase: $slowest_phase,
+      slowest_seconds: $slowest_duration,
+      per_phase: $phase_durations
+    }
+  }'

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -66,7 +66,8 @@ Do not create duplicates. One good document beats two partial ones.
 1. **Rewrite the compiled truth.** Read the current Problem, Solution, and Prevention sections. Do they reflect what you know NOW, or what you knew when the document was created? If the new sprint changed your understanding, rewrite these sections completely — don't append to them. The compiled truth must always reflect the current best understanding, not a history of partial fixes.
 2. Increment `applied_count` in the frontmatter
 3. Set `validated: true` and `last_validated` to today's date
-4. Append a `### YYYY-MM-DD — Context` entry to the `## History` section at the bottom, documenting what happened in this sprint and what changed
+4. **Adjust confidence** (1-10 scale): if the solution worked perfectly this sprint → set to current + 2 (cap 10). If it worked with adjustments → keep current. If it failed or needed major changes → set to current - 2 (floor 1). Confidence determines search ranking: high-confidence solutions surface first.
+5. Append a `### YYYY-MM-DD — Context` entry to the `## History` section at the bottom, documenting what happened in this sprint and what changed
 
 **Compiled truth is rewritten. Timeline is appended.** The sections above History always reflect the latest understanding. The History section is the immutable evidence trail of how that understanding evolved. If old information was wrong, rewrite the compiled truth — don't leave stale text. The History entry records what changed and why.
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -37,9 +37,10 @@ Then run `session.sh phase-start plan`.
   ```bash
   ~/.claude/skills/nanostack/bin/resolve.sh plan
   ```
-  The output is JSON with `upstream_artifacts` (think artifact path if recent), `solutions` (ranked matches), and `config`. Use what's relevant:
+  The output is JSON with `upstream_artifacts` (think artifact path if recent), `solutions` (ranked matches), `config`, and `sprint_metrics` (git stats + cycle time from last sprint). Use what's relevant:
   - If a think artifact exists, read it and extract: `key_risk` → add to Risks. `narrowest_wedge` (starting point) → scope constraint. `out_of_scope` → pre-populate Out of Scope. `scope_mode` → if "reduce," plan smallest version. `premise_validated` → if false, flag it.
   - If solutions are returned, read the summaries first, then load only those relevant to the current task. Past mistakes and patterns should inform the sprint.
+  - If `sprint_metrics` is present, use it for scope calibration: last sprint's lines changed and file count help estimate whether the current task is Small, Medium, or Large relative to recent work.
 
   **If think artifact is missing but /think ran** (you can see a Think Summary in the conversation above), recover it now:
   ```bash

--- a/reference/solution-schema.md
+++ b/reference/solution-schema.md
@@ -24,6 +24,7 @@ All solutions share these fields:
 | files | No | string[] | File paths involved |
 | tags | No | string[] | Keywords for search |
 | severity | No | `critical`, `high`, `medium`, `low` | Impact level |
+| confidence | No | integer (1-10) | How reliable this solution is. Default 5. Adjusted by /compound: +2 on perfect application, -2 on failure. Affects search ranking. |
 | validated | No | boolean | Whether the solution has been confirmed to work |
 | last_validated | No | YYYY-MM-DD | Last date the solution was applied and confirmed |
 | applied_count | No | integer | Number of sprints that applied this solution |

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -67,15 +67,10 @@ If no sprint data exists (no artifacts, no journal, no sessions), tell the user:
 **1b. Gather git metrics:**
 
 ```bash
-# Lines changed in last sprint (commits since last session start)
-git log --oneline --since="7 days ago" --format="%h" | wc -l
-git diff --stat HEAD~10 2>/dev/null | tail -1
-
-# Cycle time: read session phase_log durations
-cat .nanostack/sessions/*.json 2>/dev/null | jq -r '.phase_log[]? | select(.status=="completed") | "\(.phase): \(.duration_seconds)s"' | tail -20
+~/.claude/skills/nanostack/bin/sprint-metrics.sh
 ```
 
-Use these numbers in your diagnostic. Lines changed gives scale. Phase durations reveal bottlenecks (review took 5 minutes but security took 45 = something to investigate). Commit frequency shows velocity.
+The output is JSON with `git` (commits, lines added/removed, files changed) and `cycle_time` (total seconds, slowest phase, per-phase durations). Use these numbers in your diagnostic. Lines changed gives scale. Phase durations reveal bottlenecks. Commit frequency shows velocity.
 
 **2. Retro diagnostic — four questions:**
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -64,6 +64,19 @@ ls -t .nanostack/know-how/journal/*.md 2>/dev/null | head -1
 
 If no sprint data exists (no artifacts, no journal, no sessions), tell the user: "No sprint data found. Run a sprint first, then come back with `/think --retro`." Stop here.
 
+**1b. Gather git metrics:**
+
+```bash
+# Lines changed in last sprint (commits since last session start)
+git log --oneline --since="7 days ago" --format="%h" | wc -l
+git diff --stat HEAD~10 2>/dev/null | tail -1
+
+# Cycle time: read session phase_log durations
+cat .nanostack/sessions/*.json 2>/dev/null | jq -r '.phase_log[]? | select(.status=="completed") | "\(.phase): \(.duration_seconds)s"' | tail -20
+```
+
+Use these numbers in your diagnostic. Lines changed gives scale. Phase durations reveal bottlenecks (review took 5 minutes but security took 45 = something to investigate). Commit frequency shows velocity.
+
 **2. Retro diagnostic — four questions:**
 
 Apply the same rigor as the forward-looking diagnostic, but to what was shipped:
@@ -71,7 +84,7 @@ Apply the same rigor as the forward-looking diagnostic, but to what was shipped:
 | # | Question | What to read |
 |---|----------|-------------|
 | 1 | **Did we solve the right problem?** Re-read the think artifact's value proposition. Does the shipped code actually address it, or did scope drift change the product? | Think artifact + ship artifact |
-| 2 | **What surprised us?** Which review/security/qa findings were unexpected? Which risks from the plan materialized and which didn't? | Review + security + qa artifacts, pattern-report risk accuracy |
+| 2 | **What surprised us?** Which review/security/qa findings were unexpected? Which risks materialized? Did cycle time or lines changed deviate from what the plan estimated? | Review + security + qa artifacts, pattern-report risk accuracy, git metrics |
 | 3 | **What's recurring?** Are the same findings showing up across sprints? If pattern-report shows a tag appearing 3+ times, that's a systemic issue, not a one-off. | pattern-report.sh recurring findings |
 | 4 | **What should the next sprint be?** Based on what was shipped, what was deferred, and what broke — what's the highest-value next thing? | Out-of-scope from plan, unresolved findings, deferred risks |
 
@@ -82,6 +95,8 @@ Apply the same rigor as the forward-looking diagnostic, but to what was shipped:
 
 **Sprint:** <session ID or date>
 **Shipped:** <what was built, one sentence>
+**Scale:** <N commits, N lines changed, N files touched>
+**Cycle time:** <total duration, slowest phase and why>
 
 **Right problem?** <yes/no — and why>
 **Surprises:** <unexpected findings or outcomes>

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -103,6 +103,28 @@ Write to `.nanostack/know-how/briefs/YYYY-MM-DD-retro.md` with the retro output 
 
 ---
 
+## Journey Context
+
+Before starting the diagnostic, check if the user has prior sprint history in this project:
+
+```bash
+ls -t .nanostack/know-how/briefs/*.md 2>/dev/null | head -3
+```
+
+If briefs exist, read the last 3 (most recent first). Also check for a retro brief:
+
+```bash
+ls -t .nanostack/know-how/briefs/*retro*.md 2>/dev/null | head -1
+```
+
+If prior briefs exist, open with context before asking the user what they want to build:
+
+> Last sprints: <title from brief 1> (<date>), <title from brief 2> (<date>). <If retro exists: The retro recommended: <recommendation from retro brief>.> What are we working on next?
+
+If no briefs exist, skip this step — the user is new to the project.
+
+This turns /think from a stateless tool into a partner that remembers. The user doesn't have to re-explain context from prior sprints.
+
 ## Session
 
 Initialize the sprint session:


### PR DESCRIPTION
## Summary

Three patterns from gstack, adapted to nanostack's zero-dependency architecture:

- **Failure capture** (`bin/capture-failure.sh`): log what went wrong without waiting for `/compound` or a successful ship. Appends structured JSONL to `.nanostack/know-how/learnings/failures.jsonl`. Universal rule added to root SKILL.md so all skills know about it. Failures compound into knowledge — next sprint avoids the same mistake.

- **Confidence scoring**: solutions gain a `confidence` field (1-10, default 5). `/compound` adjusts it on each application: +2 if the solution worked perfectly, -2 if it failed. `find-solution.sh` adds confidence to search ranking: a confidence-8 solution scores +3, a confidence-2 scores -3. High-confidence proven solutions surface first.

- **Journey memory**: `/think` reads the last 3 think briefs and the latest retro brief before starting the diagnostic. Returning users get context: "Last sprints: webhook gate, IAM checks. Retro recommended rate limiting. What are we working on next?" Turns /think from a stateless tool into a partner that remembers.

## Test plan

- [x] 44/44 existing tests pass
- [x] `bash -n` syntax check on all modified scripts
- [x] Zero shellcheck errors
- [x] capture-failure.sh creates valid JSONL with all fields
- [x] save-solution.sh includes confidence: 5 in new solutions
- [x] find-solution.sh scoring includes confidence bonus
- [x] think/SKILL.md code fences balanced (30 fences)
- [x] compound/SKILL.md code fences balanced (20 fences)
- [x] README code fences balanced (72 fences)