### PR TITLE
Enable opt-in flow measurement across skills

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,10 @@ jobs:
           # (so the privacy contract itself can mention the words
           # without tripping the check).
           set -e
-          targets="bin/lib/telemetry.sh bin/telemetry-config.sh"
+          # Scan every file in the telemetry code path: helper, config CLI,
+          # async sender, and the two skill-level wrappers. If a new file
+          # enters this path it must be added here explicitly.
+          targets="bin/lib/telemetry.sh bin/telemetry-config.sh bin/telemetry-log.sh bin/lib/skill-preamble.sh bin/lib/skill-finalize.sh"
           forbidden='HOSTNAME|USERNAME|LOGNAME|\$USER\b|whoami|[^_[:alnum:]]hostname[^_[:alnum:]]|git[[:space:]]+remote|git[[:space:]]+branch|git[[:space:]]+config|git[[:space:]]+rev-parse|basename[[:space:]]+"?\$PWD|basename[[:space:]]+"?\$\(pwd|ifconfig|ip[[:space:]]+addr'
           fail=0
           for f in $targets; do
@@ -107,6 +110,66 @@ jobs:
               fail=1
             fi
           done
+          exit $fail
+      - name: telemetry-log.sh sender safety
+        run: |
+          # The async sender in bin/telemetry-log.sh is the only place in
+          # nanostack that initiates a network request. Its curl invocation
+          # is constrained to a short, audited flag list. This job verifies
+          # the sender has what it needs and none of what it must not.
+          set -e
+          f=bin/telemetry-log.sh
+          [ -f "$f" ] || { echo "FAIL: $f missing"; exit 1; }
+          fail=0
+
+          # Required flags + configuration.
+          # grep -F -- used because most required strings start with `--`
+          # which grep interprets as an option otherwise. Regex for the URL
+          # uses -E -e to pass the pattern past the option parser.
+          for required in '--user-agent' '--max-time' '--connect-timeout' '--request POST' 'nanostack-telemetry/' 'NANOSTACK_NO_TELEMETRY' '.telemetry-disabled'; do
+            if ! grep -qF -- "$required" "$f"; then
+              echo "FAIL: $f missing required element '$required'"
+              fail=1
+            fi
+          done
+          if ! grep -qE -e 'https://nanostack-telemetry\.remoto\.workers\.dev' "$f"; then
+            echo "FAIL: $f missing endpoint URL"
+            fail=1
+          fi
+
+          # Forbidden flags (exclude comment lines so doc can mention them).
+          # Patterns target curl argv; matching `command -v` or docs is avoided.
+          non_comment=$(grep -vE '^[[:space:]]*#' "$f")
+          for pattern in \
+            '^[^#]*curl[[:space:]].*--cookie([^a-zA-Z]|$)' \
+            '^[^#]*curl[[:space:]].*--cookie-jar' \
+            '^[^#]*curl[[:space:]].*--user[[:space:]]' \
+            '^[^#]*curl[[:space:]].*--location' \
+            '^[^#]*curl[[:space:]].*--verbose' \
+            '^[^#]*curl[[:space:]].*--dump-header' \
+            '^[^#]*curl[[:space:]].*--trace' \
+            '^[^#]*--header[[:space:]]+"?Cookie' \
+            '^[^#]*--header[[:space:]]+"?Authorization' \
+            '^[^#]*--header[[:space:]]+"?Referer' \
+            '^[^#]*curl[[:space:]].*http://' \
+          ; do
+            if printf '%s\n' "$non_comment" | grep -E "$pattern" >/dev/null; then
+              echo "FAIL: $f contains forbidden pattern '$pattern'"
+              fail=1
+            fi
+          done
+
+          # The sender must hardcode exactly one endpoint URL. A second
+          # URL would mean the contract-preview and the actual send could
+          # diverge. Count distinct https://...workers.dev URLs.
+          urls=$(grep -oE 'https://[a-z0-9.-]+\.workers\.dev[a-zA-Z0-9/._-]*' "$f" | sort -u)
+          url_count=$(printf '%s\n' "$urls" | grep -c . || echo 0)
+          if [ "$url_count" -ne 1 ]; then
+            echo "FAIL: $f must hardcode exactly one workers.dev URL (found $url_count)"
+            printf '%s\n' "$urls"
+            fail=1
+          fi
+
           exit $fail
       - name: Schema field whitelist (telemetry.sh vs TELEMETRY.md)
         run: |

--- a/bin/lib/skill-finalize.sh
+++ b/bin/lib/skill-finalize.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# skill-finalize.sh — defensive telemetry finalize for any nanostack skill.
+#
+# Usage from a SKILL.md:
+#   _F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+#   [ -f "$_F" ] && . "$_F" <skill-name> <outcome>
+#   unset _F
+#
+# Outcome is one of: success, error, abort, unknown. Defaults to success.
+#
+# This file is a thin wrapper around nano_telemetry_finalize that tolerates
+# a missing telemetry helper. If telemetry.sh was not sourced (kill switch
+# active, file removed, etc.), nano_telemetry_finalize will not be defined
+# and this file becomes a no-op.
+
+_nano_skill_name="${1:-unknown}"
+_nano_skill_outcome="${2:-success}"
+
+command -v nano_telemetry_finalize >/dev/null 2>&1 && \
+  nano_telemetry_finalize "$_nano_skill_name" "$_nano_skill_outcome" 2>/dev/null
+
+unset _nano_skill_name _nano_skill_outcome

