### PR TITLE
Add loop guard for stalled autopilot and self-description generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Autopilot only stops if:
 - `/security` finds critical or high vulnerabilities
 - `/qa` tests fail
 - A product question comes up the agent can't answer from context
+- The loop guard detects 2+ phases with no repository changes (agent is stuck)
 
 Between steps the agent shows status:
 ```
@@ -594,6 +595,7 @@ bin/pattern-report.sh          # recurring issues, risk accuracy, phase bottlene
 bin/graduate.sh --status       # graduation budget: rules per skill vs caps
 bin/doctor.sh                  # know-how health: stale, unused, unvalidated solutions
 bin/sprint-metrics.sh          # git stats + cycle time per phase (used by /think --retro and /nano)
+bin/about.sh                   # generate .nanostack/ABOUT.md (compact self-description for any agent)
 bin/capture-learning.sh "..."  # append a learning to the knowledge base
 ```
 

--- a/bin/about.sh
+++ b/bin/about.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# about.sh — Generate compact self-description for agents
+# Writes .nanostack/ABOUT.md with skills, flow, key commands.
+# Any agent (Cursor, Codex, Claude Code) can read this to understand nanostack.
+#
+# Usage: about.sh          Generate/update ABOUT.md
+#        about.sh --print   Print to stdout instead of file
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRINT_ONLY=false
+[ "${1:-}" = "--print" ] && PRINT_ONLY=true
+
+# Count available data
+SOLUTIONS=$(find "$NANOSTACK_STORE/know-how/solutions" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+BRIEFS=$(find "$NANOSTACK_STORE/know-how/briefs" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+SESSIONS=$(find "$NANOSTACK_STORE/sessions" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
+HAS_CONFIG="no"
+[ -f "$NANOSTACK_STORE/config.json" ] && HAS_CONFIG="yes"
+
+DOC="# Nanostack
+
+Sprint quality framework. Turns your AI agent into an engineering team.
+
+## Flow
+
+\`\`\`
+/think → /nano → build → /review → /security → /qa → /ship
+\`\`\`
+
+## Skills
+
+| Command | What it does |
+|---------|-------------|
+| /think | Challenge assumptions, find the starting point. --autopilot for full sprint. --retro to reflect. |
+| /nano | Turn idea into implementation plan with file names and risks. |
+| /review | Two-pass code review: structural + adversarial. |
+| /security | OWASP Top 10 + STRIDE audit. |
+| /qa | Test the app: browser, API, CLI, or debug mode. |
+| /ship | Create PR, verify CI, generate sprint journal. |
+| /compound | Document what you learned. Runs after /ship. |
+| /guard | Safety guardrails. Blocks dangerous commands. |
+| /feature | Fast sprint: skips /think, runs plan through ship. |
+
+## Key Scripts
+
+| Script | What it does |
+|--------|-------------|
+| bin/resolve.sh <phase> | Load context for a phase (artifacts, solutions, config, goal). |
+| bin/session.sh init | Start a sprint session. Add --goal for business context. |
+| bin/find-solution.sh <query> | Search past solutions by keyword, tag, or file. |
+| bin/sprint-metrics.sh | Git stats + cycle time (used by /think --retro and /nano). |
+| bin/doctor.sh | Know-how health check. |
+| bin/capture-failure.sh | Log what went wrong (no /compound needed). |
+
+## State
+
+All data in \`.nanostack/\`:
+- Artifacts: \`.nanostack/<phase>/<timestamp>.json\`
+- Solutions: \`.nanostack/know-how/solutions/{bug,pattern,decision}/\`
+- Briefs: \`.nanostack/know-how/briefs/\`
+- Audit log: \`.nanostack/audit.log\`
+
+## This Project
+
+- Solutions: $SOLUTIONS
+- Briefs: $BRIEFS
+- Sprints completed: $SESSIONS
+- Configured: $HAS_CONFIG
+"
+
+if $PRINT_ONLY; then
+  echo "$DOC"
+else
+  mkdir -p "$NANOSTACK_STORE"
+  echo "$DOC" > "$NANOSTACK_STORE/ABOUT.md"
+  echo "$NANOSTACK_STORE/ABOUT.md"
+fi

--- a/bin/loop-guard.sh
+++ b/bin/loop-guard.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# loop-guard.sh — Detect stalled autopilot (no git diff between phases)
+# Tracks git state fingerprint. If two consecutive checks show no change,
+# the agent is stuck. Returns a warning block for the model to read.
+#
+# Usage: loop-guard.sh check     Check if stuck, return warning if yes
+#        loop-guard.sh snapshot   Save current git fingerprint
+#        loop-guard.sh reset      Clear tracked state
+#
+# Exit 0 always. Output is empty (no stall) or a warning block (stalled).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/audit.sh"
+
+STATE_FILE="$NANOSTACK_STORE/loop-guard.json"
+CMD="${1:-check}"
+
+# Git fingerprint: HEAD hash + working tree hash
+git_fingerprint() {
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local head diff_hash
+    head=$(git rev-parse HEAD 2>/dev/null || echo "none")
+    diff_hash=$(git diff HEAD 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+    echo "${head}:${diff_hash}"
+  else
+    echo "no-git"
+  fi
+}
+
+case "$CMD" in
+  snapshot)
+    FP=$(git_fingerprint)
+    jq -n --arg fp "$FP" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '{fingerprint: $fp, captured_at: $at, no_change_count: 0}' > "$STATE_FILE"
+    ;;
+
+  reset)
+    rm -f "$STATE_FILE"
+    ;;
+
+  check)
+    [ -f "$STATE_FILE" ] || exit 0
+
+    PREV_FP=$(jq -r '.fingerprint // ""' "$STATE_FILE" 2>/dev/null)
+    NO_CHANGE=$(jq -r '.no_change_count // 0' "$STATE_FILE" 2>/dev/null)
+    CURRENT_FP=$(git_fingerprint)
+
+    if [ "$CURRENT_FP" = "$PREV_FP" ]; then
+      NO_CHANGE=$((NO_CHANGE + 1))
+
+      # Update state
+      jq --arg fp "$CURRENT_FP" --argjson nc "$NO_CHANGE" \
+        --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '.fingerprint = $fp | .no_change_count = $nc | .last_check = $at' \
+        "$STATE_FILE" > "${STATE_FILE}.tmp"
+      mv "${STATE_FILE}.tmp" "$STATE_FILE"
+
+      if [ "$NO_CHANGE" -ge 2 ]; then
+        audit_log "loop_guard_triggered" "no_change_count=$NO_CHANGE"
+        cat <<'WARN'
+<LOOP_GUARD>
+The last 2+ phases produced no changes to the repository.
+You may be stuck. Before continuing:
+
+1. Check if the build actually ran (look for new/modified files)
+2. If blocked on something, stop and ask the user
+3. If the task is already done, mark it complete and move on
+
+Do NOT retry the same approach. Either fix the root cause or pause.
+</LOOP_GUARD>
+WARN
+      fi
+    else
+      # Progress detected — reset counter, update fingerprint
+      jq --arg fp "$CURRENT_FP" \
+        --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '.fingerprint = $fp | .no_change_count = 0 | .last_check = $at' \
+        "$STATE_FILE" > "${STATE_FILE}.tmp"
+      mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    fi
+    ;;
+
+  *)
+    echo "Usage: loop-guard.sh <check|snapshot|reset>" >&2
+    exit 1
+    ;;
+esac

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -80,6 +80,10 @@ cmd_init() {
     }' > "$SESSION_FILE"
 
   audit_log "session_init" "$session_id" "$type"
+
+  # Snapshot git state for loop guard
+  "$SCRIPT_DIR/loop-guard.sh" snapshot 2>/dev/null || true
+
   echo "$SESSION_FILE"
 }
 
@@ -200,6 +204,13 @@ cmd_phase_complete() {
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
   audit_log "phase_complete" "$phase" "${duration}s"
+
+  # Loop guard: check for stalled autopilot (no git changes between phases)
+  LOOP_WARN=$("$SCRIPT_DIR/loop-guard.sh" check 2>/dev/null || true)
+  if [ -n "$LOOP_WARN" ]; then
+    echo "$LOOP_WARN"
+  fi
+
   echo "OK: $phase completed"
 }
 


### PR DESCRIPTION
## Summary

Two patterns from codex-autorunner, adapted to nanostack:

- **Loop guard** (`bin/loop-guard.sh`): tracks git fingerprint (HEAD + working tree hash) between phases. If 2+ consecutive phase-completes show no repository changes, outputs a `<LOOP_GUARD>` warning telling the model to stop retrying and either fix the root cause or ask the user. Wired into `session.sh`: snapshot on init, check on every phase-complete. Prevents infinite autopilot loops.

- **Self-description** (`bin/about.sh`): generates `.nanostack/ABOUT.md` — compact self-description (~50 lines) with skills, flow, key scripts, state locations, and project stats. Any agent (Cursor, Codex, Claude Code) can read it to understand nanostack without loading full SKILL.md files.

## Test plan

- [x] 44/44 existing tests pass
- [x] `bash -n` syntax check on all 14 scripts
- [x] Zero shellcheck errors
- [x] Loop guard: no state = no warning
- [x] Loop guard: snapshot + 1st check = no warning
- [x] Loop guard: 2nd check same state = LOOP_GUARD warning
- [x] Loop guard: after git change = no warning (reset)
- [x] Loop guard: reset clears state file
- [x] about.sh --print: outputs to stdout
- [x] about.sh: creates .nanostack/ABOUT.md
- [x] README: loop guard in autopilot stop conditions
- [x] README: about.sh in analytics section
- [x] All SKILL.md code fences balanced