### PR TITLE
Make first-run messages actionable and agent-aware

### DIFF
--- a/setup
+++ b/setup
@@ -487,3 +487,14 @@ echo "Per-project setup (run once in each project):"
 echo "  ~/.claude/skills/nanostack/bin/init-project.sh"
 echo ""
 echo "Update:    ~/.claude/skills/nanostack/bin/upgrade.sh"
+
+# ─── Per-agent activation guidance ───────────────────────────
+# Tell the user how to actually see the skills in the agents they installed
+# for. Cursor and Codex need a restart that the install step does not perform.
+echo ""
+echo "Next step — activate the skills in your agent:"
+[ "$INSTALL_CLAUDE" -eq 1 ]   && echo "  Claude Code:  ready now. Type /nano-help to see all commands."
+[ "$INSTALL_CURSOR" -eq 1 ]   && echo "  Cursor:       restart Cursor (close and reopen), then type /nano-help."
+[ "$INSTALL_CODEX" -eq 1 ]    && echo "  Codex:        run \`codex\` in a new terminal, then type /nano-help."
+[ "$INSTALL_OPENCODE" -eq 1 ] && echo "  OpenCode:     restart your OpenCode session, then type /nano-help."
+[ "$INSTALL_GEMINI" -eq 1 ]   && echo "  Gemini CLI:   run \`gemini\` in a new terminal, then type /nano-help."

--- a/ship/bin/pre-ship-check.sh
+++ b/ship/bin/pre-ship-check.sh
@@ -15,25 +15,29 @@ fi
 
 WARNINGS=""
 
+# Each warning is "<CODE> — <message> Fix: <action>" so the code stays the
+# first word (grep-friendly, backward compatible) and the rest is plain text
+# the agent can show the user verbatim.
+
 # Check for uncommitted changes
 if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-  WARNINGS="${WARNINGS}UNCOMMITTED_CHANGES\n"
+  WARNINGS="${WARNINGS}UNCOMMITTED_CHANGES — You have unsaved changes. Fix: commit or stash them before /ship.\n"
 fi
 
 # Check if tests exist and were run recently (look for test result files)
 if ! find . -name "*.test.*" -o -name "*_test.*" -o -name "test_*" 2>/dev/null | head -1 | grep -q .; then
-  WARNINGS="${WARNINGS}NO_TESTS_FOUND\n"
+  WARNINGS="${WARNINGS}NO_TESTS_FOUND — No test files detected in this project. Fix: add at least one test, or skip this warning if the project doesn't need tests.\n"
 fi
 
 # Check for .env files that might be staged
 if git diff --cached --name-only 2>/dev/null | grep -qE '\.env$|\.env\.local$|credentials'; then
-  WARNINGS="${WARNINGS}SECRETS_STAGED\n"
+  WARNINGS="${WARNINGS}SECRETS_STAGED — Possible secrets staged for commit (.env / credentials file). Fix: unstage with \`git reset HEAD <file>\` and add the file to .gitignore.\n"
 fi
 
 # Check branch is not main/master
 BRANCH=$(git branch --show-current 2>/dev/null)
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-  WARNINGS="${WARNINGS}ON_MAIN_BRANCH\n"
+  WARNINGS="${WARNINGS}ON_MAIN_BRANCH — You're shipping directly from '${BRANCH}'. Fix: git checkout -b feature/<short-name> and ship from a branch.\n"
 fi
 
 if [ -n "$WARNINGS" ]; then

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -67,17 +67,20 @@ When they describe something, invoke the appropriate skill:
 
 If they chose "step by step":
 
-> You're all set. When you're ready, describe what you want to build. I'll walk you through each step:
+> You're all set. When you're ready, tell me what you want to build or change.
 >
-> 1. We think about the scope (/think)
-> 2. We plan the implementation (/nano)
-> 3. We build it
-> 4. We review, audit, and test (/review, /security, /qa)
-> 5. We ship it (/ship)
+> We'll go one step at a time:
+> 1. First we talk about the idea — is it the right size, the right shape?
+> 2. Then we make a plan — which files we touch, what could go wrong.
+> 3. Then we build it.
+> 4. I review the code, check it for security issues, and make sure it works.
+> 5. We save and ship it when you're happy.
 >
-> You control the pace. Tell me when you're ready.
->
-> Tip: for adding features to an existing project, try `/feature` — it skips the scope discussion and goes straight to planning.
+> You stay in control between each step. Tell me when you're ready.
+
+If the user is technical and wants the slash commands, also offer:
+
+> Quick reference: `/think` → `/nano` → build → `/review` → `/security` → `/qa` → `/ship`. For adding to an existing project, use `/feature` instead.
 
 When they describe something, invoke: use Skill tool: skill="think"
 


### PR DESCRIPTION
## Summary

Three small UX wins from the ux-accessibility spec — the first sprint of Round 2. All additive, all backward compatible.

### `pre-ship-check.sh`: codes + plain text + a Fix line

Each warning is now `<CODE> — <message> Fix: <action>`. Codes stay first-word so `grep '^UNCOMMITTED_CHANGES'` still matches; the rest is plain text the agent can show the user verbatim.

Sample:

```
WARNINGS
UNCOMMITTED_CHANGES — You have unsaved changes. Fix: commit or stash them before /ship.
ON_MAIN_BRANCH       — You're shipping directly from 'main'. Fix: git checkout -b feature/<short-name> and ship from a branch.
```

Covers `UNCOMMITTED_CHANGES`, `NO_TESTS_FOUND`, `SECRETS_STAGED`, `ON_MAIN_BRANCH`.

### `/nano-run` step-by-step mode: narrative first, slash commands second

The "step by step" branch used to dump `/think → /nano → build → /review → /security → /qa → /ship` at users who explicitly asked to take it slow. That is the exact jargon the slow path was meant to avoid.

The new version describes the five phases in plain language. The slash-command list survives as an opt-in "Quick reference" for technical users.

### `setup`: per-agent activation guidance

After installation, the script now prints which agents need a restart and which are ready immediately:

```
Next step — activate the skills in your agent:
  Claude Code:  ready now. Type /nano-help to see all commands.
  Cursor:       restart Cursor (close and reopen), then type /nano-help.
```

Only agents that were installed get a line. Memory of a real first-time Cursor user hitting "command not found" without restart guidance was the trigger.

## Backward compatibility

- `pre-ship-check.sh`: codes preserved as the first word, format `<CODE> — ... Fix: ...`. Any caller that greps `UNCOMMITTED_CHANGES` keeps working.
- `start/SKILL.md`: still chains into `/think` at the end. The slash-command reference is preserved verbatim, just relocated.
- `setup`: every previous output line is still printed. The per-agent block is appended.

## Test plan

- [x] `pre-ship-check.sh` on a dirty `main` branch with no tests → outputs three warnings, codes still match `awk '/^[A-Z_]+ /'`.
- [x] Setup tail block with a Claude+Cursor combination → prints exactly two lines, both correct.
- [x] `start/SKILL.md` step-by-step preview renders narrative, then "Quick reference" line.
- [ ] Real first-run smoke test on a downstream project (Cursor recommended given the original feedback).