--- a/bin/lib/skill-preamble.sh
+++ b/bin/lib/skill-preamble.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# skill-preamble.sh — defensive telemetry init for any nanostack skill.
+#
+# Usage from a SKILL.md:
+#   _P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+#   [ -f "$_P" ] && . "$_P" <skill-name>
+#   unset _P
+#
+# Responsibilities:
+#   - Respect all three telemetry kill switches (env var, marker file,
+#     file removal). Any one of them makes this a no-op.
+#   - Source bin/lib/telemetry.sh if present.
+#   - Call nano_telemetry_init and nano_telemetry_pending_write with the
+#     skill name.
+#
+# This file never prompts the user. The opt-in prompt lives in think/SKILL.md
+# because it runs once per install; pre-existing users and anyone whose
+# first skill is not /think stay at tier=off until they opt in manually
+# via `nanostack-config set telemetry ...`.
+
+_nano_skill_name="${1:-unknown}"
+
+# Kill switch 1: environment variable.
+if [ -n "${NANOSTACK_NO_TELEMETRY:-}" ]; then
+  unset _nano_skill_name
+  return 0 2>/dev/null || true
+fi
+
+# Kill switch 2: user-level marker file. NANO_TEL_HOME override respected so
+# sysadmins testing in a sandbox dir hit the expected path.
+if [ -f "${NANO_TEL_HOME:-$HOME/.nanostack}/.telemetry-disabled" ]; then
+  unset _nano_skill_name
+  return 0 2>/dev/null || true
+fi
+
+# Kill switch 3 (implicit): if telemetry.sh is missing, the source below
+# is a no-op and none of the nano_telemetry_* functions ever become defined.
+# Check the sibling directory first (dev / vendored installs) then the
+# standard install path. This keeps tests and production on the same path
+# logic without special-casing.
+_nano_tel_lib=""
+_nano_skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+if [ -n "$_nano_skill_dir" ] && [ -f "$_nano_skill_dir/telemetry.sh" ]; then
+  _nano_tel_lib="$_nano_skill_dir/telemetry.sh"
+elif [ -f "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" ]; then
+  _nano_tel_lib="$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh"
+fi
+
+if [ -n "$_nano_tel_lib" ]; then
+  # shellcheck disable=SC1090
+  . "$_nano_tel_lib" 2>/dev/null
+  nano_telemetry_init 2>/dev/null
+  command -v nano_telemetry_pending_write >/dev/null 2>&1 && \
+    nano_telemetry_pending_write "$_nano_skill_name" 2>/dev/null
+fi
+
+unset _nano_tel_lib _nano_skill_dir _nano_skill_name

