### PR TITLE
Conductor correctness: portable sha256, JSON build, dead code

### DIFF
--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -10,7 +10,20 @@ source "$SCRIPT_DIR/bin/lib/audit.sh"
 
 CONDUCTOR_DIR="$NANOSTACK_STORE/conductor"
 PROJECT="$(pwd)"
-PROJECT_HASH=$(echo -n "$PROJECT" | shasum -a 256 | cut -c1-12)
+
+# Portable sha256: sha256sum (most Linux), shasum -a 256 (macOS, perl-shasum).
+# Without this, /conductor breaks on Alpine and slim Docker images.
+nano_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256
+  else
+    echo "ERROR: need sha256sum or shasum to compute project hash" >&2
+    return 1
+  fi
+}
+PROJECT_HASH=$(printf '%s' "$PROJECT" | nano_sha256 | cut -c1-12)
 
 # Default phases and dependency graph
 DEFAULT_PHASES='[
@@ -201,12 +214,6 @@ cmd_complete() {
   # Release lock
   rm -rf "$phase_dir/lock"
 
-  # Check if sprint is complete
-  local all_done=true
-  jq -r '.phases[].name' "$sprint_dir/sprint.json" | while read -r p; do
-    [ -f "$sprint_dir/$p/done" ] || { all_done=false; break; }
-  done
-
   audit_log "sprint_complete" "$phase" "$agent"
   echo "OK"
 }
@@ -222,6 +229,9 @@ cmd_abort() {
 }
 
 # ─── status ──────────────────────────────────────────────────
+# Build the JSON entirely with jq so an agent name with quotes or backslashes
+# cannot break the output. Previous version assembled it with printf and was
+# brittle for any value with shell-special characters.
 cmd_status() {
   local sprint_dir
   sprint_dir=$(find_sprint) || { echo '{"status":"no_sprint"}'; exit 0; }
@@ -229,32 +239,30 @@ cmd_status() {
   local sprint_id
   sprint_id=$(jq -r '.sprint_id' "$sprint_dir/sprint.json")
 
-  echo "{"
-  echo "  \"sprint_id\": \"$sprint_id\","
-  echo "  \"project\": \"$PROJECT\","
-  echo "  \"phases\": {"
-
-  local first=true
-  jq -r '.phases[].name' "$sprint_dir/sprint.json" | while read -r phase; do
+  # Walk each phase and emit one JSON object per line; jq -s wraps them in an
+  # array which we then convert into the {phase: {state, agent, at}} map.
+  local phases_json
+  phases_json=$(jq -r '.phases[].name' "$sprint_dir/sprint.json" | while read -r phase; do
     local state="pending" agent="" ts=""
     if [ -f "$sprint_dir/$phase/done" ]; then
       state="done"
-      agent=$(jq -r '.agent' "$sprint_dir/$phase/done" 2>/dev/null)
-      ts=$(jq -r '.completed_at' "$sprint_dir/$phase/done" 2>/dev/null)
+      agent=$(jq -r '.agent // ""' "$sprint_dir/$phase/done" 2>/dev/null)
+      ts=$(jq -r '.completed_at // ""' "$sprint_dir/$phase/done" 2>/dev/null)
     elif [ -d "$sprint_dir/$phase/lock" ]; then
       state="running"
-      agent=$(jq -r '.agent' "$sprint_dir/$phase/lock/meta.json" 2>/dev/null)
-      ts=$(jq -r '.claimed_at' "$sprint_dir/$phase/lock/meta.json" 2>/dev/null)
+      agent=$(jq -r '.agent // ""' "$sprint_dir/$phase/lock/meta.json" 2>/dev/null)
+      ts=$(jq -r '.claimed_at // ""' "$sprint_dir/$phase/lock/meta.json" 2>/dev/null)
     fi
+    jq -n \
+      --arg name "$phase" --arg state "$state" --arg agent "$agent" --arg at "$ts" \
+      '{name: $name, state: $state, agent: $agent, at: $at}'
+  done | jq -s 'map({(.name): {state: .state, agent: .agent, at: .at}}) | add // {}')
 
-    $first || echo ","
-    first=false
-    printf '    "%s": {"state":"%s","agent":"%s","at":"%s"}' "$phase" "$state" "$agent" "$ts"
-  done
-
-  echo ""
-  echo "  }"
-  echo "}"
+  jq -n \
+    --arg sid "$sprint_id" \
+    --arg project "$PROJECT" \
+    --argjson phases "$phases_json" \
+    '{sprint_id: $sid, project: $project, phases: $phases}'
 }
 
 # ─── clean ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three concrete fixes in `conductor/bin/sprint.sh` from the reliability spec. The conductor is the parallel-sprint orchestrator and the least-tested feature; the audit found real bugs.

### 1. Portable sha256

`shasum -a 256` (line 13) is macOS-default but missing on Alpine, slim Docker images, and bare-metal containerized agents. The first user who runs `/conductor` inside one of those gets `shasum: command not found`.

New `nano_sha256()` wrapper prefers `sha256sum` (most Linux), falls back to `shasum -a 256` (macOS, perl-shasum). Both produce identical first-12-character hashes so `PROJECT_HASH` stays stable across platforms.

### 2. `cmd_status` JSON via `jq -n`

Old `cmd_status` interpolated `$agent` and `$ts` directly into a quoted JSON string with `printf`. Any agent name containing a `"` or `\` produced invalid JSON, which broke every downstream caller that parsed the output.

Now built end-to-end with `jq -n --argjson phases ...`. Verified with `NANOSTACK_AGENT='evil"agent\name'` — `status | jq -e .` succeeds.

### 3. Remove dead `all_done` block in `cmd_complete`

```bash
local all_done=true
jq -r '.phases[].name' "$sprint_dir/sprint.json" | while read -r p; do
  [ -f "$sprint_dir/$p/done" ] || { all_done=false; break; }
done
```

The `while` runs in a subshell because of the pipe, so `all_done=false` never propagates back. The variable is unused after the block. Pure dead code that suggests the conductor marks the sprint complete; it does not.

Removed. If we ever want to write a "sprint complete" marker into `sprint.json`, that will be an explicit follow-up.

## Backward compatibility

- All public commands (`start`, `claim`, `complete`, `abort`, `status`, `batch`, `clean`) keep their interface and behavior.
- `PROJECT_HASH` algorithm output is identical (`sha256sum` and `shasum -a 256` produce the same hex digest; `cut -c1-12` is the same).
- Status JSON has the same shape; only the way it is built changed.
- No flag, env var, or filesystem path is added or removed.

## Test plan

- [x] `bash -n conductor/bin/sprint.sh` passes.
- [x] End-to-end smoke: `start` → `status` (valid JSON, all pending) → `claim think` → `claim think` again (idempotent) → `claim plan` (correctly BLOCKED) → `complete think` → `claim plan` (now allowed) → `status` valid JSON throughout.
- [x] Adversarial: agent name `evil"agent\name` does not break status JSON.
- [ ] Reviewer with Linux/Alpine: confirm `nano_sha256` picks `sha256sum`.
- [ ] Real two-terminal `/conductor` smoke test.