### PR TITLE
Add jq preflight, session lock, and resolver timeout

### DIFF
--- a/bin/find-solution.sh
+++ b/bin/find-solution.sh
@@ -10,6 +10,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+[ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 
 SOLUTIONS_DIR="$NANOSTACK_STORE/know-how/solutions"
 

--- a/bin/lib/preflight.sh
+++ b/bin/lib/preflight.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# preflight.sh — Verify required commands are available
+# Source this file early in scripts that depend on jq/git/etc.
+# Fails fast with a clear message instead of cryptic mid-execution errors.
+#
+# Usage:
+#   source "$SCRIPT_DIR/lib/preflight.sh"
+#   nanostack_require jq
+#   nanostack_require jq git
+#
+# To skip the check (e.g., for offline test envs), set NANOSTACK_SKIP_PREFLIGHT=1.
+
+nanostack_require() {
+  [ "${NANOSTACK_SKIP_PREFLIGHT:-0}" = "1" ] && return 0
+
+  local missing=""
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      missing="${missing:+$missing }$cmd"
+    fi
+  done
+
+  if [ -n "$missing" ]; then
+    echo "ERROR: nanostack requires the following commands but they were not found: $missing" >&2
+    echo "" >&2
+    for cmd in $missing; do
+      case "$cmd" in
+        jq)  echo "  jq:  brew install jq  |  apt install jq  |  choco install jq" >&2 ;;
+        git) echo "  git: https://git-scm.com/downloads" >&2 ;;
+        *)   echo "  $cmd: install via your package manager" >&2 ;;
+      esac
+    done
+    echo "" >&2
+    echo "Set NANOSTACK_SKIP_PREFLIGHT=1 to bypass this check (not recommended)." >&2
+    exit 127
+  fi
+}

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -14,6 +14,20 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+[ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
+
+# Portable timeout wrapper: gtimeout (coreutils on macOS) → timeout (Linux) → run as-is.
+# Used to bound expensive solution lookups so resolve.sh never hangs the sprint.
+_nano_timeout() {
+  local secs="$1"; shift
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  elif command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
 
 PHASE="${1:?Usage: resolve.sh <phase> [--diff]}"
 shift
@@ -111,7 +125,12 @@ $STAGED"
         # Search by each changed file path (take top 5 unique dirs)
         DIRS=$(echo "$DIFF_FILES" | xargs -I{} dirname {} 2>/dev/null | sort -u | head -5)
         for dir in $DIRS; do
-          RESULT=$("$SCRIPT_DIR/find-solution.sh" --file "$dir" 2>/dev/null) || true
+          # Bound find-solution at 3s; on timeout/failure fall back to a direct
+          # listing of files under that dir so the model still sees candidates.
+          RESULT=$(_nano_timeout 3 "$SCRIPT_DIR/find-solution.sh" --file "$dir" 2>/dev/null || true)
+          if [ -z "$RESULT" ] && [ -d "$NANOSTACK_STORE/know-how/solutions" ]; then
+            RESULT=$(find "$NANOSTACK_STORE/know-how/solutions" -name "*.md" -type f -path "*${dir}*" 2>/dev/null | head -5)
+          fi
           [ -n "$RESULT" ] && SOLUTION_OUTPUT="$SOLUTION_OUTPUT
 $RESULT"
         done

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -14,6 +14,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
+[ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 
 # ─── Session mode: build JSON from git state + summary ──────
 if [ "${1:-}" = "--from-session" ]; then

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -12,6 +12,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
+[ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 PROJECT="$(pwd)"
@@ -88,6 +89,9 @@ cmd_init() {
 }
 
 # ─── phase-start ────────────────────────────────────────────
+# Uses an atomic mkdir-lock so concurrent agents (e.g., /conductor) cannot
+# double-register the same phase. mkdir is atomic on every POSIX filesystem;
+# flock would not work on macOS without coreutils.
 cmd_phase_start() {
   local phase="${1:?Usage: session.sh phase-start <phase>}"
 
@@ -96,12 +100,26 @@ cmd_phase_start() {
     exit 1
   fi
 
-  # Idempotent: skip if phase already completed or in progress
+  local lockdir="${SESSION_FILE}.lockdir"
+  local waited=0
+  while ! mkdir "$lockdir" 2>/dev/null; do
+    waited=$((waited + 1))
+    if [ "$waited" -gt 50 ]; then
+      # Stale lock or true contention: clear and proceed (best effort).
+      rmdir "$lockdir" 2>/dev/null || true
+      echo "WARN: session lock held >5s, proceeding without it" >&2
+      break
+    fi
+    sleep 0.1
+  done
+
+  # Re-check inside the lock (idempotent under concurrency)
   local existing
   existing=$(jq -r --arg p "$phase" \
     '[.phase_log[] | select(.phase == $p and (.status == "completed" or .status == "in_progress"))] | length' \
     "$SESSION_FILE" 2>/dev/null || echo "0")
   if [ "$existing" -gt 0 ]; then
+    rmdir "$lockdir" 2>/dev/null || true
     echo "OK: $phase already in log"
     return 0
   fi
@@ -124,6 +142,8 @@ cmd_phase_start() {
      }] |
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  rmdir "$lockdir" 2>/dev/null || true
 
   audit_log "phase_start" "$phase"
   echo "OK: $phase started"


### PR DESCRIPTION
## Summary

Three small, fully backward-compatible robustness fixes from the workflow optimization spec (`Nanostack/specs/workflow-optimization-spec.md`):

- **Preflight dependency check** (`bin/lib/preflight.sh`): scripts that need `jq` now fail fast with a clear install hint instead of producing cryptic mid-execution errors. Sourced via a guarded `[ -f ... ] && source ...` so old installs without the file still work. Bypass with `NANOSTACK_SKIP_PREFLIGHT=1`.

- **Session phase-start lock** (`bin/session.sh`): atomic `mkdir`-lock around the read-check-write of `session.json`. Eliminates the race where two concurrent `/conductor` agents could double-register the same phase. macOS-safe (no `flock` dependency). 5-second timeout falls through rather than blocking the sprint.

- **Resolver timeout + fallback** (`bin/resolve.sh`): `find-solution.sh` invocations are now wrapped in a portable `_nano_timeout` helper (`gtimeout` → `timeout` → passthrough). On timeout or failure, falls back to a direct `find` of solution files under the changed directory so the model still sees candidates.

## Backward compatibility

- Preflight `source` is guarded by `[ -f ... ]` — old installs missing the file behave exactly as before.
- The session lock is transparent to single-agent runs.
- `_nano_timeout` degrades to plain command execution when neither `timeout` nor `gtimeout` is installed.
- No public flags, paths, schemas, or skill behavior changed.

## Test plan

- [x] `nanostack_require nonexistent_cmd` exits 127 with install hint.
- [x] `nanostack_require jq` succeeds silently when jq is installed.
- [x] `NANOSTACK_SKIP_PREFLIGHT=1 nanostack_require nonexistent_cmd` returns 0.
- [x] Two concurrent `session.sh phase-start think` calls produce only one `phase_log` entry.
- [x] `resolve.sh review --diff` returns valid JSON with the timeout path exercised.
- [ ] Real sprint smoke test on a downstream project (recommended before merge).