### PR TITLE
Add opt-in telemetry with deployed Cloudflare Worker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,3 +77,136 @@ jobs:
             fi
           done
           exit $fail
+
+  telemetry-privacy:
+    name: Telemetry privacy contract
+    runs-on: ubuntu-latest
+    # Principle of least privilege: this job only reads source files to
+    # grep for forbidden patterns and validate the schema. It never needs
+    # to write to the repo, comment on PRs, or dispatch workflows.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Forbidden identity patterns in telemetry path
+        run: |
+          # The telemetry helper and config CLI must never read machine
+          # identity, account identity, or repo/branch state. This job
+          # greps for patterns that would do so, skipping comment lines
+          # (so the privacy contract itself can mention the words
+          # without tripping the check).
+          set -e
+          targets="bin/lib/telemetry.sh bin/telemetry-config.sh"
+          forbidden='HOSTNAME|USERNAME|LOGNAME|\$USER\b|whoami|[^_[:alnum:]]hostname[^_[:alnum:]]|git[[:space:]]+remote|git[[:space:]]+branch|git[[:space:]]+config|git[[:space:]]+rev-parse|basename[[:space:]]+"?\$PWD|basename[[:space:]]+"?\$\(pwd|ifconfig|ip[[:space:]]+addr'
+          fail=0
+          for f in $targets; do
+            [ -f "$f" ] || continue
+            # Skip lines that are pure comments (first non-whitespace is #).
+            if grep -vE '^[[:space:]]*#' "$f" | grep -En "$forbidden"; then
+              echo "FAIL: $f contains forbidden identity-reading pattern"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Schema field whitelist (telemetry.sh vs TELEMETRY.md)
+        run: |
+          # The frozen v1 schema is declared on a single line in
+          # bin/lib/telemetry.sh marked 'TELEMETRY_FIELDS_V1:'. Every
+          # field must appear in TELEMETRY.md with backticks, and every
+          # key used inside a jq filter in telemetry.sh must be in this
+          # declared list. Adding a field is a two-edit change: update
+          # the declared list AND document it in TELEMETRY.md.
+          set -e
+          declared=$(grep -oE 'TELEMETRY_FIELDS_V1:[[:space:]]+[a-z_ ]+' bin/lib/telemetry.sh \
+                     | sed -E 's/^TELEMETRY_FIELDS_V1:[[:space:]]+//' \
+                     | head -1)
+          if [ -z "$declared" ]; then
+            echo "FAIL: bin/lib/telemetry.sh has no TELEMETRY_FIELDS_V1 declaration"
+            exit 1
+          fi
+          echo "declared fields: $declared"
+          fail=0
+          # Every declared field must be in TELEMETRY.md with backticks.
+          for key in $declared; do
+            if ! grep -q "\`$key\`" TELEMETRY.md; then
+              echo "FAIL: TELEMETRY.md missing field '\`$key\`'"
+              fail=1
+            fi
+          done
+          # Every key:$var occurrence inside a jq filter must be in declared.
+          # Pattern targets jq object literals: '{key:$var' or ', key:$var' or ', key:null'.
+          used=$(grep -oE '[{,][[:space:]]*[a-z_]+:(\$[a-zA-Z_]+|null)' bin/lib/telemetry.sh \
+                 | grep -oE '[a-z_]+:' \
+                 | tr -d ':' \
+                 | sort -u)
+          for key in $used; do
+            case " $declared " in
+              *" $key "*) ;;
+              *)
+                echo "FAIL: telemetry.sh jq filter uses undeclared field '$key'"
+                echo "      Add it to TELEMETRY_FIELDS_V1 AND TELEMETRY.md schema table."
+                fail=1
+                ;;
+            esac
+          done
+          exit $fail
+
+  telemetry-worker-privacy:
+    name: Telemetry Worker privacy invariants
+    runs-on: ubuntu-latest
+    # The Worker source must preserve four marker comments that correspond to
+    # concrete security properties documented in TELEMETRY.md. Removing any
+    # marker (which implies removing the property) breaks this check.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Worker source exists
+        run: |
+          set -e
+          [ -f telemetry-worker/src/index.ts ] || {
+            echo "FAIL: telemetry-worker/src/index.ts missing"
+            exit 1
+          }
+      - name: Required invariant markers
+        run: |
+          # Each marker corresponds to a security property; see TELEMETRY.md
+          # "Transport security" section. Removing a marker means the property
+          # is no longer enforced, and this check fails the PR.
+          set -e
+          required='HTTPS_ENFORCED SCHEMA_STRICT IP_NEVER_STORED NO_BODY_LOGGING'
+          fail=0
+          for marker in $required; do
+            if ! grep -q "$marker" telemetry-worker/src/index.ts; then
+              echo "FAIL: marker '$marker' missing from telemetry-worker/src/index.ts"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: No body logging
+        run: |
+          # The Worker must never log request bodies, headers beyond status,
+          # or any content derived from them. This greps for console.* calls
+          # that reference the request object, body, or parsed event data.
+          set -e
+          forbidden='console\.(log|debug|info|warn|error)[[:space:]]*\([^)]*(request|req\.|body|event|headers|payload)'
+          fail=0
+          if grep -vE '^[[:space:]]*(//|\*)' telemetry-worker/src/index.ts | grep -En "$forbidden"; then
+            echo "FAIL: Worker logs request/body/headers content"
+            fail=1
+          fi
+          exit $fail
+      - name: No raw IP persistence
+        run: |
+          # The raw CF-Connecting-IP may only appear inside rate-limit logic.
+          # It must never be passed to D1 .bind() or written to any log.
+          # Simple check: grep for IP-related variables near DB.prepare/bind
+          # outside the rateLimitKey function scope.
+          set -e
+          # Allow IP read only in one place (rate limit). Fail if we see it
+          # anywhere near D1 insertion code.
+          if grep -nE 'CF-Connecting-IP|clientIp' telemetry-worker/src/index.ts | \
+             grep -qE 'bind|INSERT|prepare|batch|INTO events'; then
+            echo "FAIL: clientIp appears near D1 write path"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ tests/
 
 # Nanostack knowledge base (internal docs, specs, decisions — not for public repo)
 Nanostack/
+
+# Cloudflare Worker build artifacts (never commit)
+telemetry-worker/.wrangler/
+telemetry-worker/node_modules/
+telemetry-worker/bun.lock

