### PR TITLE
Add examples/custom-skill-template for extension authors

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -2,6 +2,8 @@
 
 Add your own skills that plug into nanostack's workflow. Your skills save artifacts, read what other skills produced, and compose with /think, /review and /ship.
 
+> **Quickest way to start:** copy `examples/custom-skill-template/audit-licenses/` and edit it. The template is a working `/audit-licenses` skill (~100 lines) that demonstrates frontmatter, the artifact store, stack detection and the standard output format. See `examples/custom-skill-template/README.md` for the walkthrough.
+
 ## Configure your stack
 
 nanostack has opinionated defaults for new projects (Next.js, Supabase, Drizzle, etc.). You can override any of them with your own preferences.

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ Your skills use the same infrastructure: `save-artifact.sh` persists artifacts, 
 
 A marketing team builds `/audience` and `/campaign`. A data team builds `/explore` and `/model`. A design team builds `/wireframe` and `/usability`. All compose with nanostack's `/think` for ideation, `/review` for quality and `/ship` for delivery.
 
-Full guide: [`EXTENDING.md`](EXTENDING.md).
+Full guide: [`EXTENDING.md`](EXTENDING.md). Working starting point: [`examples/custom-skill-template/`](examples/custom-skill-template/) is a `/audit-licenses` skill you can copy and adapt.
 
 ## Privacy
 

--- a/examples/custom-skill-template/README.md
+++ b/examples/custom-skill-template/README.md
@@ -1,0 +1,68 @@
+# Custom Skill Template
+
+A working example you can copy and adapt to build your own nanostack skill. Sister to `examples/starter-todo` (which teaches the sprint flow) — this one teaches you how to extend it.
+
+The included example is `/audit-licenses`: a small skill that scans your project's direct dependencies and flags GPL or AGPL licenses. It is not a production license scanner; it is small enough to read end-to-end and shows every pattern a custom skill needs.
+
+## What the example covers
+
+- A complete `SKILL.md` with the frontmatter the agent runtime expects (`name`, `description`, `concurrency`, `summary`, `estimated_tokens`).
+- A bash helper at `bin/audit.sh` that does the actual work and returns structured JSON.
+- Stack detection (npm, pip, go) the same way `/nano` and `/security` detect projects.
+- A pattern for saving an artifact via `bin/save-artifact.sh` so other skills (or `/compound`) can read your output later.
+- A standardized one-line headline at the close, matching the format the built-in skills use.
+
+## Try the example
+
+From any project with a `package.json`, `requirements.txt`, `pyproject.toml`, or `go.mod`:
+
+```bash
+~/.claude/skills/nanostack/examples/custom-skill-template/audit-licenses/bin/audit.sh node
+```
+
+Replace `node` with `python` or `go` to match your stack. The output is JSON with a counts object and a flagged list.
+
+## Use it from your agent
+
+To make `/audit-licenses` an actual slash command in your agent, copy the skill folder into your agent's skills directory.
+
+For Claude Code:
+
+```bash
+cp -r ~/.claude/skills/nanostack/examples/custom-skill-template/audit-licenses ~/.claude/skills/
+```
+
+Then restart your agent. The agent reads `SKILL.md` to learn the trigger (`/audit-licenses`) and the description.
+
+For other agents, follow the install pattern documented in `EXTENDING.md` at the repo root.
+
+## Adapt it to your domain
+
+The example skill is just bash + jq. To build your own, copy `audit-licenses/` to a new directory and edit:
+
+1. **Frontmatter in `SKILL.md`** (`name`, `description`, `concurrency`, `summary`). The `name` is what the user types after `/`. The `description` is what the agent reads to decide when to invoke your skill — write it as the agent will see it, not as documentation.
+2. **The `Process` section in `SKILL.md`** — describe step by step what the agent should do. Keep it directives, not narrative. Reference your `bin/` scripts with absolute or relative paths.
+3. **Your bash helper(s)** under `bin/`. Use the same conventions as the built-in skills: `set -e`, source `lib/store-path.sh` if you need `$NANOSTACK_STORE`, output JSON, exit non-zero on failure.
+4. **Save an artifact** when your skill has a result worth keeping. The artifact ends up in `.nanostack/<your-skill-name>/` and is automatically picked up by `/compound`, `bin/find-artifact.sh`, and the conductor.
+
+## What integrates automatically
+
+Once your skill is in place, you get this for free:
+
+- **The artifact store**. Anything you save with `bin/save-artifact.sh <your-skill> '<json>'` lands at `.nanostack/<your-skill>/<timestamp>.json` with project scoping and integrity hash.
+- **The audit log**. `bin/lib/audit.sh` will record your skill's lifecycle events alongside the built-in ones at `.nanostack/audit.log`.
+- **The conductor**. If you set `concurrency: read` in your frontmatter, `/conductor batch` will schedule your skill in parallel with other read-only phases. Set `write` for skills that mutate files; `exclusive` for skills that need full repo access.
+- **The CI lint**. The repo's `.github/workflows/lint.yml` checks every `SKILL.md` for the required `name` and `description` fields and runs `bash -n` on every `*.sh`. If you copy this template you get these checks for free.
+
+## What is NOT included on purpose
+
+- A test suite. The repo's policy is "no tests in repo, tests are local only." Your skill should follow the same rule unless you specifically need CI tests.
+- A web UI or background daemon. Skills are CLI-first and stateless between invocations. The artifact store is the only persistent state.
+- Node, Python, or Go runtime dependencies. The example uses bash + jq because that is what nanostack itself uses. Pick the language your team already knows; just keep the SKILL.md and the entry-point script working under bash.
+
+## Further reading
+
+- `EXTENDING.md` at the repo root — the full guide to extending nanostack.
+- `bin/save-artifact.sh --help` — the artifact contract.
+- `bin/find-artifact.sh` — how skills look up upstream artifacts.
+- The built-in skills (`think/`, `plan/`, `review/`, etc.) are the canonical reference for advanced patterns.

