### PR TITLE
Centralize portable shell wrappers, fix 4 retroactive portability bugs

### DIFF
--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -8,6 +8,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
+[ -f "$SCRIPT_DIR/lib/portable.sh" ] && source "$SCRIPT_DIR/lib/portable.sh"
 
 PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days]}"
 MAX_AGE="${2:-30}"
@@ -66,7 +67,11 @@ fi
 if [ "$VERIFY" = true ]; then
   STORED_HASH=$(jq -r '.integrity // ""' "$RESULT" 2>/dev/null)
   if [ -n "$STORED_HASH" ]; then
-    COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | shasum -a 256 | cut -d' ' -f1)
+    if declare -F nano_sha256 >/dev/null 2>&1; then
+      COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | nano_sha256 | cut -d' ' -f1)
+    else
+      COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | shasum -a 256 | cut -d' ' -f1)
+    fi
     if [ "$STORED_HASH" != "$COMPUTED_HASH" ]; then
       echo "INTEGRITY FAILED: $RESULT" >&2
       exit 1

--- a/bin/lib/cache.sh
+++ b/bin/lib/cache.sh
@@ -5,18 +5,28 @@
 # Cache files live under "$NANOSTACK_STORE/.cache/". Set NANOSTACK_NO_CACHE=1
 # to force callers to bypass caches (useful for debugging stale data).
 
-# Cross-platform file mtime in epoch seconds. Echo 0 on failure.
-nano_mtime() {
-  local f="$1"
-  [ -e "$f" ] || { echo 0; return; }
-  if stat -f %m "$f" >/dev/null 2>&1; then
-    stat -f %m "$f"
-  elif stat -c %Y "$f" >/dev/null 2>&1; then
-    stat -c %Y "$f"
-  else
-    echo 0
-  fi
-}
+# nano_mtime moved to lib/portable.sh in V4 so it can be reused outside the
+# cache layer. Source it transparently here so existing callers of cache.sh
+# get nano_mtime as before, with no change to their source pattern.
+_NANO_CACHE_DIR_OF_THIS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_NANO_CACHE_DIR_OF_THIS/portable.sh" ]; then
+  source "$_NANO_CACHE_DIR_OF_THIS/portable.sh"
+else
+  # Fallback if portable.sh is missing (older install): keep the original
+  # local definition so cache.sh still works standalone.
+  nano_mtime() {
+    local f="$1"
+    [ -e "$f" ] || { echo 0; return; }
+    if stat -f %m "$f" >/dev/null 2>&1; then
+      stat -f %m "$f"
+    elif stat -c %Y "$f" >/dev/null 2>&1; then
+      stat -c %Y "$f"
+    else
+      echo 0
+    fi
+  }
+fi
+unset _NANO_CACHE_DIR_OF_THIS
 
 # Age of a file in seconds. Echo a very large number on failure so callers
 # treat missing files as expired.

--- a/bin/lib/portable.sh
+++ b/bin/lib/portable.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# portable.sh — Cross-platform wrappers for shell tools that have different
+# names or flags on macOS (BSD) vs Linux (GNU). Source this file from any
+# script that needs sha256 or file mtime.
+#
+# History: each of these was added piecemeal in earlier rounds (sha256 in V3
+# for /conductor, mtime in V1 for the cache helpers). Centralizing them here
+# stops the next portability bug from being fixed in one site and forgotten
+# in three others.
+#
+# Functions exposed:
+#   nano_sha256         Read stdin, write hex hash + "  -" to stdout (matches
+#                       both `sha256sum` and `shasum -a 256` output format).
+#   nano_mtime <path>   Print the file's mtime as epoch seconds, or 0 if the
+#                       file is missing or stat fails.
+
+# Hash a stream from stdin. Prefers sha256sum (Linux default), falls back to
+# shasum -a 256 (macOS / perl-shasum). Without one of the two, scripts that
+# use this should treat the missing hash as a hard error, not a silent skip.
+nano_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    return 1
+  fi
+}
+
+# File mtime as epoch seconds. Returns 0 on missing file or stat failure so
+# callers that compare timestamps fall back to "treat as old" rather than
+# crashing. Handles BSD (macOS) and GNU (Linux) stat.
+nano_mtime() {
+  local f="$1"
+  [ -e "$f" ] || { echo 0; return; }
+  if stat -c %Y "$f" >/dev/null 2>&1; then
+    stat -c %Y "$f"
+  elif stat -f %m "$f" >/dev/null 2>&1; then
+    stat -f %m "$f"
+  else
+    echo 0
+  fi
+}

