### PR TITLE
Conductor UX: per-process agent identity, next, unstuck

### DIFF
--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -98,6 +98,22 @@ conductor/bin/sprint.sh abort [phase]
 
 Release a claim without completing. Use when an agent encounters a blocker.
 
+### Next
+
+```bash
+conductor/bin/sprint.sh next
+```
+
+Print the first phase that is not done, has all dependencies met, and is not currently locked. Empty output means nothing is claimable right now (sprint complete, or all available phases are held by other agents). Use this so an agent that just joined the sprint does not have to parse `status` to know what to claim.
+
+### Unstuck
+
+```bash
+conductor/bin/sprint.sh unstuck <phase> [--force]
+```
+
+Force-release a lock when its owner PID is dead, without waiting the 1-hour grace period that `claim` uses for auto-recovery. Refuses if the PID is alive (you should let the owner finish or call `abort` yourself); pass `--force` to release a lock with a live PID. Use this when an agent crashed without releasing its lock and you need to keep moving.
+
 ### Batch (auto-parallelize)
 
 ```bash

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -36,19 +36,39 @@ DEFAULT_PHASES='[
   {"name":"ship","depends_on":["review","qa","security"]}
 ]'
 
-# Detect agent name (must be stable across invocations)
+# Detect agent name. Identity must be stable within one process and unique
+# across processes — two terminals running the same agent (e.g., two Claude
+# Code sessions on the same machine) used to both resolve to "claude" and
+# collide on the same lock.
+#
+# Strategy: <agent-family>-<short-id>, where short-id is the agent's session
+# id when exposed, otherwise the parent shell PID. NANOSTACK_AGENT overrides
+# everything for tests and explicit naming.
 detect_agent() {
   if [ -n "${NANOSTACK_AGENT:-}" ]; then
     echo "$NANOSTACK_AGENT"
-  elif [ -n "${CLAUDE_SESSION_ID:-}" ] || [ -n "${CLAUDE_CODE:-}" ]; then
-    echo "claude"
-  elif [ -n "${CODEX_SESSION_ID:-}" ]; then
-    echo "codex"
-  elif [ -n "${OPENCODE_SESSION_ID:-}" ]; then
-    echo "opencode"
-  else
-    echo "agent-$(whoami)"
+    return
   fi
+
+  local family="" short_id=""
+  if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    family="claude"
+    short_id="${CLAUDE_SESSION_ID:0:8}"
+  elif [ -n "${CLAUDE_CODE:-}" ]; then
+    family="claude"
+    short_id="$PPID"
+  elif [ -n "${CODEX_SESSION_ID:-}" ]; then
+    family="codex"
+    short_id="${CODEX_SESSION_ID:0:8}"
+  elif [ -n "${OPENCODE_SESSION_ID:-}" ]; then
+    family="opencode"
+    short_id="${OPENCODE_SESSION_ID:0:8}"
+  else
+    family="agent-$(whoami)"
+    short_id="$PPID"
+  fi
+
+  echo "${family}-${short_id}"
 }
 
 # Find active sprint for this project
@@ -265,6 +285,74 @@ cmd_status() {
     '{sprint_id: $sid, project: $project, phases: $phases}'
 }
 
+# ─── next ────────────────────────────────────────────────────
+# Print the first phase that is not done, has all dependencies met, and is
+# not currently locked by anyone. Empty output means nothing is claimable
+# right now (sprint complete, or all available phases held by other agents).
+cmd_next() {
+  local sprint_dir
+  sprint_dir=$(find_sprint) || { echo "ERROR: no active sprint" >&2; exit 1; }
+
+  jq -r '.phases[].name' "$sprint_dir/sprint.json" | while read -r phase; do
+    # Skip done and locked phases
+    [ -f "$sprint_dir/$phase/done" ] && continue
+    [ -d "$sprint_dir/$phase/lock" ] && continue
+
+    # Check deps
+    local deps_met=true
+    local deps
+    deps=$(jq -r --arg p "$phase" '.phases[] | select(.name == $p) | .depends_on[]' "$sprint_dir/sprint.json" 2>/dev/null)
+    for dep in $deps; do
+      if [ ! -f "$sprint_dir/$dep/done" ]; then
+        deps_met=false
+        break
+      fi
+    done
+
+    if [ "$deps_met" = true ]; then
+      echo "$phase"
+      return
+    fi
+  done
+}
+
+# ─── unstuck ─────────────────────────────────────────────────
+# Force-release a lock when its owner PID is dead, without waiting the 1h
+# grace period that claim's auto-recovery uses. Refuses if the PID is alive
+# (you must let the owner finish or call abort yourself). Pass --force to
+# release a lock with a live PID; required when stdin is not a TTY.
+cmd_unstuck() {
+  local phase="${1:?Usage: sprint.sh unstuck <phase> [--force]}"
+  local force=false
+  [ "${2:-}" = "--force" ] && force=true
+
+  local sprint_dir
+  sprint_dir=$(find_sprint) || { echo "ERROR: no active sprint" >&2; exit 1; }
+
+  local lock_dir="$sprint_dir/$phase/lock"
+  if [ ! -d "$lock_dir" ]; then
+    echo "OK: '$phase' has no lock"
+    return 0
+  fi
+
+  local lock_pid lock_agent
+  lock_pid=$(jq -r '.pid // 0' "$lock_dir/meta.json" 2>/dev/null)
+  lock_agent=$(jq -r '.agent // "unknown"' "$lock_dir/meta.json" 2>/dev/null)
+
+  if [ "$lock_pid" -gt 0 ] && kill -0 "$lock_pid" 2>/dev/null; then
+    if [ "$force" != true ]; then
+      echo "REFUSED: '$phase' is held by '$lock_agent' (PID $lock_pid is alive)" >&2
+      echo "Pass --force only if you are sure that process is no longer doing useful work." >&2
+      exit 1
+    fi
+    echo "WARNING: forcing release of lock held by alive PID $lock_pid ($lock_agent)" >&2
+  fi
+
+  rm -rf "$lock_dir"
+  audit_log "sprint_unstuck" "$phase" "$lock_agent"
+  echo "OK: released '$phase' (was held by '$lock_agent')"
+}
+
 # ─── clean ───────────────────────────────────────────────────
 cmd_clean() {
   # Remove archived sprints older than 7 days
@@ -379,8 +467,10 @@ case "$CMD" in
   status)   cmd_status "$@" ;;
   batch)    cmd_batch "$@" ;;
   clean)    cmd_clean "$@" ;;
+  next)     cmd_next "$@" ;;
+  unstuck)  cmd_unstuck "$@" ;;
   *)
-    echo "Usage: sprint.sh <start|claim|complete|abort|status|batch|clean>" >&2
+    echo "Usage: sprint.sh <start|claim|complete|abort|status|batch|clean|next|unstuck>" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Three UX improvements to `/conductor` from the reliability spec, building on the correctness fixes in PR #104.

### `detect_agent` returns a per-process identity

Two terminals running the same agent on the same machine used to both resolve to `"claude"` (or `"codex"`, etc.) and fight over the same lock. The second agent's own claim came back as "held by another agent" — confusing.

New format: `<family>-<short-id>`.
- `short-id` is the agent's session id when the runtime exposes one (`CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, `OPENCODE_SESSION_ID`).
- Falls back to the parent shell PID (`$PPID`) when no session id is exposed. Different terminals have different PPIDs.
- `NANOSTACK_AGENT` still overrides everything for explicit naming.

