### PR TITLE
Standardize guard block messages and add resolve.sh control flags

### DIFF
--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -4,9 +4,12 @@
 # Routes context based on phase: loads upstream artifacts, matched solutions,
 # conflict precedents, diarizations, and config.
 #
-# Usage: resolve.sh <phase> [--diff]
+# Usage: resolve.sh <phase> [--diff] [--skip-solutions] [--max-age <phase>:<days>]...
 #   phase: plan, review, security, qa, ship, compound, feature
-#   --diff: match solutions against current git diff file paths
+#   --diff:                match solutions against current git diff file paths
+#   --skip-solutions:      do not load solutions (for fast/CI runs)
+#   --max-age <phase>:<n>: override per-phase upstream artifact age window in days
+#                          (e.g., --max-age plan:5 --max-age think:30). Repeatable.
 #
 # Output: JSON blob with all resolved context paths and summaries.
 # Exit 0 on success (even if some lookups return empty).
@@ -30,11 +33,27 @@ _nano_timeout() {
   fi
 }
 
-PHASE="${1:?Usage: resolve.sh <phase> [--diff]}"
+PHASE="${1:?Usage: resolve.sh <phase> [--diff] [--skip-solutions] [--max-age <phase>:<days>]...}"
 shift
 USE_DIFF=false
-for arg in "$@"; do
-  [ "$arg" = "--diff" ] && USE_DIFF=true
+SKIP_SOLUTIONS_FLAG=false
+MAX_AGE_OVERRIDES=""  # space-separated "phase:days" pairs from --max-age flags
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --diff) USE_DIFF=true; shift ;;
+    --skip-solutions) SKIP_SOLUTIONS_FLAG=true; shift ;;
+    --max-age)
+      if [ -n "${2:-}" ]; then
+        MAX_AGE_OVERRIDES="${MAX_AGE_OVERRIDES:+$MAX_AGE_OVERRIDES }$2"
+        shift 2
+      else
+        echo "ERROR: --max-age requires <phase>:<days> argument" >&2
+        exit 2
+      fi
+      ;;
+    *) shift ;;  # unknown flag: ignore (forward compatibility)
+  esac
 done
 
 # ─── Routing table ─────────────────────────────────────────
@@ -96,6 +115,14 @@ for entry in $UPSTREAM; do
   phase="${entry%%:*}"
   age="${entry#*:}"
   [ "$age" = "$entry" ] && age=2  # default if no colon
+  # Apply --max-age override if one matches this phase
+  for override in $MAX_AGE_OVERRIDES; do
+    o_phase="${override%%:*}"
+    o_age="${override#*:}"
+    if [ "$o_phase" = "$phase" ] && [ -n "$o_age" ] && [ "$o_age" != "$override" ]; then
+      age="$o_age"
+    fi
+  done
   RESULT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$age" 2>/dev/null) || RESULT=""
   if [ -n "$RESULT" ]; then
     $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
@@ -108,7 +135,7 @@ ARTIFACTS_JSON="$ARTIFACTS_JSON}"
 # ─── 2. Resolve solutions ──────────────────────────────────
 
 SOLUTIONS_JSON="[]"
-if [ "$LOAD_SOLUTIONS" = true ]; then
+if [ "$LOAD_SOLUTIONS" = true ] && [ "$SKIP_SOLUTIONS_FLAG" = false ]; then
   DIFF_FILES=""
   if [ "$USE_DIFF" = true ]; then
     # Cache the diff keyed on HEAD rev so multiple resolve.sh invocations in

--- a/guard/bin/budget-gate.sh
+++ b/guard/bin/budget-gate.sh
@@ -26,6 +26,7 @@ if [ "$ACTION" = "stop" ]; then
   echo "Category: cost-control"
   echo "Spent: \$${SPENT} / \$${MAX}"
   echo ""