--- a/bin/loop-guard.sh
+++ b/bin/loop-guard.sh
@@ -13,6 +13,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
+[ -f "$SCRIPT_DIR/lib/portable.sh" ] && source "$SCRIPT_DIR/lib/portable.sh"
 
 STATE_FILE="$NANOSTACK_STORE/loop-guard.json"
 CMD="${1:-check}"
@@ -22,7 +23,11 @@ git_fingerprint() {
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     local head diff_hash
     head=$(git rev-parse HEAD 2>/dev/null || echo "none")
-    diff_hash=$(git diff HEAD 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+    if declare -F nano_sha256 >/dev/null 2>&1; then
+      diff_hash=$(git diff HEAD 2>/dev/null | nano_sha256 | cut -d' ' -f1)
+    else
+      diff_hash=$(git diff HEAD 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+    fi
     echo "${head}:${diff_hash}"
   else
     echo "no-git"

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -15,6 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
+[ -f "$SCRIPT_DIR/lib/portable.sh" ] && source "$SCRIPT_DIR/lib/portable.sh"
 
 # ─── Session mode: build JSON from git state + summary ──────
 if [ "${1:-}" = "--from-session" ]; then
@@ -134,8 +135,12 @@ ENRICHED=$(echo "$JSON" | jq \
   --arg branch "$(git branch --show-current 2>/dev/null || echo 'unknown')" \
   '. + {timestamp: ($ts), project: ($proj), branch: ($branch)}')
 
-# ── Integrity checksum ──
-CHECKSUM=$(echo "$ENRICHED" | jq -Sc '.' | shasum -a 256 | cut -d' ' -f1)
+# ── Integrity checksum (portable: nano_sha256 or shasum fallback) ──
+if declare -F nano_sha256 >/dev/null 2>&1; then
+  CHECKSUM=$(echo "$ENRICHED" | jq -Sc '.' | nano_sha256 | cut -d' ' -f1)
+else
+  CHECKSUM=$(echo "$ENRICHED" | jq -Sc '.' | shasum -a 256 | cut -d' ' -f1)
+fi
 ENRICHED=$(echo "$ENRICHED" | jq --arg cs "$CHECKSUM" '. + {integrity: $cs}')
 
 echo "$ENRICHED" | jq '.' > "$FILENAME"

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -11,18 +11,23 @@ source "$SCRIPT_DIR/bin/lib/audit.sh"
 CONDUCTOR_DIR="$NANOSTACK_STORE/conductor"
 PROJECT="$(pwd)"
 
-# Portable sha256: sha256sum (most Linux), shasum -a 256 (macOS, perl-shasum).
-# Without this, /conductor breaks on Alpine and slim Docker images.
-nano_sha256() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256
-  else
-    echo "ERROR: need sha256sum or shasum to compute project hash" >&2
-    return 1
-  fi
-}
+# Use the centralized nano_sha256 from bin/lib/portable.sh (V4). Falls back
+# to a local copy if that file is missing (older install) so sprint.sh stays
+# standalone-runnable.
+if [ -f "$SCRIPT_DIR/bin/lib/portable.sh" ]; then
+  source "$SCRIPT_DIR/bin/lib/portable.sh"
+else
+  nano_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum
+    elif command -v shasum >/dev/null 2>&1; then
+      shasum -a 256
+    else
+      echo "ERROR: need sha256sum or shasum to compute project hash" >&2
+      return 1
+    fi
+  }
+fi
 PROJECT_HASH=$(printf '%s' "$PROJECT" | nano_sha256 | cut -c1-12)
 
 # Default phases and dependency graph

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -30,6 +30,8 @@ STORE_PATH_SH="$NANOSTACK_ROOT/bin/lib/store-path.sh"
 
 [ -f "$STORE_PATH_SH" ] || exit 0
 source "$STORE_PATH_SH"
+PORTABLE_SH="$NANOSTACK_ROOT/bin/lib/portable.sh"
+[ -f "$PORTABLE_SH" ] && source "$PORTABLE_SH"
 
 FIND_ARTIFACT="$NANOSTACK_ROOT/bin/find-artifact.sh"
 SESSION_SH="$NANOSTACK_ROOT/bin/session.sh"
@@ -42,9 +44,24 @@ last_code_timestamp() {
   local ts
   ts=$(git log -1 --format=%ct 2>/dev/null || echo 0)
   if [ "$ts" -eq 0 ]; then
-    # No commits yet — use newest source file
-    ts=$(find . -maxdepth 3 \( -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.html' -o -name '*.css' -o -name '*.sh' \) 2>/dev/null \
-      | head -20 | xargs stat -f %m 2>/dev/null | sort -rn | head -1 || echo 0)
+    # No commits yet: use newest source file mtime. Use nano_mtime so this
+    # works on Linux too (the previous `xargs stat -f %m` was BSD-only and
+    # silently returned 0 on Linux, neutering the phase gate).
+    if declare -F nano_mtime >/dev/null 2>&1; then
+      local newest=0 candidate
+      while IFS= read -r f; do
+        candidate=$(nano_mtime "$f")
+        [ "$candidate" -gt "$newest" ] && newest="$candidate"
+      done < <(find . -maxdepth 3 \( -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.html' -o -name '*.css' -o -name '*.sh' \) 2>/dev/null | head -20)
+      ts="$newest"
+    else
+      # Fallback: try BSD stat then GNU stat in one go.
+      ts=$(find . -maxdepth 3 \( -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.html' -o -name '*.css' -o -name '*.sh' \) 2>/dev/null \
+        | head -20 | xargs stat -f %m 2>/dev/null | sort -rn | head -1)
+      [ -z "$ts" ] && ts=$(find . -maxdepth 3 \( -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.html' -o -name '*.css' -o -name '*.sh' \) 2>/dev/null \
+        | head -20 | xargs stat -c %Y 2>/dev/null | sort -rn | head -1)
+      [ -z "$ts" ] && ts=0
+    fi
   fi
   echo "$ts"
 }


### PR DESCRIPTION
## Summary

V3 added a `sha256` wrapper to `conductor/bin/sprint.sh` (PR #104) but I did not search the rest of the repo. Three other call sites kept hard-coding `shasum -a 256`, which fails on Alpine and slim Docker images. One more site used `stat -f %m` without a Linux fallback, silently neutering the phase gate when `git log` returns no commits.

This PR centralizes the wrappers and fixes every call site.

## What is new

`bin/lib/portable.sh` (new file) exports two helpers:

- **`nano_sha256`** — prefers `sha256sum` (Linux default), falls back to `shasum -a 256` (macOS / perl-shasum), errors out clearly when neither is available.
- **`nano_mtime <path>`** — prefers GNU `stat -c %Y`, falls back to BSD `stat -f %m`, returns 0 on missing files.

Sourced (with the established `[ -f ... ] && source ...` guard pattern) by every script that needs hashing or mtime.

## Bugs fixed

| Site | Bug | Symptom on Alpine / Linux |
|------|-----|---------------------------|
| `bin/save-artifact.sh:138` | hardcoded `shasum -a 256` for integrity hash | save fails → sprint pipeline broken |
| `bin/find-artifact.sh:69`  | hardcoded `shasum -a 256` for `--verify` | integrity check silently passes (false negative) |
| `bin/loop-guard.sh:25`     | hardcoded `shasum -a 256` for git diff fingerprint | loop guard never fires |
| `guard/bin/phase-gate.sh:47` | hardcoded `stat -f %m` (BSD only) | `last_code_timestamp = 0` → phase gate lets every commit through |

## Backward compatibility

Each touched script keeps a guarded fallback to the previous shell command when `portable.sh` is missing, so older installs and partial checkouts behave identically to before this PR. `cache.sh` continues to expose `nano_mtime` standalone for the same reason. `conductor/bin/sprint.sh` drops its local copy of `nano_sha256` (added in PR #104) but keeps the same fallback pattern.

## Test plan

- [x] `bash -n` clean across all 7 modified files.
- [x] Lint workflow checks pass locally (file-by-file iteration this time, after the PR #108 lesson).
- [x] Roundtrip on this repo: `save-artifact think '<json>'` produces an integrity hash, `find-artifact think 1 --verify` returns exit 0. Confirms the macOS fallback branch (`shasum -a 256`) works end-to-end.
- [x] No remaining bare `shasum -a 256` or `stat -f %m` in the modified files except in the documented fallback branches.
- [ ] Reviewer on Linux/Alpine: verify `command -v sha256sum` resolves first and the integrity check works there too.