### `sprint.sh next`

```bash
conductor/bin/sprint.sh next
```

Prints the first phase that is not done, has dependencies met, and is not locked. Empty output means nothing is claimable right now. Analog to `bin/next-step.sh` from V2 but for the multi-agent sprint. Lets an agent that just joined the sprint know what to claim without parsing `status` JSON.

### `sprint.sh unstuck <phase> [--force]`

Force-releases a stuck lock when its owner PID is dead, without waiting the 1-hour grace period that auto-recovery uses inside `claim`. Refuses if the PID is alive (you should let the owner finish or call `abort` yourself). `--force` overrides with a warning.

Sample:

```
$ sprint.sh unstuck plan
REFUSED: 'plan' is held by 'claude-abc12345' (PID 50399 is alive)
Pass --force only if you are sure that process is no longer doing useful work.

$ sprint.sh unstuck plan --force
WARNING: forcing release of lock held by alive PID 50399 (claude-abc12345)
OK: released 'plan' (was held by 'claude-abc12345')
```

`conductor/SKILL.md` documents both new commands.

## Backward compatibility

- All existing commands (`start`, `claim`, `complete`, `abort`, `status`, `batch`, `clean`) keep their interface and output.
- `detect_agent` format change is invisible to callers — the lock metadata already stored an opaque string.
- New commands are additive; none of the existing dispatch table entries changed.

## Test plan

- [x] `bash -n` passes (lint workflow check 1).
- [x] No em-dashes in public copy (lint workflow check 3).
- [x] `next` returns the right phase across `start` → `claim think` → `next (empty)` → `complete think` → `next = plan`.
- [x] `unstuck` REFUSES on a real alive PID without `--force`.
- [x] `unstuck --force` releases a live-PID lock with a warning.
- [x] `unstuck` releases on a confirmed-dead PID without prompting.
- [x] `unstuck` no-op on a phase with no lock.
- [ ] Real two-terminal smoke test: confirm two Claude Code sessions on one machine claim independently and `next` keeps each one productive.