--- a/README.md
+++ b/README.md
@@ -654,7 +654,17 @@ Full guide: [`EXTENDING.md`](EXTENDING.md). Working starting point: [`examples/c
 
 ## Privacy
 
-All data stays on your machine in `.nanostack/`. No remote calls. No telemetry.
+Sprint data (briefs, plans, artifacts, journals) stays on your machine in `.nanostack/`. That has not changed.
+
+v0.5 adds **opt-in telemetry** about skill usage. Three tiers: `off`, `anonymous`, `community`. Installs from v0.4 and earlier default to `off` and see no prompt. New installs see a one-time prompt on first skill run. Nothing is sent over the network in the initial v0.5 release; a remote endpoint lands in a later PR. Full disclosure of what is collected, what is never collected, and how to audit or opt out: [TELEMETRY.md](TELEMETRY.md).
+
+Change your tier at any time:
+
+```sh
+nanostack-config set telemetry off
+nanostack-config set telemetry anonymous
+nanostack-config set telemetry community
+```
 
 Run `bin/analytics.sh` to see your own usage: which skills you run, how often, in what mode. Reads local artifacts only.
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,339 @@
+# Telemetry
+
+**TL;DR.** nanostack has opt-in telemetry about skill usage. Three tiers: `off`, `anonymous`, `community`. Default is `off`; you must opt in explicitly. Opt out any time with `nanostack-config set telemetry off`. The client writes events locally to `~/.nanostack/` regardless; a Cloudflare Worker at `nanostack-telemetry.remoto.workers.dev` accepts opt-in uploads and is the only network endpoint involved. Source of the Worker lives in this repo under `telemetry-worker/`.
+
+This document is the source of truth for what we collect, why, and how to audit it. If you find a gap between this file and the code, that is a bug; open an issue.
+
+## How to turn it off
+
+One command, any time:
+
+```sh
+nanostack-config set telemetry off
+```
+
+That is it. No reboot, no reinstall, no follow-up. The next skill you run will not write any event. To also delete the local log of past events:
+
+```sh
+nanostack-config clear-data
+```
+
+If nanostack was already installed on your system before this feature existed, your tier defaults to `off` and you see no prompt. You do not have to do anything.
+
+## Why this exists
+
+Without usage data we cannot tell which skills are used most, where sprints abort, which `error_class` shows up in production, or which nanostack version is in the wild. Every prioritization decision becomes gut feel. Opt-in telemetry answers the questions that shape what gets fixed next.
+
+### What your opt-in answers
+
+- Which skill is the entry point for most sprints.
+- What percentage of `/think` sprints reach `/ship`. If half abort before shipping, something upstream is wrong.
+- Which `error_class` shows up most often. That is the next bug to fix.
+- Which versions are running. Critical for deciding when to deprecate a behavior.
+- Whether any users actually run nanostack in Alpine, slim Docker, or older macOS.
+
+The difference between the two opt-in tiers:
+
+- **Anonymous** answers "how many people use X". Enough to prioritize.
+- **Community** answers "do people who use X also use Y, and in what order". Better for understanding real workflows and catching regressions that only show up in specific sequences.
+
+Neither tier reveals who you are or what you are building. You pick which question you are willing to help answer.
+
+## The three tiers
+
+When a new installation first runs any skill, nanostack prompts once. The choice persists in `~/.nanostack/user-config.json`.
+
+| Tier | Local write | Remote send | Notes |
+|---|---|---|---|
+| `off` | Nothing | Nothing | No JSONL file is created. |
+| `anonymous` | Full event | Same event minus `session_id` and `installation_id` | Server sees unlinked events. Cannot tie two events together. |
+| `community` | Full event | Full event including `session_id` and `installation_id` | Server can see flow within one sprint and across sprints of the same installation. Installation identity is a random UUID with no tie to your machine, name, or account. |
+
+Change tier at any time:
+
+```sh
+nanostack-config set telemetry off
+nanostack-config set telemetry anonymous
+nanostack-config set telemetry community
+```
+
+## Schema v1 (frozen)
+
+Every recorded event is one JSON object on one line in `~/.nanostack/analytics/skill-usage.jsonl`. Schema v1 is frozen. Future versions add fields; they never rename, remove, or repurpose.
+
+```json
+{
+  "v": 1,
+  "ts": "2026-04-21T12:00:00Z",
+  "skill": "think",
+  "session_id": "12345-1776747000",
+  "nanostack_version": "0.5.0",
+  "os": "darwin",
+  "arch": "arm64",
+  "duration_s": 180,
+  "outcome": "success",
+  "error_class": null,
+  "installation_id": "a3f7c2e1-4b9d-4e8a-b21c-d8f92c4a7e1b"
+}
+```
+
+Field by field:
+
+| Field | Type | Why | Collected when |
+|---|---|---|---|
+| `v` | int | Schema version. Enables forward-compatible changes. | always |
+| `ts` | ISO-8601 UTC | When the skill finished. Rounded to the second. | always |
+| `skill` | string | Which skill ran. This is the primary signal. | always |
+| `session_id` | string | Links events within one sprint. `$PID-$EPOCH`. Never crosses sprints. | always locally; community only remotely |
+| `nanostack_version` | string | Version of the installed skill. Helps us triage by release. | always |
+| `os` | enum `darwin`, `linux`, `unknown` | Portability signal. Any other value collapses to `unknown`. | always |
+| `arch` | enum `x86_64`, `arm64`, `unknown` | Portability signal. Any other value collapses to `unknown`. | always |
+| `duration_s` | int seconds or null | Performance signal. Rounded to the second, never milliseconds. | when computable |
+| `outcome` | enum `success`, `error`, `abort`, `unknown` | Success rate metric. | always |
+| `error_class` | enum from a whitelist or `other`, or null | Triage signal. Whitelist prevents leaking error strings. | when outcome is `error` |
+| `installation_id` | UUID v4 or null | Stable identity for the installation, random, not derived. | community tier only |
+
+The enum whitelists are enforced in `bin/lib/telemetry.sh` and checked by CI. Any value outside the enum collapses to the fallback (`unknown`, `other`). This guards against accidental leakage of a string that contains user-specific information.
+
+## How anonymization works
+
+Three mechanisms, applied at different points in the pipeline.
+
+### 1. Identity-free by construction
+
+The fields we collect are deliberately chosen to be non-identifying. `skill`, `duration_s`, `outcome`, `os`, `arch`, `nanostack_version`. None of these say anything about who you are. They are the minimum needed to answer aggregate questions about how nanostack is used.
+
+Fields that would identify you (hostname, username, repo name, branch, file paths, code, prompts, LLM responses) are never read by the telemetry code. This is enforced by a CI grep on every PR. If a contributor tries to add one, the build fails before the code can be merged.
+
+### 2. installation_id is not a fingerprint
+
+When you opt into `community`, nanostack generates a UUID v4 at `~/.nanostack/installation-id`. Three properties worth stating:
+
+- **Random, not derived.** It has no mathematical relationship to your hostname, username, MAC address, or any other machine identifier. Two laptops on the same network get different UUIDs. The same laptop, if you delete the file and regenerate, gets a different UUID.
+- **Not joinable.** There is no external registry. nanostack has no email, no GitHub account, no signup. Nothing maps the UUID back to you as a person.
+- **Local until you send it.** On `anonymous` or `off`, the UUID either does not exist or is not transmitted. A local file alone is not surveillance.
+
+Source of randomness, in priority order: `uuidgen`, `/proc/sys/kernel/random/uuid`, then `od -tx1 -N16 /dev/urandom` with manual v4/variant bit formatting. All three produce a standard RFC 4122 UUID v4 with 122 bits of entropy.
+
+The file is stored at `~/.nanostack/installation-id`, mode `0600`, one line, raw UUID.
+
+To rotate your UUID at any time:
+
+```sh
+nanostack-config set telemetry off
+nanostack-config set telemetry community
+```
+
+### 3. Network-layer anonymization (server-side)
+
+The Worker hashes your IP with a salt that rotates every 24 hours and keeps only the hash in KV with a 70-second TTL for rate limiting. The raw IP is never written to the database and never logged. Because the salt rotates daily, yesterday's hash of your IP does not match today's hash. An attacker who dumps the database cannot correlate your events across days, even if your network location never changed.
+
+Worker source: `telemetry-worker/src/index.ts`. The `rateLimitKey` function is the only place that touches the raw IP; see the `IP_NEVER_STORED` marker comment.
+
+### What anonymization does NOT cover
+
+Being honest about the limits: anonymization is about the data we collect and store, not about the fact that a request happens. Your ISP and your local DNS resolver see that your machine talks to `nanostack-telemetry.remoto.workers.dev`. That visibility is inherent to any network call and we cannot hide it. If it is unacceptable for your threat model, the only safe tier is `off`.
+
+## What is NEVER collected
+
+Hard rule. If a field is not in the schema above, it does not appear in the JSONL, is not sent over the network, and is not processed in any way.
+
+- Prompts, briefs, LLM responses, or any text the user or model generated.
+- File paths, file names, file contents.
+- Repository names, branch names, commit hashes, commit messages, remote URLs.
+- Hostname, username, MAC address, UID, GID.
+- IP address in any usable form. The Worker hashes IPs with a daily-rotating salt for rate limiting only; neither the raw IP nor the hash is persisted.
+- Email, auth tokens, account identifiers, third-party service IDs.
+- Environment variables, shell history, process lists.
+- Cookies, browser fingerprints, device identifiers beyond the random UUID.
+- Keystrokes, clipboard, screen contents, any kind of session replay.
+
+CI lint fails any PR that adds a field not declared here or introduces a pattern that reads any of the above into the telemetry path.
+
+## What a leak looks like
+
+If a mistake exposes the Worker's D1 database, the worst case is a dump of event records. What that dump shows:
+
+- Aggregate counts per skill, per version, per OS, per week.
+- Per-installation sequences of events. Example: installation `a3f7c2e1` ran `/think` at 12:00, `/nano` at 12:03, aborted `/review` at 12:07, reported `error_class=lint_error`.
+- No way to map installation UUIDs to human identities, email addresses, or source code.
+
+That is embarrassing, not catastrophic. It does not reveal what users are building, who they are, or where their code lives.
+
+## How to inspect your own data
+
+Everything is local and human-readable. Remote uploads, when you opt into them, send exactly what `show-data --remote-preview` prints. Commands:
+
+```sh
+# show current tier, installation-id, data directory
+nanostack-config get all
+
+# show the last 20 events, pretty-printed
+nanostack-config show-data
+
+# show everything
+nanostack-config show-data --full
+
+# dry-run: what would be sent if tier were not off
+# (tier-aware: anonymous drops session_id and installation_id)
+nanostack-config show-data --remote-preview
+
+# summary: tier, event count, top skills last 30 days
+nanostack-config status
+
+# delete the local log (irreversible)
+nanostack-config clear-data
+```
+
+For paranoid live inspection, set the debug flag and watch stderr:
+
+```sh
+NANO_TEL_DEBUG=1 /think "some idea"
+# each event is printed to stderr before it is written to disk
+```
+
+## How to verify we are not lying
+
+The source of truth is the code. Three checks:
+
+1. `bin/lib/telemetry.sh` contains every function that can write to the JSONL or read from system state. Grep it for `HOSTNAME`, `USER`, `git remote`, `git branch`, `basename $PWD`, or any path reading that is not part of the enum fallback. You should find none.
+2. `.github/workflows/lint.yml` has a `telemetry-privacy` job that runs on every PR. It fails if new code introduces any of the patterns above, and it fails if a field appears in `telemetry.sh` that is not declared in this document.
+3. The Cloudflare Worker source lives at `telemetry-worker/src/index.ts`. The endpoint validates incoming events against a strict whitelist; fields outside the whitelist are rejected with HTTP 400 and never stored. Four invariant markers (`HTTPS_ENFORCED`, `SCHEMA_STRICT`, `IP_NEVER_STORED`, `NO_BODY_LOGGING`) are required by the CI job `telemetry-worker-privacy`; removing any marker breaks the build.
+
+Run the adversarial smoke suite against the deployed endpoint:
+
+```sh
+cd telemetry-worker && ./verify-security.sh
+```
+
+The script exercises HTTPS enforcement, method gating, Content-Type gating, size caps, batch caps, schema rejection for every enum violation, and confirms that unknown fields (like `hostname`, `repo`, `ip`) are silently dropped rather than persisted. It exits non-zero on any deviation.
+
+All three are reproducible by a stranger with nothing but a clone of the repo.
+
+## Data lifecycle
+
+- **Local JSONL.** Grows append-only until 10 MB, then rotates to `skill-usage.jsonl.prev` and starts fresh. `.prev` is overwritten on the next rotation. Maximum disk usage is bounded at ~20 MB.
+- **Pending markers.** `~/.nanostack/analytics/.pending-$SESSION_ID`. Written at skill start, removed at skill end. If a skill crashes, the marker survives and the next skill run finalizes it as `outcome=unknown`. This is how we detect crash rates honestly without special instrumentation.
+- **Remote (Worker D1).** 90 days of raw events. After 90 days, rows are aggregated into daily per-skill counts; `installation_id` and `session_id` are dropped at aggregation. Rate-limit counters in KV expire every 70 seconds.
+
+## Transport security
+
+The Worker is deployed and enforces the contract below. Source: `telemetry-worker/src/index.ts`. Adversarial smoke tests: `telemetry-worker/verify-security.sh` (19 assertions, run against the live endpoint).
+
+### Endpoint
+
+- URL: `https://nanostack-telemetry.remoto.workers.dev/v1/event`
+- HTTPS only. Enforced by an explicit check at the top of the Worker handler:
+
+  ```ts
+  if (url.protocol !== "https:") {
+    return new Response("HTTPS required", { status: 400 });
+  }
+  ```
+
+  This is a line of code, not a platform default. The CI job `telemetry-worker-privacy` fails the build if the `HTTPS_ENFORCED` marker comment is removed from the Worker source.
+- Method: POST with `Content-Type: application/json`. Anything else returns 405 or 415.
+
+### Request (what the client sends)
+
+Headers the client sets explicitly:
+
+- `User-Agent: nanostack-telemetry/<version>` (fixed string, hides local curl version)
+- `Content-Type: application/json`
+
+Headers the client never sets: Cookie, Authorization, Referer, X-Forwarded-*, any custom identifier. A CI lint on `bin/telemetry-log.sh` rejects any curl invocation that adds one of these.
+
+Body: a JSON array of one or more events, each conforming exactly to the schema above. Tier-aware stripping happens client-side before the POST:
+
+- Community tier: all declared fields, including `session_id` and `installation_id`.
+- Anonymous tier: same fields minus `session_id` and `installation_id`.
+- Off tier: the client never issues the request.
+
+What `show-data --remote-preview` prints is byte-identical to what would be POSTed. The preview function and the send function share the same jq filter.
+
+### Client-side policy
+
+- Timeouts: 2s connect, 5s total. Telemetry never blocks a skill.
+- Failure mode: fire-and-forget. On any non-2xx or timeout, the event stays in the local queue for the next sync.
+- Queue cap: 100 events. Overflow drops the oldest first.
+- Rate limit: at most one sync attempt per 5 minutes per installation, tracked via the mtime of `~/.nanostack/analytics/.last-sync-time`.
+- Cursor: `~/.nanostack/analytics/.last-sync-line` records the last line successfully acknowledged by the server. Network hiccups do not duplicate events, and aborted syncs do not lose them.
+
+### Server-side policy (the Worker)
+
+- Schema strict. Any field outside `TELEMETRY_FIELDS_V1` returns HTTP 400 and is never stored. Version field (`v`) must equal `1`; other values return 400.
+- Payload size cap: 50 KB. Over limit returns 413.
+- Batch size cap: 100 events per request. Over limit returns 400.
+- Rate limit: 100 requests per minute per client. Key is `sha256(client_ip + daily_rotating_salt)`. Over limit returns 429 with `Retry-After: 60`.
+- IP handling: the raw IP from `CF-Connecting-IP` is hashed with a salt that rotates every 24 hours. The hash is used only for the rate-limit counter. Neither the raw IP nor the hash is persisted to D1.
+- Worker logging: the source is forbidden from logging request bodies, headers beyond method and status, or any derived content. A CI lint rejects patterns matching `console.log` near the request object.
+
+### D1 schema and retention
+
+- Table `events` stores one row per accepted event. Columns match the declared schema exactly.
+- Retention: 90 days of raw events. After 90 days, rows are aggregated into daily per-skill counts. The aggregation drops `installation_id` and `session_id`; only counts survive.
+- Access: the Worker reads and writes via a scoped service binding. There is no user-facing SQL interface.
+
+### What network observers still see
+
+When remote sync runs, the TCP connection to `nanostack-telemetry.remoto.workers.dev:443` is visible to the local DNS resolver, the ISP, and any corporate firewall on the path. Inside TLS the payload is encrypted, but the endpoint hostname itself reveals that the source IP uses nanostack. If that observability is unacceptable, stay on tier `off`.
+
+### How to verify this contract holds
+
+- Read the Worker source in `telemetry-worker/src/index.ts`. It is small on purpose.
+- Run `telemetry-worker/verify-security.sh` against the live endpoint. It posts adversarial payloads (oversized, wrong schema version, injection attempts, unknown fields) and asserts the expected 4xx responses. Non-zero exit on any failure.
+- Inspect the CI jobs `telemetry-privacy` and `telemetry-worker-privacy` on every PR. They fail if the forbidden patterns appear in client or Worker code, or if any of the four Worker invariant markers are removed.
+
+## Enterprise deployment
+
+nanostack is designed so a security team can verify it does not phone home without trusting any runtime logic. Three questions, three answers:
+
+### Does a default install make network calls?
+
+No. Default tier is `off`. On `off`, the client never builds a request and never contacts the Worker. Run this grep on a fresh install:
+
+```sh
+grep -rE '(curl|wget|fetch[^a-zA-Z]|nc |http[s]?://[^c])' ~/.claude/skills/nanostack/bin/
+```
+
+The only network-capable command in the client paths is the future remote-sync script (lands in a follow-up PR). It is gated on tier being `anonymous` or `community`; on `off` it exits immediately without a network call.
+
+### How do I disable telemetry permanently?
+
+Three independent mechanisms, any of them sufficient. Pick whichever fits your deployment model:
+
+```sh
+# Option A: environment variable. Affects the current shell and its children.
+export NANOSTACK_NO_TELEMETRY=1
+
+# Option B: user-level file marker. Affects all skill invocations for this user.
+touch ~/.nanostack/.telemetry-disabled
+
+# Option C: remove the telemetry helpers entirely. Affects all users of this install.
+rm ~/.claude/skills/nanostack/bin/lib/telemetry.sh
+rm ~/.claude/skills/nanostack/bin/telemetry-config.sh
+```
+
+Option C is the strongest. The skill preambles use defensive sourcing, so removing the helpers leaves the skills functional and makes the absence of telemetry code auditable with `ls`. Verify:
+
+```sh
+ls ~/.claude/skills/nanostack/bin/lib/telemetry.sh 2>/dev/null && echo present || echo removed
+grep -rE 'nano_telemetry' ~/.claude/skills/nanostack/think/
+# Matches appear only inside conditional `[ -f ... ] && source` blocks.
+```
+
+### What if the endpoint is blocked at the firewall?
+
+The client treats all network failures as no-ops. A blocked or unreachable Worker does not cause a skill to fail, hang, or retry beyond its local queue. The client's max timeout is 5 seconds; the queue cap is 100 events. If the firewall rejects or drops the connection, events stay on disk until the user manually opts out or the queue rotates.
+
+For regulated environments (air-gapped, data classification, export control) the recommended posture is Option C above, bundled into the deployment script. That install has no code path that can initiate a network request.
+
+## Questions, disagreements, concerns
+
+Open an issue. Please include:
+
+- What you think is wrong (claim vs reality).
+- How to reproduce, if applicable.
+- What outcome you want.
+
+We take privacy feedback as seriously as we take security bugs.

--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# telemetry.sh — Local-only opt-in telemetry helper.
+# Sourced by skill preambles; writes append-only JSONL to the user's home.
+# Zero network traffic in V5 Sprint 1; remote sync arrives in Sprint 3.
+#
+# Privacy contract (enforced by CI lint in .github/workflows/lint.yml):
+# this file must never read machine identity, account identity, repo
+# identity, or any path outside NANO_TEL_HOME. See TELEMETRY.md for the
+# full list of what is never collected.
+#
+# The frozen v1 schema is declared here on a single machine-parseable
+# line so CI can verify the jq filters below only use these fields.
+# TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id
+#
+# Enum whitelists:
+#   os           {darwin, linux, unknown}
+#   arch         {x86_64, arm64, unknown}
+#   outcome      {success, error, abort, unknown}
+#   error_class  {phase_timeout, save_failed, lint_error, resolver_error,
+#                 budget_exceeded, user_abort, other}
+#
+# Usage from a skill preamble:
+#   source ~/.claude/skills/nanostack/bin/lib/telemetry.sh
+#   nano_telemetry_init                     # sets env vars, may prompt
+#   nano_telemetry_pending_write "think"    # mark start
+#   # ... skill runs ...
+#   nano_telemetry_finalize "think" success # mark end, write event
+
+# Never exit the parent shell on a telemetry error. The skill's flow wins.
+# We intentionally avoid `set -e` at the top so a bad stat / write never
+# aborts the caller.
+
+# ─── Paths (user-scoped, NOT project-scoped) ───────────────────────────
+# Telemetry lives in $HOME, not in the project's .nanostack/. Project
+# store paths (NANOSTACK_STORE) are for sprint artifacts; telemetry is
+# a user preference that spans projects.
+NANO_TEL_HOME="${NANO_TEL_HOME:-$HOME/.nanostack}"
+NANO_TEL_CONFIG="$NANO_TEL_HOME/user-config.json"
+NANO_TEL_INSTALL_ID_FILE="$NANO_TEL_HOME/installation-id"
+NANO_TEL_ANALYTICS_DIR="$NANO_TEL_HOME/analytics"
+NANO_TEL_JSONL="$NANO_TEL_ANALYTICS_DIR/skill-usage.jsonl"
+NANO_TEL_JSONL_MAX_BYTES=10485760  # 10 MB rotation threshold
+NANO_TEL_PROMPTED_MARKER="$NANO_TEL_HOME/.telemetry-prompted"
+
+# Resolve nanostack version from VERSION file next to this script's skill dir.
+_nano_tel_version() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
+  if [ -n "$here" ] && [ -f "$here/VERSION" ]; then
+    tr -d '[:space:]' < "$here/VERSION" 2>/dev/null
+  elif [ -f "$HOME/.claude/skills/nanostack/VERSION" ]; then
+    tr -d '[:space:]' < "$HOME/.claude/skills/nanostack/VERSION" 2>/dev/null
+  else
+    printf 'unknown'
+  fi
+}
+
+# ─── UUID v4 generation with 3-level fallback ──────────────────────────
+# Portable: uuidgen (macOS / coreutils) → /proc/sys/kernel/random/uuid
+# (Linux) → manual hex format from /dev/urandom.
+nano_uuid_v4() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+  if [ -r /proc/sys/kernel/random/uuid ]; then
+    cat /proc/sys/kernel/random/uuid 2>/dev/null
+    return
+  fi
+  if [ -r /dev/urandom ]; then
+    # Format 16 random bytes as 8-4-4-4-12 with v4 + RFC4122 variant bits.
+    local hex
+    hex=$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n')
+    [ ${#hex} -lt 32 ] && return 1
+    # Force version 4 (nibble 13 = 4) and variant 10xx (nibble 17 in {8,9,a,b}).
+    local v4="${hex:0:12}4${hex:13:3}"
+    local variant_nibble="${hex:16:1}"
+    case "$variant_nibble" in
+      0|1|2|3|4|5|6|7) variant_nibble="8" ;;
+      8|9|a|b)         : ;;
+      c|d|e|f)         variant_nibble="a" ;;
+    esac
+    local v4f="${v4}${variant_nibble}${hex:17:3}${hex:20:12}"
+    printf '%s-%s-%s-%s-%s' \
+      "${v4f:0:8}" "${v4f:8:4}" "${v4f:12:4}" "${v4f:16:4}" "${v4f:20:12}"
+    return
+  fi
+  return 1
+}
+
+# ─── Config read / write ───────────────────────────────────────────────
+# Config format: {"telemetry": "off|anonymous|community"}
+nano_tel_get_tier() {
+  if [ ! -f "$NANO_TEL_CONFIG" ]; then
+    printf 'off'
+    return
+  fi
+  local t
+  t=$(jq -r '.telemetry // "off"' "$NANO_TEL_CONFIG" 2>/dev/null)
+  case "$t" in
+    off|anonymous|community) printf '%s' "$t" ;;
+    *) printf 'off' ;;
+  esac
+}
+
+# Inline mtime helper so telemetry.sh stays self-contained. Portability
+# helpers live in bin/lib/portable.sh, but this file is sourced by skill
+# preambles and we want zero cross-file dependencies on the privacy path.
+_nano_tel_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# Acquire a user-config lock via atomic mkdir. Returns 0 if acquired, 1
+# otherwise. Stale locks (older than 30s) are reaped automatically: if
+# they exist, a process either crashed mid-write or the system slept for
+# longer than we wait. Either way the correct move is to reclaim.
+_nano_tel_lock_acquire() {
+  local lock="$NANO_TEL_HOME/.config-lock"
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+    if mkdir "$lock" 2>/dev/null; then
+      return 0
+    fi
+    if [ -d "$lock" ]; then
+      local now age mt
+      now=$(date +%s 2>/dev/null || echo 0)
+      mt=$(_nano_tel_mtime "$lock")
+      age=$(( now - mt ))
+      if [ "$age" -gt 30 ] 2>/dev/null; then
+        rmdir "$lock" 2>/dev/null
+      fi
+    fi
+    sleep 0.1 2>/dev/null || sleep 1
+  done
+  return 1
+}
+
+_nano_tel_lock_release() {
+  rmdir "$NANO_TEL_HOME/.config-lock" 2>/dev/null
+}
+
+nano_tel_set_tier() {
+  local new="$1"
+  case "$new" in
+    off|anonymous|community) ;;
+    *) echo "ERROR: invalid tier '$new' (use off|anonymous|community)" >&2; return 1 ;;
+  esac
+  mkdir -p "$NANO_TEL_HOME" 2>/dev/null
+
+  # Serialize concurrent set_tier calls. If the lock cannot be acquired
+  # after ~3 seconds we proceed unlocked rather than blocking indefinitely;
+  # this preserves UX at the cost of last-writer-wins in a pathological
+  # edge case (two skills setting different tiers at the exact same time).
+  local lock_held=0
+  _nano_tel_lock_acquire && lock_held=1
+
+  local existing='{}'
+  [ -f "$NANO_TEL_CONFIG" ] && existing=$(cat "$NANO_TEL_CONFIG" 2>/dev/null)
+  # Unique tmp per PID so two concurrent processes do not clobber each
+  # other's in-flight write even if the lock above failed.
+  local tmp="$NANO_TEL_CONFIG.tmp.$$"
+  if ! printf '%s' "$existing" | jq --arg t "$new" '.telemetry = $t' \
+       > "$tmp" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null
+    [ $lock_held -eq 1 ] && _nano_tel_lock_release
+    echo "ERROR: failed to write telemetry config (is jq installed?)" >&2
+    return 1
+  fi
+  if ! mv "$tmp" "$NANO_TEL_CONFIG" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null
+    [ $lock_held -eq 1 ] && _nano_tel_lock_release
+    echo "ERROR: failed to persist telemetry config at $NANO_TEL_CONFIG" >&2
+    return 1
+  fi
+  # Tier preference is user-scoped; restrict to owner so shared systems
+  # do not expose another user's choice.
+  chmod 600 "$NANO_TEL_CONFIG" 2>/dev/null
+  [ $lock_held -eq 1 ] && _nano_tel_lock_release
+
+  if [ "$new" = "community" ]; then
+    [ ! -f "$NANO_TEL_INSTALL_ID_FILE" ] && _nano_tel_ensure_install_id
+  else
+    rm -f "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null
+  fi
+}
+
+_nano_tel_ensure_install_id() {
+  [ -f "$NANO_TEL_INSTALL_ID_FILE" ] && return 0
+  local id
+  id=$(nano_uuid_v4)
+  [ -z "$id" ] && return 1
+  mkdir -p "$NANO_TEL_HOME" 2>/dev/null
+  printf '%s' "$id" > "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null
+  chmod 600 "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null
+}
+
+# ─── Enum sanitizers ───────────────────────────────────────────────────
+# Any value outside the whitelist collapses to a safe default. This
+# prevents a surprising string from leaking to disk.
+_nano_tel_os() {
+  case "$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')" in
+    darwin) printf 'darwin' ;;
+    linux)  printf 'linux' ;;
+    *)      printf 'unknown' ;;
+  esac
+}
+
+_nano_tel_arch() {
+  case "$(uname -m 2>/dev/null)" in
+    x86_64|amd64)  printf 'x86_64' ;;
+    arm64|aarch64) printf 'arm64' ;;
+    *)             printf 'unknown' ;;
+  esac
+}
+
+_nano_tel_outcome() {
+  case "$1" in
+    success|error|abort|unknown) printf '%s' "$1" ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+_nano_tel_error_class() {
+  case "$1" in
+    phase_timeout|save_failed|lint_error|resolver_error|budget_exceeded|user_abort|other|"")
+      printf '%s' "$1" ;;
+    *) printf 'other' ;;
+  esac
+}
+
+# ─── Pre-V5 detection ──────────────────────────────────────────────────
+# Users who installed nanostack pre-V5 already have ~/.nanostack/ with
+# content (sessions, config, etc.). They get default silent `off` — no
+# prompt. New installs have an empty or missing ~/.nanostack/ on first
+# skill run, which triggers the opt-in prompt (handled by the skill).
+nano_tel_is_pre_v5_user() {
+  # A user is pre-V5 if ~/.nanostack/ exists AND has content OTHER than
+  # what this helper would create on a new install (the helper creates
+  # user-config.json and analytics/). Anything else that pre-exists is
+  # evidence of prior installation.
+  [ -d "$NANO_TEL_HOME" ] || return 1
+  local found_prior=0
+  # Look for any file or dir that wasn't created by telemetry itself.
+  while IFS= read -r entry; do
+    local base
+    base=$(basename "$entry")
+    case "$base" in
+      user-config.json|analytics|installation-id|.telemetry-prompted) : ;;
+      *) found_prior=1; break ;;
+    esac
+  done < <(find "$NANO_TEL_HOME" -mindepth 1 -maxdepth 1 2>/dev/null)
+  [ $found_prior -eq 1 ] && return 0 || return 1
+}
+
+# ─── Init (called at skill preamble) ───────────────────────────────────
+# Sets the following env vars for the caller:
+#   NANO_TEL_TIER            current tier: off|anonymous|community
+#   NANO_TEL_SESSION_ID      PID-epoch session id
+#   NANO_TEL_START_EPOCH     seconds epoch when this skill started
+#   NANO_TEL_SKIP_PROMPT     1 if pre-V5 user, 0 if prompt is appropriate
+#   NANO_TEL_INSTALLATION_ID UUID (community only; empty otherwise)
+nano_telemetry_init() {
+  mkdir -p "$NANO_TEL_HOME" 2>/dev/null
+  mkdir -p "$NANO_TEL_ANALYTICS_DIR" 2>/dev/null
+  # Restrict directory perms so other local users on shared systems cannot
+  # list pending-* markers (which embed session_id) or read event logs.
+  chmod 700 "$NANO_TEL_HOME" 2>/dev/null
+  chmod 700 "$NANO_TEL_ANALYTICS_DIR" 2>/dev/null
+
+  # Prune .pending-* markers older than 7 days regardless of current tier.
+  # Stale markers from crashed sessions would otherwise accumulate forever
+  # on installs that sit in `off`, and their context is too old to trust.
+  _nano_tel_prune_old_markers
+
+  # Decide if the caller should show the opt-in prompt.
+  # Precedence: marker present → never prompt again. Pre-V5 install → silent
+  # off + mark prompted. Otherwise (fresh V5 install) → caller should prompt.
+  if [ -f "$NANO_TEL_PROMPTED_MARKER" ]; then
+    NANO_TEL_SKIP_PROMPT=1
+  elif nano_tel_is_pre_v5_user; then
+    [ ! -f "$NANO_TEL_CONFIG" ] && nano_tel_set_tier off
+    touch "$NANO_TEL_PROMPTED_MARKER" 2>/dev/null
+    NANO_TEL_SKIP_PROMPT=1
+  else
+    NANO_TEL_SKIP_PROMPT=0
+  fi
+
+  NANO_TEL_TIER=$(nano_tel_get_tier)
+  NANO_TEL_SESSION_ID="$$-$(date +%s 2>/dev/null || echo 0)"
+  NANO_TEL_START_EPOCH=$(date +%s 2>/dev/null || echo 0)
+  NANO_TEL_INSTALLATION_ID=""
+  if [ "$NANO_TEL_TIER" = "community" ] && [ -f "$NANO_TEL_INSTALL_ID_FILE" ]; then
+    NANO_TEL_INSTALLATION_ID=$(cat "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null)
+  fi
+
+  export NANO_TEL_TIER NANO_TEL_SESSION_ID NANO_TEL_START_EPOCH \
+         NANO_TEL_SKIP_PROMPT NANO_TEL_INSTALLATION_ID
+}
+
+# Re-read tier + installation_id from disk. Called before every write so
+# an opt-in that happens mid-skill (user picks 'community' at the prompt
+# AFTER init has already run) is honored for subsequent events in the
+# same skill run.
+_nano_tel_refresh_tier() {
+  NANO_TEL_TIER=$(nano_tel_get_tier)
+  NANO_TEL_INSTALLATION_ID=""
+  if [ "$NANO_TEL_TIER" = "community" ] && [ -f "$NANO_TEL_INSTALL_ID_FILE" ]; then
+    NANO_TEL_INSTALLATION_ID=$(cat "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null)
+  fi
+}
+
+# ─── Pending marker (crash detection) ──────────────────────────────────
+# Written at skill start; cleared at skill end. If a skill crashes, the
+# marker survives and the next invocation finalizes it as outcome=unknown.
+nano_telemetry_pending_write() {
+  local skill="$1"
+  _nano_tel_refresh_tier
+  [ "$NANO_TEL_TIER" = "off" ] && return 0
+  local marker="$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID"
+  mkdir -p "$NANO_TEL_ANALYTICS_DIR" 2>/dev/null
+  printf '{"skill":"%s","session_id":"%s","ts":"%s"}' \
+    "$skill" "$NANO_TEL_SESSION_ID" "$(_nano_tel_ts)" \
+    > "$marker" 2>/dev/null
+}
+
+_nano_tel_ts() {
+  # Valid ISO-8601 always. If `date` fails, fall back to epoch 0 rather
+  # than an "unknown" sentinel so downstream validators do not reject.
+  date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf '1970-01-01T00:00:00Z'
+}
+
+_nano_tel_rotate_if_large() {
+  [ -f "$NANO_TEL_JSONL" ] || return 0
+  local size
+  size=$(wc -c < "$NANO_TEL_JSONL" 2>/dev/null | tr -d ' ')
+  [ -z "$size" ] && return 0
+  if [ "$size" -gt "$NANO_TEL_JSONL_MAX_BYTES" ] 2>/dev/null; then
+    mv "$NANO_TEL_JSONL" "$NANO_TEL_JSONL.prev" 2>/dev/null
+  fi
+}
+
+# Drop .pending-* markers older than 7 days. Runs in init regardless of
+# tier so markers do not accumulate across long `off` periods.
+_nano_tel_prune_old_markers() {
+  [ -d "$NANO_TEL_ANALYTICS_DIR" ] || return 0
+  find "$NANO_TEL_ANALYTICS_DIR" -maxdepth 1 -name '.pending-*' -type f \
+    -mtime +7 -delete 2>/dev/null || true
+}
+
+_nano_tel_finalize_stale_markers() {
+  local self="$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID"
+  [ -d "$NANO_TEL_ANALYTICS_DIR" ] || return 0
+  local marker skill ts
+  for marker in "$NANO_TEL_ANALYTICS_DIR"/.pending-*; do
+    [ -f "$marker" ] || continue
+    [ "$marker" = "$self" ] && continue
+    skill=$(jq -r '.skill // "unknown"' "$marker" 2>/dev/null)
+    ts=$(jq -r '.ts // ""' "$marker" 2>/dev/null)
+    [ -z "$ts" ] && ts=$(_nano_tel_ts)
+    _nano_tel_write_event "$skill" "" "unknown" "other" "$ts"
+    rm -f "$marker" 2>/dev/null
+  done
+}
+
+# ─── Write a single event to the JSONL ─────────────────────────────────
+_nano_tel_write_event() {
+  local skill="$1" duration="$2" outcome="$3" error_class="$4" ts_override="$5"
+  local ts os arch version
+  ts="${ts_override:-$(_nano_tel_ts)}"
+  os=$(_nano_tel_os)
+  arch=$(_nano_tel_arch)
+  version=$(_nano_tel_version)
+  outcome=$(_nano_tel_outcome "$outcome")
+  error_class=$(_nano_tel_error_class "$error_class")
+
+  mkdir -p "$NANO_TEL_ANALYTICS_DIR" 2>/dev/null
+  _nano_tel_rotate_if_large
+
+  local jq_args=(
+    -n
+    --argjson v 1
+    --arg ts "$ts"
+    --arg skill "$skill"
+    --arg session "$NANO_TEL_SESSION_ID"
+    --arg version "$version"
+    --arg os "$os"
+    --arg arch "$arch"
+    --arg outcome "$outcome"
+  )
+  local filter='{v:$v, ts:$ts, skill:$skill, session_id:$session,
+                 nanostack_version:$version, os:$os, arch:$arch,
+                 outcome:$outcome}'
+
+  if [ -n "$duration" ]; then
+    jq_args+=(--argjson duration "$duration")
+    filter="$filter + {duration_s:\$duration}"
+  else
+    filter="$filter + {duration_s:null}"
+  fi
+
+  if [ -n "$error_class" ]; then
+    jq_args+=(--arg err "$error_class")
+    filter="$filter + {error_class:\$err}"
+  else
+    filter="$filter + {error_class:null}"
+  fi
+
+  if [ "$NANO_TEL_TIER" = "community" ] && [ -n "$NANO_TEL_INSTALLATION_ID" ]; then
+    jq_args+=(--arg iid "$NANO_TEL_INSTALLATION_ID")
+    filter="$filter + {installation_id:\$iid}"
+  else
+    filter="$filter + {installation_id:null}"
+  fi
+
+  local line
+  line=$(jq -c "${jq_args[@]}" "$filter" 2>/dev/null)
+  [ -z "$line" ] && return 0
+
+  if [ "${NANO_TEL_DEBUG:-0}" = "1" ]; then
+    printf '[telemetry:%s] %s\n' "$NANO_TEL_TIER" "$line" >&2
+  fi
+
+  # Ensure JSONL is owner-only before the first append. The file may
+  # contain installation_id in community tier; defense-in-depth on shared
+  # systems. chmod is idempotent and cheap, so run unconditionally.
+  if [ ! -f "$NANO_TEL_JSONL" ]; then
+    # Create with restrictive perms before any write.
+    (umask 077 && : > "$NANO_TEL_JSONL") 2>/dev/null
+  fi
+  printf '%s\n' "$line" >> "$NANO_TEL_JSONL" 2>/dev/null
+  chmod 600 "$NANO_TEL_JSONL" 2>/dev/null
+}
+
+# ─── Finalize (called at skill end) ────────────────────────────────────
+nano_telemetry_finalize() {
+  local skill="$1" outcome="${2:-success}" error_class="${3:-}"
+  _nano_tel_refresh_tier
+  [ "$NANO_TEL_TIER" = "off" ] && {
+    rm -f "$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID" 2>/dev/null
+    return 0
+  }
+  local end duration
+  end=$(date +%s 2>/dev/null || echo 0)
+  if [ -n "$NANO_TEL_START_EPOCH" ] && [ "$NANO_TEL_START_EPOCH" -gt 0 ] 2>/dev/null; then
+    duration=$(( end - NANO_TEL_START_EPOCH ))
+    if [ "$duration" -lt 0 ] 2>/dev/null || [ "$duration" -gt 86400 ] 2>/dev/null; then
+      duration=""
+    fi
+  else
+    duration=""
+  fi
+  _nano_tel_write_event "$skill" "$duration" "$outcome" "$error_class" ""
+  rm -f "$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID" 2>/dev/null
+  _nano_tel_finalize_stale_markers
+}

--- a/bin/telemetry-config.sh
+++ b/bin/telemetry-config.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# telemetry-config.sh — user-facing CLI for telemetry preferences.
+# Usage:
+#   telemetry-config.sh get [telemetry|installation-id|data-dir|all]
+#   telemetry-config.sh set telemetry <off|anonymous|community>
+#   telemetry-config.sh show-data [--full | --remote-preview]
+#   telemetry-config.sh clear-data [--yes]
+#   telemetry-config.sh status
+#
+# Reads / writes only $HOME/.nanostack/ paths. Never touches project state.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/telemetry.sh"
+
+_usage() {
+  cat >&2 <<'USAGE'
+telemetry-config.sh — manage nanostack telemetry preferences
+
+Subcommands:
+  get [key]              Show current value. key: telemetry | installation-id | data-dir | all (default)
+  set telemetry <tier>   Set tier. Valid: off | anonymous | community
+  show-data [opt]        Print the local event log. opt: --full (no tail), --remote-preview (show what WOULD be sent)
+  clear-data [--yes]     Delete the local JSONL log (irreversible)
+  status                 Summary of tier + recent activity
+
+All state lives in ~/.nanostack/. Nothing is sent over the network in this
+release. See TELEMETRY.md in the skill directory for the privacy contract.
+USAGE
+}
+
+_cmd_get() {
+  local key="${1:-all}"
+  case "$key" in
+    telemetry)
+      nano_tel_get_tier
+      printf '\n'
+      ;;
+    installation-id)
+      if [ -f "$NANO_TEL_INSTALL_ID_FILE" ]; then
+        cat "$NANO_TEL_INSTALL_ID_FILE"
+        printf '\n'
+      else
+        echo "(none — only community tier has an installation-id)"
+      fi
+      ;;
+    data-dir)
+      printf '%s\n' "$NANO_TEL_HOME"
+      ;;
+    all)
+      local tier iid
+      tier=$(nano_tel_get_tier)
+      iid="(none)"
+      [ -f "$NANO_TEL_INSTALL_ID_FILE" ] && iid=$(cat "$NANO_TEL_INSTALL_ID_FILE")
+      cat <<EOF
+tier:             $tier
+installation-id:  $iid
+data-dir:         $NANO_TEL_HOME
+event-log:        $NANO_TEL_JSONL
+EOF
+      ;;
+    *)
+      echo "ERROR: unknown key '$key'" >&2
+      _usage
+      return 1
+      ;;
+  esac
+}
+
+_cmd_set() {
+  local key="${1:-}" value="${2:-}"
+  case "$key" in
+    telemetry)
+      nano_tel_set_tier "$value" || return 1
+      echo "telemetry tier set to: $value"
+      if [ "$value" = "community" ]; then
+        echo "installation-id: $(cat "$NANO_TEL_INSTALL_ID_FILE" 2>/dev/null)"
+      fi
+      ;;
+    *)
+      echo "ERROR: only 'set telemetry <tier>' is supported" >&2
+      _usage
+      return 1
+      ;;
+  esac
+}
+
+_cmd_show_data() {
+  local mode="${1:-}"
+  if [ ! -f "$NANO_TEL_JSONL" ]; then
+    echo "(no events recorded yet — tier may be 'off' or no skill has run)"
+    return 0
+  fi
+  case "$mode" in
+    --full)
+      jq . "$NANO_TEL_JSONL" 2>/dev/null || cat "$NANO_TEL_JSONL"
+      ;;
+    --remote-preview)
+      _cmd_remote_preview
+      ;;
+    '' )
+      local lines=20
+      echo "(showing last $lines events — use --full for everything)"
+      tail -n "$lines" "$NANO_TEL_JSONL" | jq . 2>/dev/null || tail -n "$lines" "$NANO_TEL_JSONL"
+      ;;
+    *)
+      echo "ERROR: unknown option '$mode'" >&2
+      _usage
+      return 1
+      ;;
+  esac
+}
+
+# Show what would be sent to the remote endpoint IF tier is not off.
+# In V5 Sprint 1 nothing is sent; this is a dry-run preview of the shape.
+_cmd_remote_preview() {
+  local tier
+  tier=$(nano_tel_get_tier)
+  if [ "$tier" = "off" ]; then
+    echo "(tier is 'off' — nothing would be sent)"
+    return 0
+  fi
+  if [ ! -f "$NANO_TEL_JSONL" ]; then
+    echo "(no events recorded — nothing to preview)"
+    return 0
+  fi
+  echo "=== remote-preview for tier=$tier ==="
+  echo "(reminder: V5 Sprint 1 does not send anything. This is a dry-run.)"
+  echo
+  local filter
+  if [ "$tier" = "anonymous" ]; then
+    # Anonymous tier drops session_id and installation_id on send.
+    filter='del(.session_id, .installation_id)'
+  else
+    # Community keeps everything.
+    filter='.'
+  fi
+  tail -n 20 "$NANO_TEL_JSONL" | jq -c "$filter" 2>/dev/null
+}
+
+_cmd_clear_data() {
+  local confirm="${1:-}"
+  if [ ! -f "$NANO_TEL_JSONL" ] && [ ! -f "$NANO_TEL_JSONL.prev" ]; then
+    echo "(nothing to clear)"
+    return 0
+  fi
+  if [ "$confirm" != "--yes" ]; then
+    read -r -p "This deletes $NANO_TEL_JSONL and .prev. Continue? [y/N] " ans
+    case "$ans" in
+      y|Y|yes) : ;;
+      *) echo "cancelled."; return 0 ;;
+    esac
+  fi
+  rm -f "$NANO_TEL_JSONL" "$NANO_TEL_JSONL.prev"
+  echo "local event log cleared."
+}
+
+_cmd_status() {
+  local tier iid count
+  tier=$(nano_tel_get_tier)
+  iid="(none)"
+  [ -f "$NANO_TEL_INSTALL_ID_FILE" ] && iid=$(cat "$NANO_TEL_INSTALL_ID_FILE")
+  count=0
+  [ -f "$NANO_TEL_JSONL" ] && count=$(wc -l < "$NANO_TEL_JSONL" 2>/dev/null | tr -d ' ')
+  cat <<EOF
+tier:             $tier
+installation-id:  $iid
+event count:      $count
+event log:        $NANO_TEL_JSONL
+EOF
+  if [ "$count" -gt 0 ] 2>/dev/null; then
+    echo
+    echo "top skills (last 30 days):"
+    local since
+    since=$(date -u -v-30d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+         || date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+         || echo '1970-01-01T00:00:00Z')
+    jq -r --arg s "$since" 'select(.ts >= $s) | .skill' "$NANO_TEL_JSONL" 2>/dev/null \
+      | sort | uniq -c | sort -rn | head -10
+  fi
+}
+
+main() {
+  local cmd="${1:-}"
+  shift 2>/dev/null || true
+  case "$cmd" in
+    get)              _cmd_get "$@" ;;
+    set)              _cmd_set "$@" ;;
+    show-data)        _cmd_show_data "$@" ;;
+    clear-data)       _cmd_clear_data "$@" ;;
+    status)           _cmd_status ;;
+    help|--help|-h|'') _usage ;;
+    *)
+      echo "ERROR: unknown subcommand '$cmd'" >&2
+      _usage
+      return 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/telemetry-worker/README.md
+++ b/telemetry-worker/README.md
@@ -1,0 +1,109 @@
+# nanostack-telemetry Worker
+
+Cloudflare Worker that ingests opt-in telemetry events from nanostack clients.
+Strict by construction: HTTPS-only, schema-whitelisted, rate-limited, never
+stores raw IP, never logs request bodies.
+
+Privacy contract is documented at `../TELEMETRY.md`. This README covers
+deployment and operations only. If a claim in this folder conflicts with
+`TELEMETRY.md`, the contract wins.
+
+## Layout
+
+```
+telemetry-worker/
+  src/index.ts          Worker code (validate + insert + rate limit)
+  migrations/0001_init.sql  D1 schema
+  wrangler.toml         CF bindings
+  verify-security.sh    Adversarial smoke tests against a deployed endpoint
+  package.json
+  tsconfig.json
+  README.md
+```
+
+## One-time setup (maintainer)
+
+Prereqs: `bunx wrangler@latest login` against the account that owns
+`nanostack-telemetry.remoto.workers.dev`.
+
+```sh
+cd telemetry-worker
+
+# 1. Create the D1 database. Copy the printed database_id into wrangler.toml.
+bunx wrangler@latest d1 create nanostack-telemetry
+
+# 2. Apply the schema.
+bunx wrangler@latest d1 execute nanostack-telemetry --remote --file=migrations/0001_init.sql
+
+# 3. Create the KV namespace for rate limiting. Copy the id into wrangler.toml.
+bunx wrangler@latest kv namespace create rate-limit
+
+# 4. Set the daily-salt secret. Pick any 32+ char random value; it never
+#    leaves the Worker runtime. Rotate whenever you want to guarantee no
+#    cross-day hash correlation.
+openssl rand -hex 32 | bunx wrangler@latest secret put MASTER_SALT
+
+# 5. Deploy.
+bunx wrangler@latest deploy
+```
+
+After step 5, `https://nanostack-telemetry.remoto.workers.dev/` returns `ok`.
+
+## Verifying the security contract
+
+Run the adversarial smoke tests against the live endpoint:
+
+```sh
+./verify-security.sh
+```
+
+The script exits non-zero if any assertion fails. It covers:
+
+- HTTP (non-TLS) request → 400
+- Wrong method → 405
+- Wrong Content-Type → 415
+- Oversized payload → 413
+- Oversized batch → 400
+- Wrong schema version → rejected
+- Unknown fields → dropped, not persisted
+- Prompt-injection-like strings in fields → rejected by enum validation
+
+## Routing summary
+
+```
+GET  /           200 "ok"       (liveness probe)
+POST /v1/event   200 { inserted, rejected }   on success
+POST /v1/event   4xx             on schema / size / auth / rate-limit failures
+any other        404
+```
+
+## Invariants the CI lint enforces
+
+Looks in `src/index.ts` for the marker comments:
+
+- `HTTPS_ENFORCED`   — non-HTTPS must return 400.
+- `SCHEMA_STRICT`    — only TELEMETRY_FIELDS_V1 survive validation.
+- `IP_NEVER_STORED`  — raw IP never written to D1; only hashed for rate limit.
+- `NO_BODY_LOGGING`  — no console.log on request body, headers, or derived content.
+
+Removing any of these invariants breaks the CI job `telemetry-worker-privacy`.
+
+## Operating notes
+
+- **Logs.** `bunx wrangler tail` streams live logs. Only method, path, status,
+  and derived counts appear. No body, no headers beyond Content-Type.
+- **D1 retention.** 90 days of raw events. A cron job (separate, not in this
+  PR) aggregates older rows into daily per-skill counts and drops
+  installation_id + session_id at aggregation.
+- **Rate limit.** Per-IP-hash, per-minute. KV TTL 70s. Exceeding 100 req/min
+  returns 429 with `Retry-After: 60`.
+- **Salt rotation.** The daily salt derives from `MASTER_SALT || YYYYMMDD`.
+  To force-rotate, set a new `MASTER_SALT` with `wrangler secret put`.
+  Rotating invalidates all prior rate-limit counters; fine.
+
+## Known non-goals
+
+- No authentication. The endpoint accepts anonymous POSTs on purpose; adding
+  an API key would create a credential that leaks to any disassembled client.
+- No CORS. The endpoint is not intended for browsers.
+- No GraphQL, no batch beyond 100, no streaming, no websockets.

