### PR TITLE
Fix README drift: 6-tier guard, document conductor next/unstuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 | Skill | What it does |
 |-------|-------------|
 | `/compound` | **Knowledge** | Documents solved problems after each sprint. Three types: bug, pattern, decision. Solutions evolve across sprints: validated and applied_count track which solutions actually work. `/nano` and `/review` search past solutions automatically, ranked by proven value. Checks if any solutions are ready to graduate into skill files. |
-| `/guard` | **Safety** | Five-tier safety: allowlist, in-project bypass, phase-aware concurrency (blocks writes during read-only phases), phase gate (blocks commit/push until review+security+qa pass), and pattern matching with 33 block rules. Blocked commands get a safer alternative. `/freeze` locks edits to one directory. Rules in `guard/rules.json`. |
+| `/guard` | **Safety** | Six-tier safety: allowlist, in-project bypass, phase-aware concurrency (blocks writes during read-only phases), phase gate (blocks commit/push until review+security+qa pass), budget gate (blocks all commands when sprint cost exceeds the limit), and pattern matching with 33 block rules. Blocked commands get a safer alternative. `/freeze` locks edits to one directory. Rules in `guard/rules.json`. |
 | `/conductor` | **Orchestrator** | Parallel agent sessions with auto-batching. `sprint.sh batch` reads skill concurrency metadata and groups parallel-safe phases. Session resume on crash. Dependency validation before each phase. No daemon, just atomic file ops. |
 | `/feature` | **Builder** | Add functionality to an existing project. Skips /think, goes straight to plan, build, review, audit, test, ship. |
 | `/nano-run` | **Onboarding** | First-time setup. Configures stack, permissions, and work preferences through a conversation. Auto-detects your project and guides your first sprint. |
@@ -292,6 +292,12 @@ Nanostack works well with one agent. It gets interesting with three running at o
 No daemon. No message queue. Just `mkdir` for atomic locking, JSON for state, symlinks for artifact handoff.
 
 `sprint.sh batch` reads each skill's `concurrency` metadata (read, write, exclusive) and outputs execution batches. Review, QA and security are all `read` and share the same dependency, so they batch together automatically.
+
+### Coordination commands
+
+`sprint.sh next` prints the first phase that is not done, has all dependencies met, and is not currently locked. An agent that just joined the sprint runs this to know what to claim, without parsing `status` JSON.
+
+`sprint.sh unstuck <phase>` force-releases a stuck lock when its owner PID is dead, so a crashed agent does not block the sprint for the 1-hour grace period that auto-recovery uses. Refuses if the PID is alive; pass `--force` to override with a warning.
 
 ### Session resume
 


### PR DESCRIPTION
## Summary

Post-V4 documentation review (no new feature work) found two real drifts in `README.md` that contradicted either the code or the rest of the same file.

### 1. Five vs six tiers — internal contradiction

- **Line 116** (Power tools table): "Five-tier safety: allowlist, in-project bypass, phase-aware concurrency, phase gate, and pattern matching..."
- **Line 320** (Guard section): "guard evaluates every command through **six tiers**" and enumerates Tier 1, 2, 2.5, 2.75, 2.8, 3.

The same README contradicted itself. The budget gate (Tier 2.8) was added in V1 PR #97 and the summary line was never updated. Fixed: "Six-tier safety" with the budget gate explicitly listed alongside the others.

### 2. Conductor `next` and `unstuck` not in README

V3 PR #106 added two commands to `/conductor`:
- `sprint.sh next` — print the first claimable phase, so an agent that just joined the sprint knows what to claim without parsing `status` JSON.
- `sprint.sh unstuck <phase>` — force-release a lock with a dead PID without waiting the 1-hour grace.

Both were documented in `conductor/SKILL.md` (which the agent reads) but a human reading the README's Parallel sprints section never learned they exist. Added a "Coordination commands" subsection between the batch description and Session resume.

## What was checked and is fine

Drift checks across all top-level docs came back clean:
- `README.es.md` already says "Seis tiers" (correct from V2 #102).
- `TROUBLESHOOTING.md` linked from README.
- `examples/starter-todo/` and `examples/custom-skill-template/` both linked.
- `/think --retro` mentioned 5 times in README.
- 13-skills count matches reality (12 internal SKILL.md + the meta-skill at root).
- `EXTENDING.md`, `ZEN.md`, `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md` — no drift.

## Backward compatibility

Pure documentation. No code, no flags, no behavior changes.

## Test plan

- [x] `grep '5-tier\|Five-tier' README.md` returns nothing.
- [x] Both tier mentions in README now agree on six.
- [x] `sprint.sh next` and `sprint.sh unstuck` appear in README's Parallel sprints section.
- [x] Em-dash check passes (file-by-file iteration, lesson from V3 #108).