### PR TITLE
Add examples/starter-todo as a sandbox for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ One command. Detects your agents, installs everything, runs setup. Works with Cl
 
 Then run `/nano-run` in your agent to configure your project through a conversation. On your first sprint, `/think` shows the full pipeline so you know what comes next.
 
+Want to try it on a sandbox first? `examples/starter-todo/` is a tiny TODO app with three suggested features to learn the sprint flow without touching a real project. See [`examples/starter-todo/README.md`](examples/starter-todo/README.md).
+
 Or jump straight in:
 
 ```

--- a/examples/starter-todo/README.md
+++ b/examples/starter-todo/README.md
@@ -1,0 +1,71 @@
+# Starter TODO
+
+A sandbox for trying nanostack. Tiny TODO app in one HTML file (under 100 lines, zero dependencies, no build step). The point is not the code. It is having a real, harmless project to run a full nanostack sprint on before touching anything you care about.
+
+## How to use this
+
+```bash
+git clone https://github.com/garagon/nanostack
+cd nanostack/examples/starter-todo
+```
+
+Open `index.html` in your browser to see what you are starting with.
+
+If you have not installed nanostack yet:
+
+```bash
+npx create-nanostack
+```
+
+Then in your agent (Claude Code, Cursor, Codex, OpenCode, Gemini), from inside this directory:
+
+```
+/nano-run
+```
+
+Answer the questions. Then pick a feature from the list below and try a full sprint.
+
+## Three features to try
+
+Each one is small enough to finish in one sprint. Each one teaches something different about the workflow.
+
+### 1. Persist tasks across reloads
+
+> "Tasks disappear when I refresh the page. Save them so they come back."
+
+Touches: 1 file (`index.html`), localStorage.
+What you learn: how `/think` reframes "save them" into the smallest version that works (probably localStorage, not a backend); how `/review` checks scope drift; how `/qa` actually opens the page and checks the behavior.
+
+### 2. Add a "delete" button to each task
+
+> "I can mark tasks done but I cannot remove them. Add a delete button."
+
+Touches: 1 file (`index.html`).
+What you learn: how `/nano` plans a tiny change with explicit out-of-scope items; how `/review` catches missing edge cases (what if the list is empty?).
+
+### 3. Filter tasks by status
+
+> "Show me a way to see only tasks that are not done yet."
+
+Touches: 1 file (`index.html`), some UI state.
+What you learn: how `/think` may push back ("do you need filters, or do you need to hide done items?"). A good test of whether the agent challenges your framing or just does what you said.
+
+## What to expect
+
+A first sprint on this project should take around 5-10 minutes end to end. You will see the agent:
+
+1. `/think` ask you about the why and the smallest version
+2. `/nano` write a plan that lists every file touched
+3. Build the change
+4. `/review` give you a one-line summary with auto-fixed nits
+5. `/security` grade the change (most likely an A, there is no backend)
+6. `/qa` open the page and confirm the new behavior works
+7. `/ship` wrap it up (or just stop here, since this is a sandbox)
+
+If anything confuses you, see [`../../TROUBLESHOOTING.md`](../../TROUBLESHOOTING.md).
+
+## Notes
+
+- This example uses `.nanostack/` for sprint artifacts. That directory is gitignored at the repo root.
+- The HTML is intentionally simple. If you want to change the styling or framework as your first feature, that is fine. It teaches you how `/nano` handles bigger refactors.
+- Once you are comfortable, delete this directory or just ignore it. It is not a dependency of nanostack itself.

--- a/examples/starter-todo/index.html
+++ b/examples/starter-todo/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Starter TODO — nanostack example</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font: 16px/1.5 system-ui, -apple-system, sans-serif;
+      max-width: 32rem;
+      margin: 4rem auto;
+      padding: 0 1rem;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+    form { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
+    input[type=text] {
+      flex: 1;
+      padding: 0.5rem 0.75rem;
+      font: inherit;
+      border: 1px solid currentColor;
+      border-radius: 0.375rem;
+      background: transparent;
+      color: inherit;
+    }
+    button {
+      padding: 0.5rem 1rem;
+      font: inherit;
+      border: 1px solid currentColor;
+      border-radius: 0.375rem;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+    }
+    ul { list-style: none; padding: 0; }
+    li {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+    }
+    li.done span { opacity: 0.5; text-decoration: line-through; }
+    li span { flex: 1; }
+    .empty { opacity: 0.6; font-style: italic; }
+  </style>
+</head>
+<body>
+  <h1>Starter TODO</h1>
+  <p>A tiny example to practice nanostack on. See <a href="README.md">README</a>.</p>
+
+  <form id="add">
+    <input type="text" name="task" placeholder="What needs doing?" required autofocus>
+    <button type="submit">Add</button>
+  </form>
+
+  <ul id="list"></ul>
+
+  <script>
+    const list = document.getElementById('list');
+    const form = document.getElementById('add');
+    const tasks = [];
+
+    function render() {
+      list.innerHTML = tasks.length
+        ? tasks.map((t, i) => `
+            <li class="${t.done ? 'done' : ''}">
+              <input type="checkbox" data-i="${i}" ${t.done ? 'checked' : ''}>
+              <span>${t.text}</span>
+            </li>`).join('')
+        : '<li class="empty">No tasks yet.</li>';
+    }
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const text = form.task.value.trim();
+      if (text) tasks.push({ text, done: false });
+      form.reset();
+      render();
+    });
+
+    list.addEventListener('change', e => {
+      const i = e.target.dataset.i;
+      if (i !== undefined) tasks[i].done = e.target.checked;
+      render();
+    });
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

A new user's first sprint is the hardest one. They are learning the flow and the agent at the same time, often on a project that matters. Several pieces of feedback came down to "I want to try this without risking my real work."

This PR adds [`examples/starter-todo/`](examples/starter-todo/), a sandbox project:

- One HTML file (under 100 lines, no build, no deps): a working TODO app with add and check off.
- A README with three suggested features to try: persist tasks, add delete, filter by status. Each is small enough to finish in one sprint and was chosen to exercise a different part of the workflow (scope reframing, edge cases, challenging the user's framing).
- Points at `TROUBLESHOOTING.md` if anything breaks. Tells users they can delete the folder when done. Not a dependency of nanostack.

The main README gains a single sentence near Quick start linking to the sandbox.

## Why a TODO app

It is the smallest non-trivial example. Every web developer recognizes it. There is enough behavior to plan, review, and test, but not so much that the example becomes the lesson. The HTML uses CSS variables for color-scheme so it works in light and dark mode without a framework.

## Backward compatibility

- New top-level `examples/` directory. Nothing else changes.
- README diff is one sentence in the Quick start section.
- No build, no deps, no install step.

## Style

- No em-dashes in prose, no Oxford commas, no emojis (same rules the project applies elsewhere).
- HTML uses `system-ui` font stack and `color-scheme: light dark` so it follows the user's OS preference.

## Test plan

- [x] `index.html` opens in a browser standalone (no server required).
- [x] Form submit adds tasks. Checkbox toggles strikethrough.
- [x] All README links resolve (relative paths to `../../TROUBLESHOOTING.md`).
- [x] Main README link to `examples/starter-todo/README.md` resolves.
- [ ] Reviewer: open the HTML and confirm visual rendering on your OS theme (the example claims dark mode works without a framework).
- [ ] First-run sprint on the sandbox to verify the three suggested features actually walk through the full flow as described.