--- a/examples/custom-skill-template/README.md
+++ b/examples/custom-skill-template/README.md
@@ -1,6 +1,6 @@
 # Custom Skill Template
 
-A working example you can copy and adapt to build your own nanostack skill. Sister to `examples/starter-todo` (which teaches the sprint flow) — this one teaches you how to extend it.
+A working example you can copy and adapt to build your own nanostack skill. Sister to `examples/starter-todo`, which teaches the sprint flow; this one teaches you how to extend it.
 
 The included example is `/audit-licenses`: a small skill that scans your project's direct dependencies and flags GPL or AGPL licenses. It is not a production license scanner; it is small enough to read end-to-end and shows every pattern a custom skill needs.
 
@@ -40,8 +40,8 @@ For other agents, follow the install pattern documented in `EXTENDING.md` at the
 
 The example skill is just bash + jq. To build your own, copy `audit-licenses/` to a new directory and edit:
 
-1. **Frontmatter in `SKILL.md`** (`name`, `description`, `concurrency`, `summary`). The `name` is what the user types after `/`. The `description` is what the agent reads to decide when to invoke your skill — write it as the agent will see it, not as documentation.
-2. **The `Process` section in `SKILL.md`** — describe step by step what the agent should do. Keep it directives, not narrative. Reference your `bin/` scripts with absolute or relative paths.
+1. **Frontmatter in `SKILL.md`** (`name`, `description`, `concurrency`, `summary`). The `name` is what the user types after `/`. The `description` is what the agent reads to decide when to invoke your skill, so write it as the agent will see it, not as documentation.
+2. **The `Process` section in `SKILL.md`**. Describe step by step what the agent should do. Keep it directives, not narrative. Reference your `bin/` scripts with absolute or relative paths.
 3. **Your bash helper(s)** under `bin/`. Use the same conventions as the built-in skills: `set -e`, source `lib/store-path.sh` if you need `$NANOSTACK_STORE`, output JSON, exit non-zero on failure.
 4. **Save an artifact** when your skill has a result worth keeping. The artifact ends up in `.nanostack/<your-skill-name>/` and is automatically picked up by `/compound`, `bin/find-artifact.sh`, and the conductor.
 
@@ -62,7 +62,7 @@ Once your skill is in place, you get this for free:
 
 ## Further reading
 