-  echo "Save your work and stop. To override: NANOSTACK_SKIP_BUDGET=1"
+  echo "Action: save your work and stop the sprint. Run \`bin/budget.sh check\` for details, or raise the limit with \`bin/budget.sh set --max-usd N\`."
+  echo "Bypass: NANOSTACK_SKIP_BUDGET=1   (use sparingly)"
   exit 1
 fi

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -118,7 +118,8 @@ if [ -f "$STORE_PATH_SH" ]; then
             echo "Category: concurrency-safety"
             echo "Command: $CMD"
             echo ""
-            echo "Phase '$CURRENT_PHASE' has concurrency=read. Write operations are blocked to prevent race conditions in parallel execution. Report as a finding instead of auto-fixing."
+            echo "Action: report this as a finding instead of auto-fixing. The current phase is read-only to prevent race conditions when multiple agents run in parallel."
+            echo "Bypass: complete the current phase first (\`bin/session.sh phase-complete $CURRENT_PHASE\`), or end the session if you're not in a sprint."
             exit 1
             ;;
         esac

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -81,8 +81,9 @@ check_phases() {
 print_block() {
   local missing="$1"
   echo "BLOCKED [PHASE-GATE] Sprint phases incomplete: $(echo "$missing" | tr ' ' ', ')"
+  echo "Category: sprint-pipeline"
   echo ""
-  echo "A sprint is active. Complete these phases before committing:"
+  echo "Action: complete these phases before committing:"
   for phase in $missing; do
     case "$phase" in
       review)   echo "  /review   — Code review" ;;
@@ -91,7 +92,7 @@ print_block() {
     esac
   done
   echo ""
-  echo "To bypass (non-sprint commit): NANOSTACK_SKIP_GATE=1 git commit ..."
+  echo "Bypass: NANOSTACK_SKIP_GATE=1 git commit ...   (non-sprint commits only)"
 }
 
 print_warning() {


### PR DESCRIPTION
## Summary

Two small UX wins from the workflow optimization spec — the final sprint.

### Guard block format consistency

Tier 3 already prints a `Safer alternative:` line. The other three gating tiers (concurrency, phase-gate, budget) printed bespoke free-form messages. All of them now share the same shape:

```
BLOCKED [TAG] <one-line reason>
Category: <category>
[Command: <cmd>]

Action: <what to do instead>
Bypass: <env var or method, when applicable>
```

This makes messages easier to scan for humans **and** for the agent — the bypass env var is now in a predictable place so the agent can pick the right escape hatch without guessing.

Sample (Tier 2.5 concurrency):

```
BLOCKED [PHASE] Write operation during read-only phase 'review'
Category: concurrency-safety
Command: rm foo.txt

Action: report this as a finding instead of auto-fixing. The current phase is read-only to prevent race conditions when multiple agents run in parallel.
Bypass: complete the current phase first (`bin/session.sh phase-complete review`), or end the session if you're not in a sprint.
```

### `resolve.sh` flags

Two additive flags:

- `--skip-solutions` — bypass the solution lookup pass. Useful in CI runs and quick iterations where solution loading is the slowest part of resolve.
- `--max-age <phase>:<n>` — override the per-phase upstream artifact age window. Repeatable: `--max-age plan:5 --max-age think:30`.

## Backward compatibility

- Exit codes and audit log entries from the guards are unchanged.
- `resolve.sh` defaults are unchanged. No skill currently passes the new flags, so behavior is identical to before unless a caller opts in.
- Unknown flags are ignored for forward compatibility.
- `--max-age` without an argument exits 2 with a clear error message.

## Test plan

- [x] Tier 2.5 concurrency block prints `Action:` and `Bypass:` lines.
- [x] Tier 2.75 phase-gate block prints `Action:` and `Bypass:` lines.
- [x] Tier 2.8 budget block prints `Action:` and `Bypass:` lines.
- [x] `resolve.sh review --skip-solutions` returns `solutions: []`.
- [x] `resolve.sh review --max-age plan:5` resolves the plan artifact under the new window.
- [x] `resolve.sh review --max-age` (no argument) exits 2 with a clear error.
- [x] `resolve.sh review --bogus-flag` succeeds (forward-compatible).
- [ ] Real sprint smoke test on a downstream project.