--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -351,7 +351,10 @@ _nano_tel_finalize_stale_markers() {
   local self="$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID"
   [ -d "$NANO_TEL_ANALYTICS_DIR" ] || return 0
   local marker skill ts
-  for marker in "$NANO_TEL_ANALYTICS_DIR"/.pending-*; do
+  # Use find instead of a shell glob. Bash would need `shopt -s nullglob`
+  # to avoid iterating the literal pattern when nothing matches; zsh throws
+  # on unmatched globs by default. find handles both uniformly.
+  while IFS= read -r marker; do
     [ -f "$marker" ] || continue
     [ "$marker" = "$self" ] && continue
     skill=$(jq -r '.skill // "unknown"' "$marker" 2>/dev/null)
@@ -359,7 +362,7 @@ _nano_tel_finalize_stale_markers() {
     [ -z "$ts" ] && ts=$(_nano_tel_ts)
     _nano_tel_write_event "$skill" "" "unknown" "other" "$ts"
     rm -f "$marker" 2>/dev/null
-  done
+  done < <(find "$NANO_TEL_ANALYTICS_DIR" -maxdepth 1 -name '.pending-*' -type f 2>/dev/null)
 }
 
 # ─── Write a single event to the JSONL ─────────────────────────────────
@@ -431,6 +434,34 @@ _nano_tel_write_event() {
   chmod 600 "$NANO_TEL_JSONL" 2>/dev/null
 }
 
+# Fire-and-forget remote sync. Spawns telemetry-log.sh in the background
+# and disowns so the parent skill never waits. All safety is inside the
+# sender script: rate limit, tier check, kill switches, curl budget.
+# Calling this function does not guarantee a send; the sender itself may
+# exit silently for many reasons. That is by design.
+_nano_tel_send_async() {
+  # Respect the same three kill switches as the sender does. Checking here
+  # avoids even spawning a process when telemetry is disabled, which is
+  # cleaner for `ps` audits on enterprise systems. The marker path uses
+  # NANO_TEL_HOME to respect the same env override the helper uses, so
+  # a sysadmin testing disable behavior hits the expected path.
+  [ -n "${NANOSTACK_NO_TELEMETRY:-}" ] && return 0
+  [ -f "${NANO_TEL_HOME:-$HOME/.nanostack}/.telemetry-disabled" ] && return 0
+
+  local sender
+  sender="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)/telemetry-log.sh"
+  if [ ! -x "$sender" ]; then
+    # Fallback: look in the standard install path. If neither exists, no send.
+    sender="$HOME/.claude/skills/nanostack/bin/telemetry-log.sh"
+    [ -x "$sender" ] || return 0
+  fi
+
+  # Background + detach. nohup + redirects mean the sender survives if the
+  # parent exits and never writes to the parent's stdout/stderr.
+  (nohup "$sender" >/dev/null 2>&1 &) >/dev/null 2>&1
+  return 0
+}
+
 # ─── Finalize (called at skill end) ────────────────────────────────────
 nano_telemetry_finalize() {
   local skill="$1" outcome="${2:-success}" error_class="${3:-}"
@@ -452,4 +483,9 @@ nano_telemetry_finalize() {
   _nano_tel_write_event "$skill" "$duration" "$outcome" "$error_class" ""
   rm -f "$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID" 2>/dev/null
   _nano_tel_finalize_stale_markers
+
+  # Trigger background sync to the Worker. Fire-and-forget; the sender
+  # enforces its own rate limit (5 min between attempts) so calling this
+  # on every skill completion does not generate traffic proportional.
+  _nano_tel_send_async
 }

--- a/bin/telemetry-log.sh
+++ b/bin/telemetry-log.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# telemetry-log.sh — async sender for opt-in telemetry.
+#
+# Reads ~/.nanostack/analytics/skill-usage.jsonl, strips tier-specific
+# fields, POSTs a batch to the Worker, advances the cursor on 2xx with
+# inserted > 0. Fire-and-forget: never exits non-zero to the caller, never
+# blocks longer than its max-time curl budget, never retries synchronously.
+#
+# Invoked as a background process by nano_telemetry_finalize in
+# bin/lib/telemetry.sh, or manually by the user.
+#
+# Kill switches (any one is sufficient to prevent all network activity):
+#   NANOSTACK_NO_TELEMETRY=1 in the environment
+#   ~/.nanostack/.telemetry-disabled file present
+#   bin/telemetry-log.sh removed from the install
+#
+# Privacy contract (enforced by CI lint):
+#   - Endpoint URL is hardcoded https://. Not configurable.
+#   - User-Agent is fixed string. curl's default UA is never sent.
+#   - Cookies, Authorization, Referer, -v / --verbose are forbidden.
+#   - Max batch = 100 events. Max payload = 50 KB. Cursor advances only on 2xx.
+
+set -uo pipefail
+
+# ─── Paths (user-scoped, NOT project-scoped) ──────────────────────────
+# Resolved first so the marker-file kill switch below can use the override.
+NANO_TEL_HOME="${NANO_TEL_HOME:-$HOME/.nanostack}"
+
+# ─── Kill switches ────────────────────────────────────────────────────
+[ -n "${NANOSTACK_NO_TELEMETRY:-}" ] && exit 0
+[ -f "$NANO_TEL_HOME/.telemetry-disabled" ] && exit 0
+
+# ─── Dependencies ─────────────────────────────────────────────────────
+command -v curl >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v sed >/dev/null 2>&1 || exit 0
+
+# ─── Remaining paths ──────────────────────────────────────────────────
+NANO_TEL_CONFIG="$NANO_TEL_HOME/user-config.json"
+NANO_TEL_INSTALL_ID_FILE="$NANO_TEL_HOME/installation-id"
+NANO_TEL_ANALYTICS_DIR="$NANO_TEL_HOME/analytics"
+NANO_TEL_JSONL="$NANO_TEL_ANALYTICS_DIR/skill-usage.jsonl"
+CURSOR_FILE="$NANO_TEL_ANALYTICS_DIR/.last-sync-line"
+RATE_FILE="$NANO_TEL_ANALYTICS_DIR/.last-sync-time"
+
+# Endpoint is hardcoded. Not configurable by env or flag; an attacker who
+# flips an env var cannot redirect telemetry to a collector they control.
+NANO_TEL_ENDPOINT="https://nanostack-telemetry.remoto.workers.dev/v1/event"
+NANO_TEL_UA="nanostack-telemetry/0.5.0"
+NANO_TEL_MAX_BATCH=100
+NANO_TEL_MAX_PAYLOAD_BYTES=50000
+
+# ─── Pre-checks ────────────────────────────────────────────────────────
+# No JSONL → nothing to sync.
+[ -f "$NANO_TEL_JSONL" ] || exit 0
+
+# Read tier. Off → exit silently.
+if [ -f "$NANO_TEL_CONFIG" ]; then
+  TIER=$(jq -r '.telemetry // "off"' "$NANO_TEL_CONFIG" 2>/dev/null)
+else
+  TIER="off"
+fi
+case "$TIER" in
+  anonymous|community) ;;
+  *) exit 0 ;;
+esac
+
+# Rate limit: at most one sync per 5 minutes per install. The mtime of
+# RATE_FILE carries the last attempted sync time. `find -mmin +5` returns
+# the file iff older than 5 min; no output means we are still inside the
+# window and must defer.
+if [ -f "$RATE_FILE" ]; then
+  STALE=$(find "$RATE_FILE" -mmin +5 -print 2>/dev/null || true)
+  [ -z "$STALE" ] && exit 0
+fi
+
+# ─── Cursor ────────────────────────────────────────────────────────────
+CURSOR=0
+if [ -f "$CURSOR_FILE" ]; then
+  CURSOR=$(cat "$CURSOR_FILE" 2>/dev/null | tr -d ' \n\r\t')
+  case "$CURSOR" in *[!0-9]*) CURSOR=0 ;; esac
+fi
+
+TOTAL_LINES=$(wc -l < "$NANO_TEL_JSONL" 2>/dev/null | tr -d ' ')
+if [ -z "$TOTAL_LINES" ] || [ "$CURSOR" -gt "$TOTAL_LINES" ] 2>/dev/null; then
+  CURSOR=0
+fi
+[ "${CURSOR:-0}" -ge "${TOTAL_LINES:-0}" ] 2>/dev/null && exit 0
+
+SKIP=$(( CURSOR + 1 ))
+UNSENT=$(tail -n "+$SKIP" "$NANO_TEL_JSONL" 2>/dev/null || true)
+[ -z "$UNSENT" ] && exit 0
+
+# ─── Build batch (tier-aware stripping) ───────────────────────────────
+BATCH="["
+FIRST=1
+COUNT=0
+
+while IFS= read -r LINE; do
+  [ -z "$LINE" ] && continue
+  # Skip lines that are not JSON objects.
+  case "$LINE" in "{"*"}") ;; *) continue ;; esac
+
+  # Anonymous tier: drop session_id and installation_id. Community: keep all.
+  # The filter is byte-identical to what `show-data --remote-preview` uses,
+  # enforcing the promise that preview == send.
+  if [ "$TIER" = "anonymous" ]; then
+    CLEAN=$(printf '%s' "$LINE" | jq -c 'del(.session_id, .installation_id)' 2>/dev/null)
+  else
+    CLEAN=$(printf '%s' "$LINE" | jq -c '.' 2>/dev/null)
+  fi
+  [ -z "$CLEAN" ] && continue
+
+  if [ "$FIRST" = "1" ]; then
+    FIRST=0
+    BATCH="$BATCH$CLEAN"
+  else
+    BATCH="$BATCH,$CLEAN"
+  fi
+  COUNT=$(( COUNT + 1 ))
+  [ "$COUNT" -ge "$NANO_TEL_MAX_BATCH" ] && break
+done <<< "$UNSENT"
+
+BATCH="$BATCH]"
+[ "$COUNT" -eq 0 ] && exit 0
+
+# Final size gate. Worker caps at 50 KB; drop the attempt if the local
+# batch would overshoot after stripping, rather than truncate mid-event.
+BATCH_BYTES=${#BATCH}
+if [ "$BATCH_BYTES" -gt "$NANO_TEL_MAX_PAYLOAD_BYTES" ]; then
+  exit 0
+fi
+
+# ─── POST (curl invocation is the only network call in nanostack) ─────
+# The curl flag list is fixed and audited by CI:
+#   --silent --show-error: no prompt spam, stderr on hard error only
+#   --user-agent: fixed string. CI rejects if missing or variable.
+#   --max-time / --connect-timeout: never blocks the caller > 5s
+#   --request POST: explicit
+#   --header Content-Type: application/json: the only content header sent
+#   --data-binary @-: body from stdin, no shell interpolation into argv
+# Forbidden flags (CI lint): --cookie, --cookie-jar, --user, --header Cookie,
+#   --header Authorization, --header Referer, --location, -v, --verbose,
+#   --dump-header, --trace, http:// URLs.
+RESP_FILE=$(mktemp "/tmp/nano-tel-send.XXXXXX" 2>/dev/null) || exit 0
+HTTP_CODE=$(printf '%s' "$BATCH" | curl \
+  --silent --show-error \
+  --user-agent "$NANO_TEL_UA" \
+  --max-time 5 \
+  --connect-timeout 2 \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --data-binary @- \
+  --output "$RESP_FILE" \
+  --write-out '%{http_code}' \
+  "$NANO_TEL_ENDPOINT" 2>/dev/null || echo "000")
+
+# ─── Advance cursor on 2xx with inserted > 0 ──────────────────────────
+case "$HTTP_CODE" in
+  2*)
+    INSERTED=$(jq -r '.inserted // 0' "$RESP_FILE" 2>/dev/null | head -1)
+    case "$INSERTED" in *[!0-9]*|'') INSERTED=0 ;; esac
+    if [ "$INSERTED" -gt 0 ] 2>/dev/null; then
+      NEW_CURSOR=$(( CURSOR + COUNT ))
+      printf '%s' "$NEW_CURSOR" > "$CURSOR_FILE" 2>/dev/null || true
+      chmod 600 "$CURSOR_FILE" 2>/dev/null || true
+    fi
+    ;;
+esac
+
+rm -f "$RESP_FILE" 2>/dev/null || true
+
+# Always update the rate-limit marker, even on failure, so a failing endpoint
+# does not spin the sender every invocation.
+touch "$RATE_FILE" 2>/dev/null || true
+
+exit 0

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 250
 
 After a sprint or a significant fix, extract what you learned into structured, searchable documents. Next time the agent plans or reviews, it finds these automatically.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" compound
