### PR TITLE
Fix non-zero exit from setup on installs without Gemini

### DIFF
--- a/setup
+++ b/setup
@@ -498,3 +498,9 @@ echo "Next step — activate the skills in your agent:"
 [ "$INSTALL_CODEX" -eq 1 ]    && echo "  Codex:        run \`codex\` in a new terminal, then type /nano-help."
 [ "$INSTALL_OPENCODE" -eq 1 ] && echo "  OpenCode:     restart your OpenCode session, then type /nano-help."
 [ "$INSTALL_GEMINI" -eq 1 ]   && echo "  Gemini CLI:   run \`gemini\` in a new terminal, then type /nano-help."
+
+# The `[ test ] && echo` lines above each return 1 for any agent the user
+# did NOT install. Without an explicit success at the end, the script's
+# exit code would be the last test's result — making a clean setup look
+# failed to upgrade.sh (which runs under `set -e`) and to any CI path.
+exit 0


### PR DESCRIPTION
## What

`setup` ended with a cascade of `[ "$INSTALL_<AGENT>" -eq 1 ] && echo ...` lines. For every agent the user did NOT install, the test returns 1 and `&&` short-circuits. Because the last such line was the last statement in the script, its non-zero exit propagated as the script's own exit code.

## Impact

Any user running `/nano-update` (or invoking `./setup` manually) who is not installing Gemini CLI saw `Exit code 1` after a visibly successful run. `upgrade.sh` runs setup under `set -e`, so a clean upgrade looked failed to the caller. Reported by a user on a Claude-only install today.

## Fix

Explicit `exit 0` at the end of setup, with a comment explaining why so the pattern is not reintroduced.

## Verification

Before:
```
$ bash -c 'A=0; [ "$A" -eq 1 ] && echo yes; echo "exit: $?"'
exit: 1
```

After: `./setup` on a Claude-only install exits 0 cleanly. Verified locally.

## Scope

One file, six lines added (four of comment, one blank, one `exit 0`). No behavior change other than the exit code.