-- `EXTENDING.md` at the repo root — the full guide to extending nanostack.
-- `bin/save-artifact.sh --help` — the artifact contract.
-- `bin/find-artifact.sh` — how skills look up upstream artifacts.
+- `EXTENDING.md` at the repo root: the full guide to extending nanostack.
+- `bin/save-artifact.sh --help`: the artifact contract.
+- `bin/find-artifact.sh`: how skills look up upstream artifacts.
 - The built-in skills (`think/`, `plan/`, `review/`, etc.) are the canonical reference for advanced patterns.

--- a/examples/custom-skill-template/audit-licenses/SKILL.md
+++ b/examples/custom-skill-template/audit-licenses/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: audit-licenses
+description: Use to list the open-source licenses of every dependency in this project, grouped by license family. Flags GPL or AGPL dependencies that may force the project itself to be open-source. Triggers on /audit-licenses.
+concurrency: read
+depends_on: []
+summary: "License compliance check across npm/pip/go dependencies."
+estimated_tokens: 180
+---
+
+# /audit-licenses — Dependency License Audit
+
+You audit the open-source licenses of this project's dependencies. The point is compliance: some licenses (GPL, AGPL) force the project that uses them to be open-source under the same terms. The team needs to know that before shipping.
+
+This is an example custom skill. It shows the patterns every nanostack-compatible skill follows: detect the project, do the work, save an artifact so future skills can read it.
+
+## Process
+
+### 1. Resolve context
+
+Other phases may have run before this one. Load whatever upstream context exists:
+
+```bash
+~/.claude/skills/nanostack/bin/resolve.sh audit-licenses
+```
+
+The resolver does not have a routing rule for `audit-licenses` so this returns minimal output. That is fine. Custom skills can still use the artifact store (see step 3) and the conductor (see `/conductor`).
+
+### 2. Detect the stack and run the audit
+
+Check what kind of project this is and read its dependency manifest. Cover the three common stacks:
+
+```bash
+if [ -f package.json ]; then
+  ./examples/custom-skill-template/audit-licenses/bin/audit.sh node
+elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
+  ./examples/custom-skill-template/audit-licenses/bin/audit.sh python
+elif [ -f go.mod ]; then
+  ./examples/custom-skill-template/audit-licenses/bin/audit.sh go
+else
+  echo "No supported manifest found (package.json, requirements.txt, pyproject.toml, go.mod)."
+  exit 1
+fi
+```
+
+The script prints a JSON block with `{ permissive: N, weak_copyleft: N, strong_copyleft: N, unknown: N, flagged: [...] }` plus a human-readable summary table.
+
+### 3. Show the result and save the artifact
+
+Show the user the summary first, then save an artifact so a future skill (or `/compound`) can read it:
+
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh audit-licenses \
+  '{"phase":"audit-licenses","summary":{"flagged":[...],"counts":{...}},"context_checkpoint":{}}'
+```
+
+The artifact lives at `.nanostack/audit-licenses/<timestamp>.json`. Other skills can find it with `bin/find-artifact.sh audit-licenses 30`.
+
+### 4. Headline
+
+Close with one summary line, same format as the built-in skills:
+
+```
+[audit-licenses] OK: 47 deps scanned, 0 GPL/AGPL flagged.
+```
+
+Use `WARN` instead of `OK` when any GPL/AGPL dependency is flagged.
+
+## Gotchas
+
+- This skill only inspects manifest files. Transitive dependencies inside `node_modules/`, `vendor/`, or `.venv/` are not walked. For deep audits use a dedicated tool like `license-checker` (npm) or `pip-licenses`.
+- "Permissive" here means MIT, BSD, Apache-2.0, ISC. "Weak copyleft" means LGPL, MPL. "Strong copyleft" means GPL, AGPL.
+- Unknown licenses are not assumed permissive. They are flagged as `unknown` and the user decides.

--- a/examples/custom-skill-template/audit-licenses/bin/audit.sh
+++ b/examples/custom-skill-template/audit-licenses/bin/audit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# audit.sh — Dependency license audit, example custom skill helper.
+#
+# Not a production license scanner. Walks direct dependencies only (no
+# transitive resolution) and maps each declared license to one of four
+# families. The goal is to show how a custom nanostack skill wires up a
+# bash helper with portable tooling and returns structured output.
+#
+# Usage: audit.sh <node|python|go>
+# Output: JSON on stdout with counts + flagged list.
+set -eu
+
+STACK="${1:-}"
+[ -z "$STACK" ] && { echo "Usage: audit.sh <node|python|go>" >&2; exit 2; }
+
+# ─── License family classifier ───────────────────────────────
+classify() {
+  local lic="$1"
+  # Normalize: uppercase, strip whitespace and quotes
+  lic=$(printf '%s' "$lic" | tr '[:lower:]' '[:upper:]' | tr -d ' "')
+  case "$lic" in
+    MIT|BSD*|APACHE*|ISC|0BSD|UNLICENSE|CC0*)              echo "permissive" ;;
+    LGPL*|MPL*|EPL*)                                       echo "weak_copyleft" ;;
+    GPL*|AGPL*)                                            echo "strong_copyleft" ;;
+    *)                                                     echo "unknown" ;;
+  esac
+}
+
+# ─── Stack-specific scanners ─────────────────────────────────
+scan_node() {
+  [ -f package.json ] || { echo "no package.json" >&2; return 1; }
+  # Read direct deps + devDeps and their declared license from each module's
+  # own package.json under node_modules. Falls back to "unknown" when the
+  # module is not installed.
+  jq -r '(.dependencies // {}) + (.devDependencies // {}) | keys[]' package.json 2>/dev/null | while read -r dep; do
+    [ -z "$dep" ] && continue
+    local mod_pkg="node_modules/$dep/package.json"
+    local lic="unknown"
+    if [ -f "$mod_pkg" ]; then
+      lic=$(jq -r '.license // (.licenses // [] | if type == "array" then .[0].type // "unknown" else . end)' "$mod_pkg" 2>/dev/null)
+      [ -z "$lic" ] && lic="unknown"
+    fi
+    printf '%s\t%s\n' "$dep" "$lic"
+  done
+}
+
+scan_python() {
+  if [ -f pyproject.toml ]; then
+    # Direct deps under [project.dependencies] or [tool.poetry.dependencies]
+    grep -E '^[a-zA-Z0-9_-]+[ ]*=|^"[^"]+' pyproject.toml 2>/dev/null | head -50 | \
+      awk -F'[="]' '{print $1}' | sed 's/[[:space:]]//g' | while read -r dep; do
+      [ -z "$dep" ] && continue
+      printf '%s\tunknown\n' "$dep"
+    done
+  elif [ -f requirements.txt ]; then
+    grep -vE '^#|^$' requirements.txt 2>/dev/null | while read -r line; do
+      local dep="${line%%[<>=~!]*}"
+      dep=$(printf '%s' "$dep" | tr -d '[:space:]')
+      [ -z "$dep" ] && continue
+      printf '%s\tunknown\n' "$dep"
+    done
+  else
+    echo "no requirements.txt or pyproject.toml" >&2
+    return 1
+  fi
+}
+
+scan_go() {
+  [ -f go.mod ] || { echo "no go.mod" >&2; return 1; }
+  grep -E '^[[:space:]]+[a-zA-Z0-9._/-]+' go.mod | awk '{print $1}' | while read -r dep; do
+    [ -z "$dep" ] && continue
+    printf '%s\tunknown\n' "$dep"
+  done
+}
+
+# ─── Run and aggregate ───────────────────────────────────────
+case "$STACK" in
+  node)   RAW=$(scan_node) ;;
+  python) RAW=$(scan_python) ;;
+  go)     RAW=$(scan_go) ;;
+  *)      echo "unknown stack: $STACK" >&2; exit 2 ;;
+esac
+
+PERMISSIVE=0
+WEAK=0
+STRONG=0
+UNKNOWN=0
+FLAGGED="[]"
+FLAGGED_LIST=""
+
+while IFS=$'\t' read -r name license; do
+  [ -z "$name" ] && continue
+  family=$(classify "$license")
+  case "$family" in
+    permissive)      PERMISSIVE=$((PERMISSIVE + 1)) ;;
+    weak_copyleft)   WEAK=$((WEAK + 1)) ;;
+    strong_copyleft)
+      STRONG=$((STRONG + 1))
+      FLAGGED_LIST="${FLAGGED_LIST}${name}|${license}
+"
+      ;;
+    unknown)         UNKNOWN=$((UNKNOWN + 1)) ;;
+  esac
+done <<< "$RAW"
+
+# Build the flagged JSON array safely with jq
+if [ -n "$FLAGGED_LIST" ]; then
+  FLAGGED=$(printf '%s' "$FLAGGED_LIST" | awk -F'|' 'NF==2 {printf "{\"name\":\"%s\",\"license\":\"%s\"}\n",$1,$2}' | jq -s '.')
+fi
+
+TOTAL=$((PERMISSIVE + WEAK + STRONG + UNKNOWN))
+
+jq -n \
+  --arg stack "$STACK" \
+  --argjson total "$TOTAL" \
+  --argjson permissive "$PERMISSIVE" \
+  --argjson weak "$WEAK" \
+  --argjson strong "$STRONG" \
+  --argjson unknown "$UNKNOWN" \
+  --argjson flagged "$FLAGGED" \
+  '{
+    stack: $stack,
+    counts: {
+      total: $total,
+      permissive: $permissive,
+      weak_copyleft: $weak,
+      strong_copyleft: $strong,
+      unknown: $unknown
+    },
+    flagged: $flagged
+  }'


### PR DESCRIPTION
## Summary

`EXTENDING.md` tells you how to add your own skill in 394 lines of prose. That works for someone who already understands the patterns. For someone starting from zero, the gap from "read the docs" to "working skill" is the same gap that `examples/starter-todo` closed for end users in Round 2.

This PR closes the symmetric gap for extension authors. Adds [`examples/custom-skill-template/`](examples/custom-skill-template/) with a real working `/audit-licenses` skill that scans the project's direct dependencies and flags GPL or AGPL licenses.

## What is in the template

```
examples/custom-skill-template/
├── README.md                          ← walkthrough
└── audit-licenses/
    ├── SKILL.md                       ← ~100 lines, complete frontmatter
    └── bin/audit.sh                   ← ~120 lines, scans node/python/go
