### PR TITLE
Cache git diff and session phase list across resolve.sh calls

### DIFF
--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -7,6 +7,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+[ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
 
 PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days]}"
 MAX_AGE="${2:-30}"
@@ -38,12 +39,22 @@ done | sort -r | head -1)
 # "in_progress" until save-artifact.sh completes it.
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 if [ -f "$SESSION_FILE" ]; then
-  # Check if phase already in session (avoid unnecessary jq calls)
-  PHASE_EXISTS=$(jq -r --arg p "$PHASE" \
-    '[.phase_log[] | select(.phase == $p)] | length' \
-    "$SESSION_FILE" 2>/dev/null)
-  PHASE_EXISTS="${PHASE_EXISTS:-0}"
-  if [ "$PHASE_EXISTS" -eq 0 ]; then
+  # Cache the phase list extracted from session.json. Multiple find-artifact.sh
+  # calls in one resolve.sh run reuse the same list; session.sh writes bump
+  # session.json's mtime which invalidates the cache automatically.
+  PHASE_LIST_CACHE=""
+  if declare -F nano_cache_dir >/dev/null 2>&1; then
+    PHASE_LIST_CACHE="$(nano_cache_dir)/session-phases"
+  fi
+
+  if [ -n "$PHASE_LIST_CACHE" ] && nano_cache_fresh "$PHASE_LIST_CACHE" 60 "$SESSION_FILE" 2>/dev/null; then
+    PHASE_LIST=$(cat "$PHASE_LIST_CACHE")
+  else
+    PHASE_LIST=$(jq -r '.phase_log[].phase' "$SESSION_FILE" 2>/dev/null || echo "")
+    [ -n "$PHASE_LIST_CACHE" ] && printf '%s\n' "$PHASE_LIST" > "$PHASE_LIST_CACHE" 2>/dev/null || true
+  fi
+
+  if ! printf '%s\n' "$PHASE_LIST" | grep -qx "$PHASE" 2>/dev/null; then
     SESSION_SH="$SCRIPT_DIR/session.sh"
     if [ -x "$SESSION_SH" ]; then
       "$SESSION_SH" phase-start "$PHASE" >/dev/null 2>&1 || true

