### PR TITLE
Phase-aware Next Step, decision tree in /nano-help, headline format

### DIFF
--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# next-step.sh — Determine which sprint phases still need to run.
+#
+# Usage: next-step.sh <current-phase>
+#   current-phase: review | security | qa
+#
+# Output: space-separated list of pending phases for the post-build trio
+#   (review, security, qa) plus "ship" if any of them is missing or if the
+#   ship artifact itself is missing.
+#
+# Pending = no fresh (within 1 day) artifact found by find-artifact.sh.
+#
+# Used by /review, /security, /qa to give phase-aware "Next Step" guidance
+# instead of always suggesting every other phase.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+
+CURRENT="${1:?Usage: next-step.sh <current-phase>}"
+FIND="$SCRIPT_DIR/find-artifact.sh"
+
+PEERS="review security qa"
+PENDING=""
+
+for phase in $PEERS; do
+  [ "$phase" = "$CURRENT" ] && continue
+  if ! "$FIND" "$phase" 1 >/dev/null 2>&1; then
+    PENDING="${PENDING:+$PENDING }$phase"
+  fi
+done
+
+# ship is the terminal step. List it if anything before it is pending,
+# or if ship itself has no fresh artifact.
+if [ -n "$PENDING" ]; then
+  PENDING="$PENDING ship"
+elif ! "$FIND" "ship" 1 >/dev/null 2>&1; then
+  PENDING="ship"
+fi
+
+echo "$PENDING"

--- a/help/SKILL.md
+++ b/help/SKILL.md
@@ -19,6 +19,17 @@ Print this directly:
 nanostack
 Make your AI agent think first.
 
+What do you want to do?
+
+  Start a brand new project       → /think (or /think --autopilot)
+  Add to a project that exists    → /feature <what to add>
+  Already wrote code, check it    → /review  (then /security, /qa)
+  Ready to save / publish         → /ship
+  First time using nanostack      → /nano-run
+  Not sure where to start         → /think (it helps you decide)
+
+Reference — every command:
+
 Getting started:
   /nano-run              First-time setup. Configures your project conversationally.
   /nano-help             You are here.

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -202,11 +202,27 @@ After QA is complete and the artifact is saved:
 
 **If AUTOPILOT is active but tests fail:** Stop and ask the user. Show failures and wait.
 
-**Otherwise:** Tell the user:
-> QA complete. Remaining steps:
-> - `/review` to run code review (if not done yet)
-> - `/security` to audit for vulnerabilities (if not done yet)
-> - `/ship` to create the PR (after review, security and qa pass)
+**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+
+```bash
+~/.claude/skills/nanostack/bin/next-step.sh qa
+```
+
+The script outputs a space-separated list of pending phases. Tell the user only what is pending. Examples:
+- Output `review security ship` → "QA complete. Next: `/review`, then `/security`, then `/ship`."
+- Output `security ship`        → "QA complete. Next: `/security`, then `/ship`."
+- Output `ship`                 → "QA complete. Ready for `/ship`."
+- Empty output                  → "QA complete. Sprint is fully verified."
+
+## Final Headline
+
+After the user-facing message above, print one summary line as the very last thing — useful for autopilot logs and quick scanning:
+
+```
+[qa] OK: <N tests, M failed>. Next: <first pending skill or "/ship">.
+```
+
+Use `WARN` instead of `OK` if any tests failed.
 
 ## Gotchas
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -165,11 +165,27 @@ After the review is complete and the artifact is saved, proceed:
 
 **If AUTOPILOT is active but blocking issues found:** Stop and ask the user to resolve. Show the blocking issues and wait. After resolution, continue autopilot.
 
-**Otherwise:** Tell the user:
-> Review complete. Remaining steps:
-> - `/security` to audit for vulnerabilities (if not done yet)
-> - `/qa` to test that everything works (if not done yet)
-> - `/ship` to create the PR (after review, security and qa pass)
+**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+
+```bash
+~/.claude/skills/nanostack/bin/next-step.sh review
+```
+
+The script outputs a space-separated list of pending phases (e.g. `security qa ship`). Tell the user only what is pending. Examples:
+- Output `security qa ship` → "Review complete. Next: `/security`, then `/qa`, then `/ship`."
+- Output `qa ship`          → "Review complete. Next: `/qa`, then `/ship`."
+- Output `ship`             → "Review complete. Ready for `/ship`."
+- Empty output              → "Review complete. Sprint is fully verified."
+
+## Final Headline
+
+After the user-facing message above, print one summary line as the very last thing — useful for autopilot logs and quick scanning:
+
+```
+[review] OK: <N findings, M blocking>. Next: <first pending skill or "/ship">.
+```
+
+Use `WARN` instead of `OK` if there are any blocking findings.
 
 ## Gotchas
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -227,11 +227,27 @@ After the security audit is complete and the artifact is saved:
 
 **If AUTOPILOT is active but critical or high findings found:** Stop and ask the user to review. Show the findings and wait. After resolution, continue autopilot.
 