--- a/telemetry-worker/migrations/0001_init.sql
+++ b/telemetry-worker/migrations/0001_init.sql
@@ -1,0 +1,25 @@
+-- nanostack telemetry D1 schema v1
+-- Fields match TELEMETRY_FIELDS_V1 from bin/lib/telemetry.sh.
+-- No raw IPs, no hostnames, no paths, no content. CI enforces that the
+-- client never sends anything outside this schema, and this DDL enforces
+-- it at storage time via column whitelist + CHECK constraints.
+
+CREATE TABLE IF NOT EXISTS events (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  received_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+  event_ts        TEXT    NOT NULL,
+  skill           TEXT    NOT NULL,
+  outcome         TEXT    NOT NULL CHECK (outcome IN ('success','error','abort','unknown')),
+  duration_s      INTEGER,
+  nanostack_version TEXT,
+  os              TEXT    CHECK (os IS NULL OR os IN ('darwin','linux','unknown')),
+  arch            TEXT    CHECK (arch IS NULL OR arch IN ('x86_64','arm64','unknown')),
+  installation_id TEXT,
+  session_id      TEXT,
+  error_class     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_skill     ON events (skill);
+CREATE INDEX IF NOT EXISTS idx_events_received  ON events (received_at);
+CREATE INDEX IF NOT EXISTS idx_events_install   ON events (installation_id) WHERE installation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_errors    ON events (error_class) WHERE outcome = 'error';

--- a/telemetry-worker/package.json
+++ b/telemetry-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nanostack-telemetry-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "nanostack telemetry ingestion Worker. Privacy-strict: HTTPS-only, schema-whitelisted, never stores raw IP.",
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "typescript": "^5.4.0",
+    "wrangler": "^3.60.0"
+  }
+}