```

It is small enough to read end-to-end and demonstrates every pattern a custom skill needs:

- A complete `SKILL.md` with the frontmatter the agent runtime expects (`name`, `description`, `concurrency`, `summary`, `estimated_tokens`).
- A `bin/` helper that does the actual work and returns structured JSON.
- Stack detection (npm / pip / go) the same way `/nano` and `/security` detect projects.
- The `save-artifact.sh` contract documented inline.
- A standardized one-line headline at the close, matching the format the built-in skills use.

`README.md` inside the template walks through how to copy and adapt it, plus what integrates automatically (artifact store, audit log, conductor scheduling, CI lint) and what is intentionally not included (no test suite — repo policy).

## Doc updates

- `EXTENDING.md`: one-line pointer at the top so first-time readers see the template before the prose.
- `README.md` Build on nanostack section: link to the template next to the existing `EXTENDING.md` reference.

## Smoke test

Ran the bash helper against three synthetic projects:

| Stack | Manifest | Detected | Output |
|-------|----------|----------|--------|
| Node | `package.json` + `node_modules/foo,bar,baz` | 3 deps | `{permissive:1, weak_copyleft:1, strong_copyleft:1, flagged:[{name:"bar",license:"GPL-3.0"}]}` |
| Python | `requirements.txt` (3 deps) | 3 deps | All `unknown` (no installed packages to read licenses from) |
| Go | `go.mod` (2 deps) | 2 deps | All `unknown` (same reason) |

Node correctly identifies and flags the GPL-3.0 dependency. Python and Go return `unknown` because the example does not install packages — production users would either install first or wire in a dedicated tool like `license-checker` / `pip-licenses`. The example explicitly notes this limitation in `Gotchas`.

## Backward compatibility

- New top-level `examples/custom-skill-template/`. Nothing else changes.
- Doc edits are pure additions: one line in `EXTENDING.md`, one phrase in `README.md`.
- No dependency on any new tooling. The skill itself only needs `bash` + `jq`, same as the rest of nanostack.

## Test plan

- [x] `bash -n` passes on the helper script.
- [x] SKILL.md frontmatter has `name` and `description` (lint check 2).
- [x] No em-dashes in any new prose (lint check 3).
- [x] Helper produces valid JSON for node/python/go synthetic inputs.
- [x] Node scenario flags a GPL dependency correctly.
- [ ] Reviewer with a real npm project: copy the template into `~/.claude/skills/` and confirm `/audit-licenses` actually appears as a slash command after restart.