+unset _P
+```
+
 ## When to run
 
 - After `/ship` completes a sprint
@@ -163,6 +173,18 @@ Consider re-running: /investigate --diarize <subject>
 Then tell the user:
 
 > Knowledge captured. These solutions will be found automatically by /nano during planning and /review during code review.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" compound success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if compound did not complete normally.
 
 ## Rules
 

--- a/conductor/SKILL.md
+++ b/conductor/SKILL.md
@@ -13,6 +13,16 @@ Coordinate multiple agent sessions working on the same project. Each agent claim
 
 **No daemon. No service. No IPC.** Just atomic file operations on `.nanostack/conductor/`.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" conductor
+unset _P
+```
+
 ## How it works
 
 ```
@@ -242,6 +252,18 @@ Every phase transition follows this protocol. The agent executes these steps at 
 1. `bin/session.sh resume` detects the last session state
 2. `bin/restore-context.sh` reads all completed phase checkpoints
 3. Skip completed phases, restart the in-progress phase from scratch
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" conductor success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if conductor did not complete normally.
 
 ## Gotchas
 

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -19,6 +19,16 @@ Fast path for adding a feature to an existing project. Skips the /think diagnost
 /feature Add import from JSON/CSV to restore backups
 ```
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" feature
+unset _P
+```
+
 ## Setup
 
 Before anything else, ensure the project is configured. Run this once (skips if already done):
@@ -91,6 +101,18 @@ Use Skill tool: skill="ship"
 ```
 
 /ship commits, creates PR if remote exists, generates sprint journal, runs /compound, and shows the result with next feature suggestions.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" feature success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if the feature flow did not complete normally.
 
 ## Rules
 

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -15,6 +15,16 @@ hooks:
 
 You have activated safety guardrails. These protect against accidental destructive operations during this session.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" guard