--- a/telemetry-worker/src/index.ts
+++ b/telemetry-worker/src/index.ts
@@ -1,0 +1,258 @@
+// nanostack-telemetry Worker
+//
+// Security contract (audited against TELEMETRY.md). Any change here must keep
+// these invariants. The Worker CI lint enforces the marker comments.
+//
+//   1. HTTPS_ENFORCED: non-HTTPS requests return 400 immediately.
+//   2. SCHEMA_STRICT:  only TELEMETRY_FIELDS_V1 survive validation. Unknown
+//                      fields are dropped before insertion. Wrong types reject.
+//   3. IP_NEVER_STORED: the raw CF-Connecting-IP is read only to compute a
+//                      daily-rotating hash used for rate-limit counting. The
+//                      hash is stored in KV with a short TTL; the raw IP is
+//                      never written to D1 or logged.
+//   4. NO_BODY_LOGGING: nothing in this file calls console.log/debug/info on
+//                      the request body, headers, or any derived content.
+//                      Only shape metrics (status codes, counts) are logged.
+
+export interface Env {
+  DB: D1Database;
+  RATE_LIMIT: KVNamespace;
+  MASTER_SALT: string;
+}
+
+// TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id
+// (kept in a comment so CI can verify client and server share the same list.)
+
+const MAX_PAYLOAD_BYTES = 50_000;
+const MAX_BATCH_SIZE = 100;
+const RATE_LIMIT_PER_MIN = 100;
+
+const ALLOWED_OS = new Set(["darwin", "linux", "unknown"]);
+const ALLOWED_ARCH = new Set(["x86_64", "arm64", "unknown"]);
+const ALLOWED_OUTCOME = new Set(["success", "error", "abort", "unknown"]);
+const ALLOWED_ERROR_CLASS = new Set([
+  "phase_timeout",
+  "save_failed",
+  "lint_error",
+  "resolver_error",
+  "budget_exceeded",
+  "user_abort",
+  "other",
+]);
+
+interface TelemetryEvent {
+  v: number;
+  ts: string;
+  skill: string;
+  session_id?: string | null;
+  nanostack_version?: string | null;
+  os?: string | null;
+  arch?: string | null;
+  duration_s?: number | null;
+  outcome: string;
+  error_class?: string | null;
+  installation_id?: string | null;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // HTTPS_ENFORCED
+    const url = new URL(request.url);
+    if (url.protocol !== "https:") {
+      return new Response("HTTPS required", { status: 400 });
+    }
+
+    // Method gate.
+    if (request.method !== "POST") {
+      // Health/liveness probes hit GET /; answer lightly without leaking info.
+      if (request.method === "GET" && url.pathname === "/") {
+        return new Response("ok\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      return new Response("POST required", {
+        status: 405,
+        headers: { Allow: "POST" },
+      });
+    }
+
+    // Route. Only /v1/event accepts payloads.
+    if (url.pathname !== "/v1/event") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    // Content-Type gate. Prevents form-encoded or multipart surprises.
+    const contentType = request.headers.get("content-type") || "";
+    if (!contentType.toLowerCase().startsWith("application/json")) {
+      return new Response("application/json required", { status: 415 });
+    }
+
+    // Payload size gate (pre-parse). CF already caps at 100MB but we cap at 50KB.
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > MAX_PAYLOAD_BYTES) {
+      return new Response("Payload too large", { status: 413 });
+    }
+
+    // Rate limit (pre-parse, cheap). IP_NEVER_STORED: we hash + KV-cache only.
+    const clientIp = request.headers.get("CF-Connecting-IP") || "unknown";
+    const rlKey = await rateLimitKey(clientIp, env.MASTER_SALT);
+    const current = parseInt((await env.RATE_LIMIT.get(rlKey)) || "0", 10);
+    if (current >= RATE_LIMIT_PER_MIN) {
+      return new Response("Rate limit exceeded", {
+        status: 429,
+        headers: { "Retry-After": "60" },
+      });
+    }
+    // Increment with 70s TTL. Eventually consistent; acceptable for rate limiting.
+    await env.RATE_LIMIT.put(rlKey, String(current + 1), { expirationTtl: 70 });
+
+    // Parse body. Any parse error → 400, no body echoed.
+    let body: unknown;
+    try {
+      const text = await request.text();
+      if (text.length > MAX_PAYLOAD_BYTES) {
+        return new Response("Payload too large", { status: 413 });
+      }
+      body = JSON.parse(text);
+    } catch {
+      return new Response("Invalid JSON", { status: 400 });
+    }
+
+    const events: unknown[] = Array.isArray(body) ? body : [body];
+    if (events.length === 0) {
+      return new Response(JSON.stringify({ inserted: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (events.length > MAX_BATCH_SIZE) {
+      return new Response(`Batch too large (max ${MAX_BATCH_SIZE})`, {
+        status: 400,
+      });
+    }
+
+    // SCHEMA_STRICT: validate each event, drop malformed, reject if all malformed.
+    const rows: TelemetryEvent[] = [];
+    for (const e of events) {
+      const validated = validateEvent(e);
+      if (validated) rows.push(validated);
+    }
+
+    if (rows.length === 0) {
+      return new Response(JSON.stringify({ inserted: 0, rejected: events.length }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Insert with parameterized prepared statements. Never build SQL from input.
+    const stmt = env.DB.prepare(
+      `INSERT INTO events
+         (event_ts, skill, outcome, duration_s, nanostack_version,
+          os, arch, installation_id, session_id, error_class)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const batch = rows.map((r) =>
+      stmt.bind(
+        r.ts,
+        r.skill,
+        r.outcome,
+        r.duration_s ?? null,
+        r.nanostack_version ?? null,
+        r.os ?? null,
+        r.arch ?? null,
+        r.installation_id ?? null,
+        r.session_id ?? null,
+        r.error_class ?? null,
+      ),
+    );
+
+    try {
+      await env.DB.batch(batch);
+    } catch {
+      // Do not echo error detail. A failed insert tells the client to retry.
+      return new Response(JSON.stringify({ error: "insert_failed" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ inserted: rows.length, rejected: events.length - rows.length }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  },
+};
+
+// SCHEMA_STRICT: return null on any schema deviation. Unknown fields are
+// ignored (not stored, not echoed). Enums collapse to safe defaults at the
+// client level already; here we defense-in-depth reject anything that slipped.
+function validateEvent(raw: unknown): TelemetryEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const e = raw as Record<string, unknown>;
+
+  if (e.v !== 1) return null;
+  if (typeof e.ts !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(e.ts)) return null;
+  if (typeof e.skill !== "string" || e.skill.length === 0 || e.skill.length > 50) return null;
+  if (typeof e.outcome !== "string" || !ALLOWED_OUTCOME.has(e.outcome)) return null;
+
+  const os = typeof e.os === "string" ? e.os : null;
+  if (os !== null && !ALLOWED_OS.has(os)) return null;
+
+  const arch = typeof e.arch === "string" ? e.arch : null;
+  if (arch !== null && !ALLOWED_ARCH.has(arch)) return null;
+
+  const errorClass = typeof e.error_class === "string" ? e.error_class : null;
+  if (errorClass !== null && !ALLOWED_ERROR_CLASS.has(errorClass)) return null;
+
+  // duration_s: integer seconds, bounded.
+  let duration: number | null = null;
+  if (typeof e.duration_s === "number") {
+    if (!Number.isFinite(e.duration_s) || e.duration_s < 0 || e.duration_s > 86400) return null;
+    duration = Math.floor(e.duration_s);
+  }
+
+  // Version + installation_id + session_id: caps on length, no content inspection.
+  const version = typeof e.nanostack_version === "string" ? e.nanostack_version.slice(0, 32) : null;
+  if (version !== null && !/^[0-9A-Za-z._-]+$/.test(version)) return null;
+
+  const installId = typeof e.installation_id === "string" ? e.installation_id.slice(0, 64) : null;
+  if (installId !== null && !/^[0-9a-f-]{36}$/.test(installId)) return null;
+
+  const sessionId = typeof e.session_id === "string" ? e.session_id.slice(0, 64) : null;
+  if (sessionId !== null && !/^[0-9]+-[0-9]+$/.test(sessionId)) return null;
+
+  return {
+    v: 1,
+    ts: e.ts,
+    skill: e.skill.slice(0, 50),
+    outcome: e.outcome,
+    os,
+    arch,
+    error_class: errorClass,
+    duration_s: duration,
+    nanostack_version: version,
+    installation_id: installId,
+    session_id: sessionId,
+  };
+}
+
+// rateLimitKey computes sha256(ip || daily_salt || minute_bucket). The per-minute
+// bucket means the counter auto-expires; the daily salt means yesterday's hashes
+// are uncorrelatable with today's. MASTER_SALT is a Worker secret, not in git.
+async function rateLimitKey(ip: string, masterSalt: string): Promise<string> {
+  const now = new Date();
+  const dateKey =
+    now.getUTCFullYear().toString() +
+    String(now.getUTCMonth() + 1).padStart(2, "0") +
+    String(now.getUTCDate()).padStart(2, "0");
+  const minuteKey = dateKey + String(now.getUTCHours()).padStart(2, "0") + String(now.getUTCMinutes()).padStart(2, "0");
+  const input = `${ip}|${masterSalt}|${dateKey}`;
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `rl:${hex}:${minuteKey}`;
+}

--- a/telemetry-worker/tsconfig.json
+++ b/telemetry-worker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/telemetry-worker/verify-security.sh
+++ b/telemetry-worker/verify-security.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# verify-security.sh — adversarial smoke tests against a deployed Worker.
+# Run after `wrangler deploy` to prove the security contract holds end to end.
+# Exits non-zero on any assertion failure.
+#
+# Usage:
+#   ./verify-security.sh [endpoint-url]
+# Default endpoint: https://nanostack-telemetry.remoto.workers.dev
+set -u
+
+ENDPOINT="${1:-https://nanostack-telemetry.remoto.workers.dev}"
+EVENT_URL="$ENDPOINT/v1/event"
+
+PASS=0
+FAIL=0
+
+_say_ok()   { printf "  \033[32mOK\033[0m    %s\n" "$1"; PASS=$((PASS+1)); }
+_say_fail() { printf "  \033[31mFAIL\033[0m  %s (got %s, expected %s)\n" "$1" "$2" "$3"; FAIL=$((FAIL+1)); }
+
+# assert_status <description> <expected-code> <curl-args...>
+assert_status() {
+  local desc="$1" expected="$2"; shift 2
+  local code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "$@" 2>/dev/null || echo "000")
+  if [ "$code" = "$expected" ]; then
+    _say_ok "$desc"
+  else
+    _say_fail "$desc" "$code" "$expected"
+  fi
+}
+
+# assert_json_field <description> <field> <expected> <curl-args...>
+assert_json_field() {
+  local desc="$1" field="$2" expected="$3"; shift 3
+  local body
+  body=$(curl -sS --max-time 5 "$@" 2>/dev/null || echo "{}")
+  local got
+  got=$(printf '%s' "$body" | jq -r ".$field // \"null\"" 2>/dev/null || echo "parse-error")
+  if [ "$got" = "$expected" ]; then
+    _say_ok "$desc"
+  else
+    _say_fail "$desc" "$got" "$expected"
+  fi
+}
+
+printf "Testing %s\n\n" "$ENDPOINT"
+
+# ─── Liveness (sanity check that the Worker is up) ─────────────
+printf "Liveness:\n"
+assert_status "GET / → 200" 200 "$ENDPOINT/"
+
+# ─── HTTPS enforcement ─────────────────────────────────────────
+printf "\nHTTPS enforcement:\n"
+# curl follows 301/302 by default — we do NOT pass -L, so an HTTP 400 response
+# from the Worker surfaces directly without any redirect interference.
+HTTP_URL=$(printf '%s' "$EVENT_URL" | sed 's|^https:|http:|')
+assert_status "POST http:// → 400 (HTTPS required)" 400 \
+  -X POST -H "Content-Type: application/json" -d '{}' "$HTTP_URL"
+
+# ─── Method gate ────────────────────────────────────────────────
+printf "\nMethod gate:\n"
+assert_status "PUT /v1/event → 405" 405 -X PUT -H "Content-Type: application/json" -d '{}' "$EVENT_URL"
+assert_status "DELETE /v1/event → 405" 405 -X DELETE "$EVENT_URL"
+assert_status "GET /v1/event → 405" 405 "$EVENT_URL"
+
+# ─── Content-Type gate ──────────────────────────────────────────
+printf "\nContent-Type gate:\n"
+assert_status "POST without Content-Type → 415" 415 \
+  -X POST --data-binary 'not json' "$EVENT_URL"
+assert_status "POST Content-Type: text/plain → 415" 415 \
+  -X POST -H "Content-Type: text/plain" --data-binary 'not json' "$EVENT_URL"
+
+# ─── Routing ────────────────────────────────────────────────────
+printf "\nRouting:\n"
+assert_status "POST /v1/other → 404" 404 \
+  -X POST -H "Content-Type: application/json" -d '{}' "$ENDPOINT/v1/other"
+
+# ─── Malformed JSON ─────────────────────────────────────────────
+printf "\nMalformed JSON:\n"
+assert_status "POST invalid JSON → 400" 400 \
+  -X POST -H "Content-Type: application/json" --data-binary 'not{json' "$EVENT_URL"
+
+# ─── Oversized payload (51KB) ───────────────────────────────────
+printf "\nSize limits:\n"
+BIG=$(printf '{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success","pad":"%.0s' "$(seq 1 1)")
+BIG_PAYLOAD=$(python3 -c 'import json,sys; print(json.dumps({"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success","pad":"x"*51000}))' 2>/dev/null || printf '{"pad":"%*s"}' 51000 '')
+assert_status "POST 51KB payload → 413" 413 \
+  -X POST -H "Content-Type: application/json" --data-binary "$BIG_PAYLOAD" "$EVENT_URL"
+
+# Oversized batch (101 events)
+BATCH_101=$(python3 -c '
+import json
+e = {"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success"}
+print(json.dumps([e]*101))
+' 2>/dev/null || echo '[]')
+assert_status "POST 101-event batch → 400" 400 \
+  -X POST -H "Content-Type: application/json" --data-binary "$BATCH_101" "$EVENT_URL"
+
+# ─── Schema rejection (all should be dropped, response is 400 when ALL rejected) ─
+printf "\nSchema validation (all-rejected returns 400):\n"
+assert_status "wrong version v=2 → 400 (all rejected)" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"v":2,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success"}' "$EVENT_URL"
+
+assert_status "os outside enum → 400" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success","os":"windows"}' "$EVENT_URL"
+
+assert_status "outcome outside enum → 400" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"victorious"}' "$EVENT_URL"
+
+assert_status "injection-like outcome → 400" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d "{\"v\":1,\"ts\":\"2026-04-21T12:00:00Z\",\"skill\":\"test\",\"outcome\":\"success'; DROP TABLE events; --\"}" "$EVENT_URL"
+
+assert_status "malformed ts → 400" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"v":1,"ts":"not-a-date","skill":"test","outcome":"success"}' "$EVENT_URL"
+
+assert_status "negative duration → 400" 400 \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"test","outcome":"success","duration_s":-5}' "$EVENT_URL"
+
+# ─── Valid payload accepted ─────────────────────────────────────
+printf "\nHappy path:\n"
+VALID='{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"verify_test","outcome":"success","os":"darwin","arch":"arm64","nanostack_version":"0.5.0-test","duration_s":1}'
+assert_json_field "valid event returns inserted:1" "inserted" "1" \
+  -X POST -H "Content-Type: application/json" -d "$VALID" "$EVENT_URL"
+
+# Unknown fields are dropped, event still accepted
+VALID_WITH_JUNK='{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"verify_test","outcome":"success","hostname":"pwned","repo":"secret","ip":"1.2.3.4"}'
+assert_json_field "unknown fields silently dropped (hostname/repo/ip) → inserted:1" "inserted" "1" \
+  -X POST -H "Content-Type: application/json" -d "$VALID_WITH_JUNK" "$EVENT_URL"
+
+# ─── Summary ────────────────────────────────────────────────────
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/telemetry-worker/wrangler.toml
+++ b/telemetry-worker/wrangler.toml
@@ -1,0 +1,24 @@
+name = "nanostack-telemetry"
+main = "src/index.ts"
+compatibility_date = "2026-04-21"
+
+# D1: stores validated events. Filled in after `wrangler d1 create nanostack-telemetry`.
+# The literal database_id below is a placeholder; replace with the value wrangler
+# prints when the DB is created, then commit. The binding name `DB` is referenced
+# by src/index.ts and must not change without updating code.
+[[d1_databases]]
+binding = "DB"
+database_name = "nanostack-telemetry"
+database_id = "114409d1-3e6b-4c57-a88a-3604d48cbbc6"
+
+# KV: stores per-minute rate-limit counters, keyed by sha256(ip + daily_salt).
+# TTL-scoped so entries self-expire. Filled in after
+# `wrangler kv namespace create rate-limit`. Binding name `RATE_LIMIT`
+# is referenced by src/index.ts.
+[[kv_namespaces]]
+binding = "RATE_LIMIT"
+id = "51e20ad3ae9d4333a2c86ec397b9c91a"
+
+# MASTER_SALT: set via `wrangler secret put MASTER_SALT`.
+# Daily effective salt = sha256(MASTER_SALT || YYYYMMDD_UTC).
+# Rotate the master when you want to guarantee no cross-day correlation.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -43,6 +43,57 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 [ -f .claude/settings.json ] || ~/.claude/skills/nanostack/bin/init-project.sh
 ```
 
+### Telemetry preamble
+
+Telemetry is optional and defensive. The skill must run identically whether the telemetry helper is present, disabled, or removed. A sysadmin can disable telemetry in three ways:
+
+- Set `NANOSTACK_NO_TELEMETRY=1` in the environment.
+- Create `~/.nanostack/.telemetry-disabled` as an empty file.
+- Delete `bin/lib/telemetry.sh` and `bin/telemetry-config.sh` from the install.
+
+Any of the three makes the block below a no-op. The skill continues normally.
+
+Run this block:
+
+```bash
+if [ -z "${NANOSTACK_NO_TELEMETRY:-}" ] \
+   && [ ! -f "$HOME/.nanostack/.telemetry-disabled" ] \
+   && [ -f "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" ]; then
+  source "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" 2>/dev/null
+  nano_telemetry_init 2>/dev/null
+  command -v nano_telemetry_pending_write >/dev/null 2>&1 && \
+    nano_telemetry_pending_write think 2>/dev/null
+fi
+echo "TEL_TIER=${NANO_TEL_TIER:-off}"
+echo "TEL_SKIP_PROMPT=${NANO_TEL_SKIP_PROMPT:-1}"
+```
+
+If telemetry was disabled or stripped, `TEL_TIER=off` and `TEL_SKIP_PROMPT=1` fall through from the defaults, and the skill simply does not prompt or record anything.
+
+**If `TEL_TIER` is not `off` AND `TEL_SKIP_PROMPT=0`**, show the opt-in prompt using `AskUserQuestion`. The helper already checks whether the user was prompted before or is a pre-existing install. Use exactly this wording:
+
+> nanostack supports opt-in telemetry. Asking once.
+>
+> **(a) Community** — sends: which skill you ran, duration, outcome, version, os/arch, a random UUID (not derived from your machine). Helps prioritize what to fix.
+>
+> **(b) Anonymous** — same data without the UUID. Events cannot be tied together.
+>
+> **(c) Off** — nothing leaves your machine. Recommended default if unsure.
+>
+> Never sent: code, prompts, briefs, repo name, paths, email, hostname. See `~/.claude/skills/nanostack/TELEMETRY.md`.
+> Change later: `nanostack-config set telemetry <off|anonymous|community>`.
+
+Map the answer to a tier and persist (only if telemetry is available; skip silently otherwise):
+
+```bash
+if command -v nano_tel_set_tier >/dev/null 2>&1; then
+  "$HOME/.claude/skills/nanostack/bin/telemetry-config.sh" set telemetry <tier>
+  touch "$HOME/.nanostack/.telemetry-prompted"
+fi
+```
+
+If `TEL_SKIP_PROMPT=1` (pre-existing install) or the marker already exists, skip the prompt entirely. Pre-existing users stay at default `off` unless they opt in manually.
+
 ## Retro Mode
 
 If the user said `/think --retro` or `/think retro` or "retrospective", run the retrospective process instead of the normal diagnostic. **Do not initialize a new session.** Retro looks backward at what was shipped, not forward at what to build.
@@ -294,6 +345,19 @@ If 2+ archived sessions (returning user), keep it short:
 > Ready for `/nano`. Say `/nano` to plan, or adjust the brief first.
 
 Wait for the user to invoke `/nano`.
+
+### Telemetry finalize
+
+Before handing control back to the user (or to `/nano` in autopilot), close out telemetry if it is available:
+
+```bash
+command -v nano_telemetry_finalize >/dev/null 2>&1 && \
+  nano_telemetry_finalize think success 2>/dev/null
+```
+
+If the flow aborted (user interrupted, blocked on missing info, error in a phase), pass `abort` or `error` instead of `success`. The `command -v` guard keeps the line harmless when telemetry is disabled or stripped. The function itself is also a no-op if tier is `off`.
+
+For retro mode (`/think --retro`), same rule applies at the end of the retro brief output.
 
 ## Gotchas
 


### PR DESCRIPTION
## TL;DR

nanostack evolves in response to how people actually use it. Right now that feedback loop is missing. We cannot see which skill is the entry point for most sprints, where sprints abort, which errors repeat across installs, or whether the portability fallbacks we ship matter in practice. Product decisions fall back to the maintainer's own usage plus the handful of users who open issues. That does not scale.

This PR adds minimal, anonymized telemetry of skill flows so the bottlenecks users actually hit become measurable. The contract is strict: opt-in only, default `off`, three independent disable mechanisms for enterprise deployment. The local client and the remote ingestion Worker land in the same PR so the privacy contract is verifiable end to end on merge.

**Endpoint (deployed, live):** `https://nanostack-telemetry.remoto.workers.dev/v1/event`
**Verify yourself:** `cd telemetry-worker && ./verify-security.sh` (19 adversarial assertions pass)

## Privacy contract (enforced, not promised)

Four independent layers. Removing any one fails CI.

1. **Enum whitelists at runtime.** `os`, `arch`, `outcome`, `error_class` collapse unknown values to a safe default. A surprising string cannot leak.
2. **Schema frozen in a parseable comment.** `bin/lib/telemetry.sh` declares `TELEMETRY_FIELDS_V1`. Any jq key outside this list fails the `telemetry-privacy` CI job.
3. **CI grep for identity patterns.** Rejects any telemetry-path code that reads hostname, username, git remote, git branch, `$PWD`, or similar. Comment lines are skipped so the contract itself can mention these words.
4. **Worker invariant markers.** `HTTPS_ENFORCED`, `SCHEMA_STRICT`, `IP_NEVER_STORED`, `NO_BODY_LOGGING` must appear in `telemetry-worker/src/index.ts`. The `telemetry-worker-privacy` CI job fails if any marker is removed.

## What IS collected (community tier only)

| Field | Example | Source |
|---|---|---|
| `skill` | `"think"` | Hardcoded per skill |
| `duration_s` | `180` | Integer seconds, never ms |
| `outcome` | `"success"` | Enum: success, error, abort, unknown |
| `os` | `"darwin"` | Enum: darwin, linux, unknown |
| `arch` | `"arm64"` | Enum: x86_64, arm64, unknown |
| `nanostack_version` | `"0.5.0"` | VERSION file |
| `session_id` | `"12345-1776747000"` | `$PID-$EPOCH`, scoped to one sprint |
| `installation_id` | UUID v4 | Random, not derived from machine |

Anonymous tier sends the same set minus `session_id` and `installation_id`. Off tier writes nothing, sends nothing.

## What is NEVER collected

Code, prompts, briefs, LLM responses. Repo names, branch names, file paths. Hostname, username, MAC, UID. Email, tokens, account identifiers. Raw IP (the Worker hashes with a daily-rotating salt for rate limiting only; neither raw IP nor hash is persisted). CI enforces this list on every PR.

## Worker security properties (verified against live endpoint)

Run `telemetry-worker/verify-security.sh` to reproduce:

- HTTPS-only (HTTP request returns 400, enforced in code)
- Method-gated (non-POST returns 405)
- Content-Type gated (non-JSON returns 415)
- Payload capped at 50 KB (oversized returns 413)
- Batch capped at 100 events (oversized returns 400)
- Schema strict: wrong version, out-of-enum values, injection strings, malformed timestamps all rejected with 400
- Unknown fields (hostname, repo, ip in the body) silently dropped before insertion into D1
- Rate limit 100 req/min per `sha256(ip + daily_salt)` with 70-second KV TTL

## Enterprise deployment

Three independent disable mechanisms documented in [`TELEMETRY.md`](TELEMETRY.md#enterprise-deployment). Any one is sufficient:

```sh
# A. Environment variable (shell scope)
export NANOSTACK_NO_TELEMETRY=1

# B. File marker (user scope)
touch ~/.nanostack/.telemetry-disabled

# C. Remove helpers (install scope, strongest)
rm ~/.claude/skills/nanostack/bin/lib/telemetry.sh
rm ~/.claude/skills/nanostack/bin/telemetry-config.sh
```

The skill preambles use defensive sourcing. A grep confirms:

```sh
grep -rE 'nano_telemetry' ~/.claude/skills/nanostack/think/
# Matches only inside conditional `[ -f ... ] && source` blocks.
```

## What changed

- `bin/lib/telemetry.sh` (new, 456 lines): helper sourced by skill preambles. UUID v4 with 3-level fallback. Pending markers for crash detection. 10 MB log rotation. Atomic mkdir lock.
- `bin/telemetry-config.sh` (new, 202 lines): user CLI with `get`, `set`, `show-data`, `show-data --remote-preview`, `clear-data`, `status`.
- `TELEMETRY.md` (new, 339 lines): privacy contract, schema, anonymization, transport, enterprise deployment.
- `telemetry-worker/` (new, 7 files): Worker source, D1 migration, wrangler config, 19-test adversarial script.
- `think/SKILL.md`: defensive preamble for opt-in prompt and telemetry wire-up.
- `README.md`: `## Privacy` section rewritten.
- `.github/workflows/lint.yml`: two new jobs for client and Worker invariants.
- `.gitignore`: exclude Worker build artifacts.

## How to audit this PR yourself

1. Read `TELEMETRY.md` top to bottom. That is the contract.
2. Read `telemetry-worker/src/index.ts`. 225 lines, no dependencies beyond CF runtime.
3. Run `cd telemetry-worker && ./verify-security.sh` against the live endpoint.
4. Grep `bin/lib/telemetry.sh` for `HOSTNAME|USER|git`. CI does the same.
5. Invoke any skill with `NANO_TEL_DEBUG=1` and watch stderr for every event before it is written.
6. `nanostack-config show-data --remote-preview` shows what would be sent (tier-aware: anonymous strips `session_id` and `installation_id`).
7. `nanostack-config clear-data` deletes the local log. Irreversible.

## Test plan

Manually verified on macOS arm64:

- 11 end-to-end client tests pass: fresh install, pre-existing install (silent off), returning user, mid-run opt-in, crash recovery, log rotation, 20 concurrent writes, file permissions 600/700, UUID fallback, anonymous tier preview stripping, CI lint local simulation.
- UUID entropy stress: 1000 unique samples from `/dev/urandom` fallback, all RFC 4122 v4.
- 19 Worker adversarial assertions pass against the live endpoint (HTTPS enforcement, method, Content-Type, size, batch, schema, happy path, unknown-field stripping).
- D1 verification: valid event inserted with correct fields only; unknown fields (hostname, repo, ip) in the payload never reached the database.

Review, security, and QA artifacts saved to `.nanostack/`.