-**Otherwise:** Tell the user:
-> Security audit complete. Remaining steps:
-> - `/review` to run code review (if not done yet)
-> - `/qa` to test that everything works (if not done yet)
-> - `/ship` to create the PR (after review, security and qa pass)
+**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+
+```bash
+~/.claude/skills/nanostack/bin/next-step.sh security
+```
+
+The script outputs a space-separated list of pending phases. Tell the user only what is pending. Examples:
+- Output `review qa ship` → "Security audit complete. Next: `/review`, then `/qa`, then `/ship`."
+- Output `qa ship`        → "Security audit complete. Next: `/qa`, then `/ship`."
+- Output `ship`           → "Security audit complete. Ready for `/ship`."
+- Empty output            → "Security audit complete. Sprint is fully verified."
+
+## Final Headline
+
+After the user-facing message above, print one summary line as the very last thing — useful for autopilot logs and quick scanning:
+
+```
+[security] OK: grade <A-F>, <N critical, M high>. Next: <first pending skill or "/ship">.
+```
+
+Use `WARN` instead of `OK` if any critical or high findings exist.
 
 ## After Fixes
 


### PR DESCRIPTION
## Summary

Three discoverability and consistency wins from the ux-accessibility spec — Sprint 2 of Round 2. All additive.

### `bin/next-step.sh` + phase-aware Next Step in /review, /security, /qa

New helper. Given the current phase, it asks `find-artifact.sh` which of `review`, `security`, `qa`, `ship` still lack a fresh (within 1 day) artifact and prints only those.

The `Otherwise` branch of each post-build skill's Next Step section now invokes `next-step.sh` and renders only the pending phases. Concrete fix for: a user runs `/security` first, then `/review`, and `/review`'s next-step suggestion still includes `/security`. With this PR, the suggestion adapts to what was actually done.

Tested on four sprint states: only review done → `security qa ship`. Review+security done → `qa ship`. All trio done → `ship`. Everything shipped → empty (sprint complete).

The autopilot branches are unchanged — they already had their own logic.

### Final headline at the close of /review, /security, /qa

Each of the same three skills now ends with a one-line summary:

```
[review]   OK: 3 findings, 0 blocking. Next: /security.
[security] WARN: grade C, 1 critical. Next: /qa.
[qa]       OK: 12 tests, 0 failed. Next: /ship.
```

The full structured output survives above. The headline is the last thing printed — useful for autopilot logs and quick scanning, and it never lies (status reflects the actual finding counts).

### `/nano-help`: decision tree first, reference list second

The reference list survives verbatim, but the response now opens with:

```
What do you want to do?

  Start a brand new project       → /think (or /think --autopilot)
  Add to a project that exists    → /feature <what to add>
  Already wrote code, check it    → /review  (then /security, /qa)
  Ready to save / publish         → /ship
  First time using nanostack      → /nano-run
  Not sure where to start         → /think (it helps you decide)
```

Answers the actual first-time user question instead of dumping a glossary.

## Backward compatibility

- `find-artifact.sh` contract unchanged.
- Autopilot path uses its existing logic, unmodified.
- `/nano-help` reference list preserved verbatim, just preceded by the decision tree.
- The headline is appended after the existing structured output, never replaces it.

## Test plan

- [x] `next-step.sh` returns the correct pending list across four real artifact states.
- [x] `next-step.sh` exits 0 with empty output when everything is shipped.
- [x] `/nano-help` decision tree renders, reference list still complete.
- [ ] Real sprint smoke test: run `/review` then `/security` and confirm the second skill's Next Step does not suggest `/review` again.
- [ ] Verify headline appears in autopilot logs (`Autopilot: <skill> complete. ...` already exists; the headline complements it).