+unset _P
+```
+
 ## Modes
 
 The user may activate a specific mode. If no mode is specified, default to **careful**.
@@ -113,6 +123,18 @@ Safer alternative: git push --force-with-lease (safer, fails if remote changed)
 Rules live in `guard/rules.json`. 28 block rules and 9 warn rules ship by default across 7 categories: mass-deletion, history-destruction, database-destruction, infra-destruction, production-access, remote-code-execution, security-degradation, safety-bypass.
 
 Users can add custom rules by editing `guard/rules.json`. Each rule has an ID, regex pattern, category, description, and (for block rules) a safer alternative.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" guard success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if guard did not complete normally.
 
 ## Gotchas
 

--- a/help/SKILL.md
+++ b/help/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 100
 
 Show the user a concise overview of nanostack. No walls of text. Organized by what they want to do.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" nano-help
+unset _P
+```
+
 ## Response
 
 Print this directly:
@@ -68,3 +78,15 @@ github.com/garagon/nanostack
 ```
 
 If the user asks about a specific skill, invoke it: use Skill tool with the skill name. Don't explain the skill yourself — let the skill's own SKILL.md handle it.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" nano-help success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if help did not complete normally.

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 400
 
 You turn validated ideas into executable steps. Every file gets named. Every step gets a verification. Every unknown gets surfaced. The plan is a contract: if it says 4 files, the PR should touch 4 files.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" nano
+unset _P
+```
+
 ## Session
 
 If no active session exists, initialize one:
@@ -173,6 +183,18 @@ Tell the user:
 > These three can run in any order. After all pass, `/ship` to create the PR.
 
 Wait for the user to invoke each one.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" nano success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if the plan did not complete normally.
 
 ## Gotchas
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 450
 
 You test like a real user and fix like an engineer. Click everything, fill every form, check every state. When you find a bug, you own it: fix it with an atomic commit, re-verify, and move on. If a fix touches more than it should, stop and report instead.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" qa