--- a/bin/lib/cache.sh
+++ b/bin/lib/cache.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# cache.sh — Small file-cache helpers used by nanostack libs.
+# Source this file; the helpers expect $NANOSTACK_STORE to be set.
+#
+# Cache files live under "$NANOSTACK_STORE/.cache/". Set NANOSTACK_NO_CACHE=1
+# to force callers to bypass caches (useful for debugging stale data).
+
+# Cross-platform file mtime in epoch seconds. Echo 0 on failure.
+nano_mtime() {
+  local f="$1"
+  [ -e "$f" ] || { echo 0; return; }
+  if stat -f %m "$f" >/dev/null 2>&1; then
+    stat -f %m "$f"
+  elif stat -c %Y "$f" >/dev/null 2>&1; then
+    stat -c %Y "$f"
+  else
+    echo 0
+  fi
+}
+
+# Age of a file in seconds. Echo a very large number on failure so callers
+# treat missing files as expired.
+nano_cache_age() {
+  local f="$1"
+  if [ ! -f "$f" ]; then echo 999999999; return; fi
+  local now mt
+  now=$(date +%s 2>/dev/null || echo 0)
+  mt=$(nano_mtime "$f")
+  echo $(( now - mt ))
+}
+
+# Returns 0 if cache is fresh (age < ttl AND not invalidated by source mtime),
+# 1 otherwise. Args: cache_file ttl_seconds [source_path_to_check_mtime_against]
+nano_cache_fresh() {
+  [ "${NANOSTACK_NO_CACHE:-0}" = "1" ] && return 1
+  local cache="$1" ttl="$2" source="${3:-}"
+  [ -f "$cache" ] || return 1
+  local age
+  age=$(nano_cache_age "$cache")
+  [ "$age" -lt "$ttl" ] || return 1
+  if [ -n "$source" ] && [ -e "$source" ]; then
+    local src_mt cache_mt
+    src_mt=$(nano_mtime "$source")
+    cache_mt=$(nano_mtime "$cache")
+    [ "$src_mt" -le "$cache_mt" ] || return 1
+  fi
+  return 0
+}
+
+nano_cache_dir() {
+  local d="$NANOSTACK_STORE/.cache"
+  mkdir -p "$d" 2>/dev/null || true
+  echo "$d"
+}
+
+# Invalidate a named cache file. Safe if the file does not exist.
+nano_cache_invalidate() {
+  local name="$1"
+  [ -z "$name" ] && return 0
+  rm -f "$NANOSTACK_STORE/.cache/$name" 2>/dev/null || true
+}

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -15,6 +15,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
+[ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
 
 # Portable timeout wrapper: gtimeout (coreutils on macOS) → timeout (Linux) → run as-is.
 # Used to bound expensive solution lookups so resolve.sh never hangs the sprint.
@@ -110,12 +111,23 @@ SOLUTIONS_JSON="[]"
 if [ "$LOAD_SOLUTIONS" = true ]; then
   DIFF_FILES=""
   if [ "$USE_DIFF" = true ]; then
-    DIFF_FILES=$(git diff --name-only HEAD 2>/dev/null || git diff --name-only 2>/dev/null || echo "")
-    # Also include staged files
-    STAGED=$(git diff --cached --name-only 2>/dev/null || echo "")
-    [ -n "$STAGED" ] && DIFF_FILES="$DIFF_FILES
+    # Cache the diff keyed on HEAD rev so multiple resolve.sh invocations in
+    # the same sprint reuse one git call. New commits invalidate via the key.
+    DIFF_CACHE=""
+    if declare -F nano_cache_dir >/dev/null 2>&1; then
+      HEAD_REV=$(git rev-parse --short HEAD 2>/dev/null || echo "no-head")
+      DIFF_CACHE="$(nano_cache_dir)/git-diff-${HEAD_REV}"
+    fi
+    if [ -n "$DIFF_CACHE" ] && nano_cache_fresh "$DIFF_CACHE" 30 2>/dev/null; then
+      DIFF_FILES=$(cat "$DIFF_CACHE")
+    else
+      DIFF_FILES=$(git diff --name-only HEAD 2>/dev/null || git diff --name-only 2>/dev/null || echo "")
+      STAGED=$(git diff --cached --name-only 2>/dev/null || echo "")
+      [ -n "$STAGED" ] && DIFF_FILES="$DIFF_FILES
 $STAGED"
-    DIFF_FILES=$(echo "$DIFF_FILES" | sort -u | head -20)
+      DIFF_FILES=$(echo "$DIFF_FILES" | sort -u | head -20)
+      [ -n "$DIFF_CACHE" ] && printf '%s\n' "$DIFF_FILES" > "$DIFF_CACHE" 2>/dev/null || true
+    fi
   fi
 
   SOLUTION_OUTPUT=""


### PR DESCRIPTION
## Summary

Adds `bin/lib/cache.sh` (cross-platform mtime helpers, `NANOSTACK_NO_CACHE=1` bypass) and applies it in two places where the same data is recomputed on every resolve.sh invocation in a sprint:

- **`resolve.sh` git diff cache**: keyed on `HEAD` short rev, file at `.nanostack/.cache/git-diff-<rev>`. New commits invalidate via the key. Skips the `git diff --name-only HEAD` + `--cached` pair on every call after the first.
- **`find-artifact.sh` session-phase cache**: caches `jq -r .phase_log[].phase` output at `.nanostack/.cache/session-phases`. Invalidated by `session.json` mtime, so any `session.sh` write transparently refreshes it. Eliminates redundant jq calls when resolve.sh walks several upstream phases in one run.

## Backward compatibility

- Both caches are guarded by `[ -f lib/cache.sh ] && source ...` so installs without the new file behave exactly as before.
- `NANOSTACK_NO_CACHE=1` forces a bypass for debugging.
- `.nanostack/.cache/` lives under `.nanostack/` which is already gitignored.
- No public flags, paths, schemas, or skill behavior changed.

## Honest perf note

Measured benefit on a synthetic 100-solution repo was a modest ~5-10% on `resolve.sh review --diff`. The helpers also lay groundwork for future optimizations and behave better under slow I/O (CI runners, NFS, network home dirs).

A solutions-directory cache was prototyped and dropped: in `find-solution.sh` the real bottleneck is per-file frontmatter parsing (sed/grep on each .md), not the `find` itself, so a file-listing cache added overhead without measurable gain. Logged as a finding for follow-up — the right fix is parsing-side, not listing-side.

## Test plan

- [x] `nano_cache_fresh` returns 1 for missing/expired files, 0 for fresh.
- [x] `NANOSTACK_NO_CACHE=1` bypasses both caches.
- [x] git-diff cache key changes with new commits (verified via `HEAD` rev).
- [x] session-phases cache invalidates on `session.json` mtime bump.
- [x] `resolve.sh review --diff` returns identical JSON with cache on/off.
- [ ] Real sprint smoke test on a downstream project.