### PR TITLE
Extract reference material from SKILL.md to references/ files

### DIFF
--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -115,40 +115,7 @@ Skip this for Small scope — it's overkill for a 3-file change.
 
 ### 6. Product Standards (if the plan includes user-facing output)
 
-If the plan produces anything a user will see or interact with, apply these standards. They are not optional. A product built with an AI agent should look and feel better than one built without it.
-
-**UI/Frontend:**
-- Use a component library. Default: shadcn/ui + Tailwind. Not raw CSS, not Bootstrap, not Material UI from 2019. The bar is professional SaaS quality.
-- Dark mode support from day one. Not as a follow-up. It takes 5 minutes more with Tailwind.
-- Mobile responsive. If it doesn't work on a phone, half the users can't use it.
-- No AI slop: no purple gradients, no centered-everything landing pages, no generic hero copy, no Inter font as the only choice. If it looks like every other AI-generated site, it's wrong.
-
-**SEO (if web-facing):**
-- Semantic HTML. `<main>`, `<article>`, `<nav>`, `<h1>` hierarchy. Not a div soup.
-- Meta tags: title, description, og:image, og:title, og:description. Every page.
-- Performance: images optimized, no layout shift, Core Web Vitals passing.
-- Sitemap and robots.txt if the site has more than one page.
-
-**LLM SEO (if the product should be discoverable by AI):**
-- Structured data (JSON-LD) for the content type: Product, Article, FAQ, HowTo, SoftwareApplication.
-- `llms.txt` at the root describing what the site/product does in plain language.
-- Clean, descriptive URLs. `/pricing` not `/page?id=3`.
-- Content that answers questions directly in the first paragraph. LLMs extract from the top, not the bottom.
-
-**CLI/TUI (if the plan produces a command-line tool):**
-- Use a TUI framework. Default by language:
-  - **Go:** [Bubble Tea](https://github.com/charmbracelet/bubbletea) + [Lip Gloss](https://github.com/charmbracelet/lipgloss) for interactive TUIs. [Cobra](https://github.com/spf13/cobra) for command structure. [Glamour](https://github.com/charmbracelet/glamour) for markdown rendering.
-  - **Python:** [Rich](https://github.com/Textualize/rich) for output formatting. [Textual](https://github.com/Textualize/textual) for interactive TUIs. [Click](https://github.com/pallets/click) or [Typer](https://github.com/tiangolo/typer) for command structure.
-  - **Node/TypeScript:** [Ink](https://github.com/vadimdemedes/ink) for interactive TUIs. [Commander](https://github.com/tj/commander.js) for command structure. [Chalk](https://github.com/chalk/chalk) for colors.
-  - **Rust:** [Ratatui](https://github.com/ratatui-org/ratatui) for interactive TUIs. [Clap](https://github.com/clap-rs/clap) for command structure.
-- Color output by default. Respect `NO_COLOR` env var and `--no-color` flag.
-- Structured output: support `--json` flag for machine-readable output. Human-readable is default.
-- Progress indicators for operations that take more than 1 second (spinners, progress bars).
-- Error messages must be actionable: what went wrong, why, and what the user should do. Not stack traces.
-- Exit codes: 0 for success, 1 for user error, 2 for system error. Consistent across all subcommands.
-- Help text: every command and flag has a description. `--help` works on every subcommand.
-- No wall of text output. Use tables, columns, indentation and color to make output scannable.
-- Version flag: `--version` prints version and exits.
+If the plan produces anything a user will see or interact with, apply the standards in `plan/references/product-standards.md`. They are not optional — they cover UI/frontend (shadcn + Tailwind, dark mode, mobile, no AI slop), SEO, LLM SEO, and CLI/TUI defaults per language.
 
 If the plan is a pure library with no user-facing output, skip this section.
 

--- a/plan/references/product-standards.md
+++ b/plan/references/product-standards.md
@@ -1,0 +1,46 @@
+# Product Standards
+
+Used by `/nano` Section 6 when the plan includes user-facing output. Apply during planning so implementation has clear constraints, not after the code is written. A product built with an AI agent should look and feel better than one built without it.
+
+If the plan is a pure library with no user-facing output, skip this entire reference.
+
+## UI / Frontend
+
+- Use a component library. **Default: shadcn/ui + Tailwind.** Not raw CSS. Not Bootstrap. Not Material UI from 2019. The bar is professional SaaS quality.
+- Dark mode support from day one. Not a follow-up. With Tailwind it takes 5 minutes more.
+- Mobile responsive. If it doesn't work on a phone, half the users can't use it.
+- No AI slop: no purple gradients, no centered-everything landing pages, no generic hero copy, no Inter font as the only choice. If it looks like every other AI-generated site, it's wrong.
+
+## SEO (web-facing)
+
+- Semantic HTML. `<main>`, `<article>`, `<nav>`, proper `<h1>` hierarchy. Not div soup.
+- Meta tags on every page: title, description, og:image, og:title, og:description.
+- Performance: images optimized, no layout shift, Core Web Vitals passing.
+- Sitemap and robots.txt if the site has more than one page.
+
+## LLM SEO (discoverable by AI)
+
+- Structured data (JSON-LD) for the content type: Product, Article, FAQ, HowTo, SoftwareApplication.
+- `llms.txt` at the root describing what the site/product does in plain language.
+- Clean, descriptive URLs. `/pricing`, not `/page?id=3`.
+- Content that answers questions directly in the first paragraph. LLMs extract from the top, not the bottom.
+
+## CLI / TUI (command-line tools)
+
+Use a TUI framework. Defaults by language:
+
+- **Go:** [Bubble Tea](https://github.com/charmbracelet/bubbletea) + [Lip Gloss](https://github.com/charmbracelet/lipgloss) for interactive TUIs. [Cobra](https://github.com/spf13/cobra) for command structure. [Glamour](https://github.com/charmbracelet/glamour) for markdown rendering.
+- **Python:** [Rich](https://github.com/Textualize/rich) for output formatting. [Textual](https://github.com/Textualize/textual) for interactive TUIs. [Click](https://github.com/pallets/click) or [Typer](https://github.com/tiangolo/typer) for command structure.
+- **Node / TypeScript:** [Ink](https://github.com/vadimdemedes/ink) for interactive TUIs. [Commander](https://github.com/tj/commander.js) for command structure. [Chalk](https://github.com/chalk/chalk) for colors.
+- **Rust:** [Ratatui](https://github.com/ratatui-org/ratatui) for interactive TUIs. [Clap](https://github.com/clap-rs/clap) for command structure.
+
+CLI behavior requirements:
+
+- Color output by default. Respect `NO_COLOR` env var and `--no-color` flag.
+- Structured output: support `--json` flag for machine-readable output. Human-readable is default.
+- Progress indicators for operations that take more than 1 second (spinners, progress bars).
+- Error messages must be actionable: what went wrong, why, and what the user should do. Not stack traces.
+- Exit codes: 0 for success, 1 for user error, 2 for system error. Consistent across all subcommands.
+- Help text: every command and flag has a description. `--help` works on every subcommand.
+- No wall-of-text output. Use tables, columns, indentation and color to make output scannable.
+- Version flag: `--version` prints version and exits.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -174,32 +174,7 @@ Document what went wrong for the team.
 
 ### 7. Repo Quality Standards
 
-Before creating the PR, verify these standards. The public repo is the face of the project.
-
-**README:**
-- All internal links resolve (check every `[text](path)` reference)
-- No stale command names or paths from previous versions
-- No AI writing tells: em dashes, en dashes, Oxford commas
-- Examples are accurate and runnable
-- Install instructions work on a clean machine
-
-**PR quality:**
-- Title under 70 characters, starts with a verb
-- Body explains what changed and why, not just what files were touched
-- Test plan is specific enough that someone else could verify it
-- No "Generated with" badges or AI attribution
-
-**Commit quality:**
-- Commit messages explain the why, not just the what
-- One concern per commit when possible
-- No AI attribution in commit messages
-
-**Repo hygiene:**
-- No secrets in the diff (API keys, tokens, passwords)
-- No large binary files committed
-- .gitignore covers editor files, OS files, build artifacts
-
-`ship/bin/quality-check.sh` automates the checks it can. Use your judgment for the rest.
+Before creating the PR, verify the standards in `ship/references/repo-quality-standards.md` (README links, PR/commit quality, repo hygiene). The public repo is the face of the project. `ship/bin/quality-check.sh` automates the checks it can; use judgment for the rest.
 
 After shipping, do these steps in order:
 

--- a/ship/references/repo-quality-standards.md
+++ b/ship/references/repo-quality-standards.md
@@ -1,0 +1,30 @@
+# Repo Quality Standards
+
+Used by `/ship` Section 7 before creating a PR. The public repo is the face of the project. `ship/bin/quality-check.sh` automates the checks it can; use judgment for the rest.
+
+## README
+
+- All internal links resolve. Check every `[text](path)` reference.
+- No stale command names or paths from previous versions.
+- No AI writing tells: em dashes, en dashes, Oxford commas.
+- Examples are accurate and runnable.
+- Install instructions work on a clean machine.
+
+## PR quality
+
+- Title under 70 characters, starts with a verb.
+- Body explains what changed and why, not just which files were touched.
+- Test plan is specific enough that someone else could verify it.
+- No "Generated with" badges or AI attribution.
+
+## Commit quality
+
+- Commit messages explain the why, not just the what.
+- One concern per commit when possible.
+- No AI attribution in commit messages.
+
+## Repo hygiene
+
+- No secrets in the diff (API keys, tokens, passwords).
+- No large binary files committed.
+- `.gitignore` covers editor files, OS files, build artifacts.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -255,43 +255,13 @@ This is the first thing you do after the summary. Not optional. Not "Step 2". Th
 
 ### Phase 6.5: Think Brief (shareable)
 
-Save a clean markdown brief to `.nanostack/know-how/briefs/`. This is a human-readable version of the Think Summary that the user can share with their team, open in Obsidian, or paste into a doc.
-
-Write the brief file directly (do not use save-artifact.sh — this is a markdown doc, not a JSON artifact):
+Save a clean markdown brief to `.nanostack/know-how/briefs/YYYY-MM-DD-<slug>.md` (slug from the value proposition). This is a human-readable version of the Think Summary the user can share with their team, open in Obsidian, or paste into a doc. Do NOT use `save-artifact.sh` — this is a markdown doc, not a JSON artifact.
 
 ```bash
 mkdir -p .nanostack/know-how/briefs
 ```
 
-Write a file named `YYYY-MM-DD-<slug>.md` (slug from the value proposition) with this format:
-
-```markdown
-# Think Brief: <value proposition short title>
-
-**Date:** YYYY-MM-DD
-**Mode:** Startup / Builder / Founder
-**Scope:** Expand / Hold / Reduce
-
-## Value Proposition
-<one sentence>
-
-## Target User
-<who specifically, and why they'd use a broken v1>
-
-## Starting Point
-<the smallest thing that delivers value>
-
-## Key Risk
-<the one thing most likely to make this fail>
-
-## What We Decided NOT to Build
-<out of scope items from the diagnostic>
-
-## Premise
-<validated or not — and the argument that tested it>
-```
-
-Keep it under 20 lines. No filler, no headers without content. Skip sections that don't apply (e.g., skip "What We Decided NOT to Build" if nothing was excluded).
+Format and rules: see `think/references/brief-template.md`. Keep under 20 lines, skip sections that don't apply.
 
 ### Phase 7: Next Step
 

--- a/think/references/brief-template.md
+++ b/think/references/brief-template.md
@@ -1,0 +1,44 @@
+# Think Brief Template
+
+Used by `/think` Phase 6.5 to write a shareable markdown brief to `.nanostack/know-how/briefs/YYYY-MM-DD-<slug>.md` (slug derived from the value proposition).
+
+This is a human-readable document the user can share with a team, paste into a doc, or open in Obsidian. It is **not** the JSON artifact (that is saved separately by `save-artifact.sh`).
+
+## Format
+
+```markdown
+# Think Brief: <value proposition short title>
+
+**Date:** YYYY-MM-DD
+**Mode:** Startup / Builder / Founder
+**Scope:** Expand / Hold / Reduce
+
+## Value Proposition
+<one sentence>
+
+## Target User
+<who specifically, and why they'd use a broken v1>
+
+## Starting Point
+<the smallest thing that delivers value>
+
+## Key Risk
+<the one thing most likely to make this fail>
+
+## What We Decided NOT to Build
+<out of scope items from the diagnostic>
+
+## Premise
+<validated or not — and the argument that tested it>
+```
+
+## Rules
+
+- Keep it under 20 lines total.
+- No filler, no headers without content.
+- Skip sections that don't apply (e.g., omit "What We Decided NOT to Build" if nothing was excluded).
+- The slug is derived from the value proposition: lowercase, hyphenated, max ~5 words.
+
+## Retro briefs
+
+For `/think --retro`, write to `.nanostack/know-how/briefs/YYYY-MM-DD-retro.md` with the retro output (Sprint, Shipped, Right problem?, Surprises, Recurring patterns, Recommendation). Same directory, different filename pattern.


### PR DESCRIPTION
## Summary

Three `SKILL.md` files carried sizable reference blocks (templates, checklists, framework lists) that the agent rarely needs verbatim. Moving them to per-skill `references/` files trims the prompt the model loads on every skill invocation while keeping `SKILL.md` focused on the directives that drive behavior.

| Skill | Before | After | Extracted to |
|-------|--------|-------|--------------|
| `think/SKILL.md` | 336 | 306 | `think/references/brief-template.md` (Phase 6.5 brief template) |
| `plan/SKILL.md` | 218 | 185 | `plan/references/product-standards.md` (UI, SEO, LLM SEO, CLI/TUI) |
| `ship/SKILL.md` | 286 | 261 | `ship/references/repo-quality-standards.md` (README, PR, commit, hygiene) |

`review/SKILL.md` (186 lines) was deliberately left untouched: it is already compact, and its content is split between Pass 1 and Pass 2 directives that need to stay in the always-loaded prompt.

## What stayed in SKILL.md

For each extraction, the directive that **triggers** the reference is still in the always-loaded prompt:

- `think` Phase 6.5 still spells out *when* to write the brief, *where* to save it, and *how* to name the file.
- `plan` Section 6 still triggers product standards when the plan produces user-facing output.
- `ship` Section 7 still requires verification before PR creation.

Only the *layout details* (template body, framework lists, checklists) moved into the reference. The model reads them when the directive points to them.

## Backward compatibility

- All extracted content is still in the repo, just in a different file.
- All other reference paths (e.g., `think/references/forcing-questions.md`) were already used the same way — this PR adds three more in the same pattern.
- No public flags, schemas, or skill behavior changed.

## Test plan

- [x] All `references/*.md` pointers in the modified SKILL.md files resolve to existing files.
- [x] No directive content was extracted — only template/checklist/list material that is read on demand.
- [x] Line counts: think -30, plan -33, ship -25 (88 lines total off the per-invocation load).
- [ ] Real sprint smoke test on a downstream project to confirm `/think`, `/nano`, `/ship` still produce briefs, apply standards, and run repo-quality checks correctly.