+unset _P
+```
+
 ## Intensity Mode
 
 If the user specifies a mode flag, use it. Otherwise, check `bin/init-config.sh` for `preferences.default_intensity`.
@@ -223,6 +233,18 @@ After the user-facing message above, print one summary line as the very last thi
 ```
 
 Use `WARN` instead of `OK` if any tests failed.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" qa success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if the QA session did not complete normally.
 
 ## Gotchas
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -15,6 +15,16 @@ hooks:
 
 You are a skeptical senior engineer who has seen production go down because someone skipped the second look. Two passes, two mindsets. Do not blend them. You own the findings: if something is mechanical, fix it yourself. If it needs judgment, ask.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" review
+unset _P
+```
+
 ## Intensity Mode
 
 If the user specifies a mode flag, use it. Otherwise, check `bin/init-config.sh` for `preferences.default_intensity`. If no config, **suggest** a mode based on the diff:
@@ -196,6 +206,18 @@ Use `WARN` instead of `OK` if there are any blocking findings.
 - **Don't suggest refactors that aren't related to the change.** "While you're here, you should also..." is scope creep. File a separate issue.
 - **Scale adversarial effort by diff size.** A 10-line utility function doesn't need a threat model. A new API endpoint does.
 - **Scope drift is informational, not punitive.** Drift happens for good reasons. The point is visibility, not blocking.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" review success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if the review did not complete normally.
 
 ## Hook: Security Suggestion
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 450
 
 You think like an attacker but report like a defender. The real attack surface is rarely the code you wrote. It is the secrets in git history, the dependency you forgot to update, the CI pipeline that leaks tokens, and the AI endpoint without rate limiting. Start there, not at the application logic.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" security
+unset _P
+```
+
 ## Intensity Mode
 
 | Mode | Flag | Scope | Confidence gate |
@@ -257,6 +267,18 @@ When the model or user fixes security findings, do NOT re-run the full audit. In
 - **MEDIUM/LOW fixes:** Verify the specific fix by reading the changed code. No re-audit needed. Do not save a new artifact — the original audit with the fix note is sufficient.
 
 Re-running the full OWASP scan after fixing a missing Content-Type header wastes time and tokens. Target the verification.
+
+## Telemetry finalize
+
+Before returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" security success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if the audit did not complete normally.
 
 ## Gotchas
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -15,6 +15,16 @@ hooks:
 
 You get code from "done" to "verified in production" in one pass. You own the full pipeline: pre-flight, PR, CI, deploy, verification. If something breaks after merge, you rollback first and debug second.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" ship
+unset _P
+```
+
 ## Local Mode
 
 Run `source bin/lib/git-context.sh && detect_git_mode`.
@@ -228,6 +238,18 @@ Include before/after test counts when tests were added. Quantify the improvement
 - **One PR = one concern.** Split unrelated changes.
 - **Check existing PRs before creating yours.** Search first.
 - **Read CONTRIBUTING.md.** Every project has different rules.
+
+## Telemetry finalize
+
+Before handing off to compound or the user:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" ship success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if ship did not complete normally.
 
 ## Next Step
 

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -11,6 +11,16 @@ estimated_tokens: 300
 
 You are a friendly onboarding guide. Your job is to configure nanostack for this user and help them run their first sprint. No jargon, no docs, just conversation.
 
+## Telemetry preamble
+
+Defensive telemetry init. No-op if telemetry is disabled via `NANOSTACK_NO_TELEMETRY=1`, `~/.nanostack/.telemetry-disabled`, or if the helpers are removed.
+
+```bash
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" nano-run
+unset _P
+```
+
 ## Step 1: Detect state
 
 Check if this project already has nanostack configured:
@@ -83,6 +93,18 @@ If the user is technical and wants the slash commands, also offer:
 > Quick reference: `/think` → `/nano` → build → `/review` → `/security` → `/qa` → `/ship`. For adding to an existing project, use `/feature` instead.
 
 When they describe something, invoke: use Skill tool: skill="think"
+
+## Telemetry finalize
+
+Before handing off to /think or returning control:
+
+```bash
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" nano-run success
+unset _F
+```
+
+Pass `abort` or `error` instead of `success` if onboarding did not complete normally.
 
 ## Rules
 

--- a/telemetry-worker/verify-security.sh
+++ b/telemetry-worker/verify-security.sh
@@ -133,6 +133,23 @@ VALID_WITH_JUNK='{"v":1,"ts":"2026-04-21T12:00:00Z","skill":"verify_test","outco
 assert_json_field "unknown fields silently dropped (hostname/repo/ip) → inserted:1" "inserted" "1" \
   -X POST -H "Content-Type: application/json" -d "$VALID_WITH_JUNK" "$EVENT_URL"
 
+# ─── Real-client simulation (bin/telemetry-log.sh style) ────────────────
+printf "\nReal-client batch:\n"
+# Simulate what bin/telemetry-log.sh sends: batch of 3 events with the
+# same flags the sender uses. Tests the full contract end to end.
+BATCH='[
+  {"v":1,"ts":"2026-04-21T12:00:00Z","skill":"verify_test","outcome":"success","os":"darwin","arch":"arm64","nanostack_version":"0.5.0-test","duration_s":10},
+  {"v":1,"ts":"2026-04-21T12:00:11Z","skill":"verify_test","outcome":"error","os":"darwin","arch":"arm64","nanostack_version":"0.5.0-test","duration_s":5,"error_class":"lint_error"},
+  {"v":1,"ts":"2026-04-21T12:00:16Z","skill":"verify_test","outcome":"abort","os":"linux","arch":"x86_64","nanostack_version":"0.5.0-test"}
+]'
+assert_json_field "batch of 3 valid events → inserted:3" "inserted" "3" \
+  --user-agent "nanostack-telemetry/0.5.0-test" \
+  --max-time 5 --connect-timeout 2 \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --data-binary "$BATCH" \
+  "$EVENT_URL"
+
 # ─── Summary ────────────────────────────────────────────────────
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -45,30 +45,19 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 
 ### Telemetry preamble
 
-Telemetry is optional and defensive. The skill must run identically whether the telemetry helper is present, disabled, or removed. A sysadmin can disable telemetry in three ways:
-
-- Set `NANOSTACK_NO_TELEMETRY=1` in the environment.
-- Create `~/.nanostack/.telemetry-disabled` as an empty file.
-- Delete `bin/lib/telemetry.sh` and `bin/telemetry-config.sh` from the install.
-
-Any of the three makes the block below a no-op. The skill continues normally.
+Telemetry is optional and defensive. Three disable mechanisms: `NANOSTACK_NO_TELEMETRY=1` in the environment, `~/.nanostack/.telemetry-disabled` marker file, or removing the helpers from `bin/lib/`. Any one is sufficient; the block below becomes a no-op.
 
 Run this block:
 
 ```bash
-if [ -z "${NANOSTACK_NO_TELEMETRY:-}" ] \
-   && [ ! -f "$HOME/.nanostack/.telemetry-disabled" ] \
-   && [ -f "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" ]; then
-  source "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" 2>/dev/null
-  nano_telemetry_init 2>/dev/null
-  command -v nano_telemetry_pending_write >/dev/null 2>&1 && \
-    nano_telemetry_pending_write think 2>/dev/null
-fi
+_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
+[ -f "$_P" ] && . "$_P" think
+unset _P
 echo "TEL_TIER=${NANO_TEL_TIER:-off}"
 echo "TEL_SKIP_PROMPT=${NANO_TEL_SKIP_PROMPT:-1}"
 ```
 
-If telemetry was disabled or stripped, `TEL_TIER=off` and `TEL_SKIP_PROMPT=1` fall through from the defaults, and the skill simply does not prompt or record anything.
+If telemetry is disabled or stripped, `TEL_TIER=off` and `TEL_SKIP_PROMPT=1` fall through from the defaults, and the skill does not prompt or record anything.
 
 **If `TEL_TIER` is not `off` AND `TEL_SKIP_PROMPT=0`**, show the opt-in prompt using `AskUserQuestion`. The helper already checks whether the user was prompted before or is a pre-existing install. Use exactly this wording:
 
@@ -348,14 +337,15 @@ Wait for the user to invoke `/nano`.
 
 ### Telemetry finalize
 
-Before handing control back to the user (or to `/nano` in autopilot), close out telemetry if it is available:
+Before handing control back to the user (or to `/nano` in autopilot), close out telemetry:
 
 ```bash
-command -v nano_telemetry_finalize >/dev/null 2>&1 && \
-  nano_telemetry_finalize think success 2>/dev/null
+_F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
+[ -f "$_F" ] && . "$_F" think success
+unset _F
 ```
 
-If the flow aborted (user interrupted, blocked on missing info, error in a phase), pass `abort` or `error` instead of `success`. The `command -v` guard keeps the line harmless when telemetry is disabled or stripped. The function itself is also a no-op if tier is `off`.
+If the flow aborted (user interrupted, blocked on missing info, error in a phase), pass `abort` or `error` instead of `success`. The finalize helper is a no-op when telemetry is disabled, stripped, or tier is `off`.
 
 For retro mode (`/think --retro`), same rule applies at the end of the retro brief output.
 


### PR DESCRIPTION
## TL;DR

PR #111 landed the Worker and the local writer. With the contract proven end to end, this PR flips on the actual data flow: an audited async sender and every slash-invokable skill calling a shared defensive preamble. Opt-in users now generate measurable skill flows. Default-off users, enterprise installs, and anyone who removed the helpers see no change: zero network calls, zero new surface area.

**What runs now:** 12 skills (think, nano, review, security, qa, ship, compound, feature, conductor, nano-run, guard, nano-help) each call a shared preamble helper at start and a finalize helper at end. Finalize triggers a background sender whose entire curl invocation is audited by CI.

**Verified against live endpoint:** `cd telemetry-worker && ./verify-security.sh` → 20/20 pass, including a real-client batch simulation.

## What's in this PR

### Async sender (`bin/telemetry-log.sh`, new)

The only place in nanostack that initiates a network request.

- Endpoint hardcoded `https://nanostack-telemetry.remoto.workers.dev/v1/event`. No environment override exists: a flipped env var cannot redirect telemetry to a collector an attacker controls.
- Curl flags fixed and audited: explicit `User-Agent: nanostack-telemetry/0.5.0` (hides curl version), 2s connect + 5s total timeout, `Content-Type: application/json`, nothing else.
- Cursor-based sync: `~/.nanostack/analytics/.last-sync-line` tracks position. Advances only on 2xx with `inserted > 0`. Network hiccups do not duplicate events; aborted syncs do not lose them.
- 5-minute client-side rate limit via mtime of `.last-sync-time`. Always touched (even on failure) to prevent spin against a broken endpoint.
- Anonymous tier strips `session_id` and `installation_id` via jq before POST, byte-identical to what `show-data --remote-preview` displays.
- Respects all three kill switches: `NANOSTACK_NO_TELEMETRY`, `~/.nanostack/.telemetry-disabled`, helper removal.

### Shared preamble / finalize helpers (`bin/lib/skill-preamble.sh`, `skill-finalize.sh`, new)

One canonical defensive block each SKILL.md calls with one line. Changes to the pattern happen in one place, not 12.

```bash
_P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
[ -f "$_P" ] && . "$_P" <skill-name>
unset _P
```

### Wire-up (12 SKILL.md files)

- Core sprint: `plan` (→ `/nano`), `review`, `security`, `qa`, `ship`, `compound`
- Entry points: `think`, `feature`, `start` (→ `/nano-run`)
- Meta/helpers: `conductor`, `guard`, `help` (→ `/nano-help`)

Each skill has a `## Telemetry preamble` block near the top and a `## Telemetry finalize` block before the reference tail (Gotchas, Rules, etc.).

`think/SKILL.md` refactored to use the shared helper while preserving its unique opt-in prompt (the only place that prompts on first run).

### `bin/lib/telemetry.sh` additions

- `_nano_tel_send_async`: spawns `telemetry-log.sh` via nohup + detach. Parent skill never waits. Disowned so sender survives parent exit.
- `nano_telemetry_finalize` now invokes the background send. Per-call rate limit happens inside the sender.
- `_nano_tel_finalize_stale_markers` uses `find` instead of bash glob. Fixes zsh `NOMATCH` throw on empty analytics dirs.

### CI (`.github/workflows/lint.yml`)

- `telemetry-privacy` job extended to scan all 5 files in the telemetry path: `telemetry.sh`, `telemetry-config.sh`, `telemetry-log.sh`, `skill-preamble.sh`, `skill-finalize.sh`.
- New `telemetry-log.sh sender safety` step: asserts required flags present (`--user-agent`, `--max-time`, `--connect-timeout`, `--request POST`, `nanostack-telemetry/`, kill-switch references). Rejects forbidden flags (`--cookie`, `--location`, `--verbose`, Authorization header, `http://`, etc.). Enforces exactly one workers.dev URL so contract-preview and actual-send cannot diverge.

### `verify-security.sh`

Added a 20th assertion: batch of 3 events using the same curl flag set the real client uses. Proves the live endpoint accepts a realistic client payload end to end.

## How to audit

```sh
# Read the sender. Small and audit-friendly.
wc -l bin/telemetry-log.sh          # ~180 lines

# Grep for every curl invocation. There is one.
grep -n curl bin/telemetry-log.sh

# Reproduce the contract against the live endpoint.
cd telemetry-worker && ./verify-security.sh     # 20/20 pass

# Verify the kill switches still zero the network path:
NANOSTACK_NO_TELEMETRY=1 bash -c '. bin/lib/skill-preamble.sh review && . bin/lib/skill-finalize.sh review success'
# Neither .last-sync-time nor any HTTP request is created.

touch ~/.nanostack/.telemetry-disabled
# Same result.

rm bin/lib/telemetry.sh bin/telemetry-config.sh bin/telemetry-log.sh
# SKILL.md preambles become no-ops. Skills still run.
```

## Test plan

Verified on macOS arm64:

- 12 skills invoked in sequence log 12 local events; cursor advances as the sender drains the queue; rate limiter prevents burst traffic.
- Real-client batch (3 events) accepted by live Worker, inserted into D1, confirmed absent after cleanup DELETE.
- All three kill switches (env var, marker file, helper removal) independently prevent any network call.
- `show-data --remote-preview` matches what the sender actually POSTs byte for byte (both use the same jq filter).
- zsh no longer throws on empty analytics directories.
- CI lint simulation (all five jobs) passes locally.

## Follow-ups

This PR closes Sprint 3 of the V5 plan. Remaining:

- Sprint 4: `/think` presets (default, yc, garry).
- Sprint 5: session tiers, multi-approach, second opinion.
- Sprint 6: internal dashboard with CF Access.