### PR TITLE
Fix telemetry state loss between preamble and finalize

### DIFF
--- a/bin/lib/skill-finalize.sh
+++ b/bin/lib/skill-finalize.sh
@@ -8,15 +8,67 @@
 #
 # Outcome is one of: success, error, abort, unknown. Defaults to success.
 #
-# This file is a thin wrapper around nano_telemetry_finalize that tolerates
-# a missing telemetry helper. If telemetry.sh was not sourced (kill switch
-# active, file removed, etc.), nano_telemetry_finalize will not be defined
-# and this file becomes a no-op.
+# Unlike a naive wrapper, this file CANNOT rely on nano_telemetry_finalize
+# already being defined. In agents like Claude Code, each Bash tool call
+# starts a fresh shell process with no inherited functions or env vars
+# from the preamble's shell. This script therefore:
+#   1. Respects the kill switches (env var, marker file) on its own.
+#   2. Sources telemetry.sh from a sibling directory or the standard
+#      install path.
+#   3. Restores session state from the .active-<skill>.env file that
+#      skill-preamble.sh wrote on disk. Without this restore, finalize
+#      would work with an empty session_id and fail to clean up the
+#      pending marker the preamble wrote.
+#
+# If any of the defensive paths fail (helper missing, kill switch active,
+# state file missing), this file is a no-op and the skill continues
+# normally. The pending marker pruner in telemetry.sh reaps orphan markers
+# after 7 days.
 
 _nano_skill_name="${1:-unknown}"
 _nano_skill_outcome="${2:-success}"
 
-command -v nano_telemetry_finalize >/dev/null 2>&1 && \
-  nano_telemetry_finalize "$_nano_skill_name" "$_nano_skill_outcome" 2>/dev/null
+# Kill switches. Same order and semantics as skill-preamble.sh so there is
+# no scenario where the preamble runs but finalize is blocked (or vice versa).
+if [ -n "${NANOSTACK_NO_TELEMETRY:-}" ]; then
+  unset _nano_skill_name _nano_skill_outcome
+  return 0 2>/dev/null || true
+fi
 
-unset _nano_skill_name _nano_skill_outcome
+if [ -f "${NANO_TEL_HOME:-$HOME/.nanostack}/.telemetry-disabled" ]; then
+  unset _nano_skill_name _nano_skill_outcome
+  return 0 2>/dev/null || true
+fi
+
+# Source telemetry.sh. Try sibling directory first (dev / vendored),
+# then standard install path. Missing is fine — we no-op.
+_nano_tel_lib=""
+_nano_skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+if [ -n "$_nano_skill_dir" ] && [ -f "$_nano_skill_dir/telemetry.sh" ]; then
+  _nano_tel_lib="$_nano_skill_dir/telemetry.sh"
+elif [ -f "$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh" ]; then
+  _nano_tel_lib="$HOME/.claude/skills/nanostack/bin/lib/telemetry.sh"
+fi
+
+if [ -n "$_nano_tel_lib" ]; then
+  # shellcheck disable=SC1090
+  . "$_nano_tel_lib" 2>/dev/null
+
+  # Restore session state written by skill-preamble.sh. The file is named
+  # per-skill so parallel skills do not overwrite each other. We remove
+  # the file after reading so it cannot accumulate; the pending marker
+  # pruner handles the case where finalize never ran.
+  _nano_state_file="${NANO_TEL_HOME:-$HOME/.nanostack}/.active-$_nano_skill_name.env"
+  if [ -f "$_nano_state_file" ]; then
+    # shellcheck disable=SC1090
+    . "$_nano_state_file" 2>/dev/null
+    rm -f "$_nano_state_file" 2>/dev/null
+  fi
+
+  command -v nano_telemetry_finalize >/dev/null 2>&1 && \
+    nano_telemetry_finalize "$_nano_skill_name" "$_nano_skill_outcome" 2>/dev/null
+
+  unset _nano_state_file
+fi
+
+unset _nano_tel_lib _nano_skill_dir _nano_skill_name _nano_skill_outcome

--- a/bin/lib/skill-preamble.sh
+++ b/bin/lib/skill-preamble.sh
@@ -52,6 +52,27 @@ if [ -n "$_nano_tel_lib" ]; then
   nano_telemetry_init 2>/dev/null
   command -v nano_telemetry_pending_write >/dev/null 2>&1 && \
     nano_telemetry_pending_write "$_nano_skill_name" 2>/dev/null
+
+  # Persist init state to disk so skill-finalize.sh can restore it in a
+  # separate shell invocation. In agents like Claude Code each Bash tool
+  # call starts a fresh process with no inherited env; without this file
+  # the finalize step cannot link to the pending marker written here.
+  # One file per skill name; accumulates only if finalize never runs (which
+  # the pruner in telemetry.sh cleans up after 7 days).
+  if command -v nano_telemetry_init >/dev/null 2>&1 && \
+     [ -n "${NANO_TEL_SESSION_ID:-}" ]; then
+    _nano_state_dir="${NANO_TEL_HOME:-$HOME/.nanostack}"
+    _nano_state_file="$_nano_state_dir/.active-$_nano_skill_name.env"
+    mkdir -p "$_nano_state_dir" 2>/dev/null
+    {
+      printf 'NANO_TEL_SESSION_ID=%s\n' "$NANO_TEL_SESSION_ID"
+      printf 'NANO_TEL_START_EPOCH=%s\n' "$NANO_TEL_START_EPOCH"
+      printf 'NANO_TEL_TIER=%s\n' "$NANO_TEL_TIER"
+      printf 'NANO_TEL_INSTALLATION_ID=%s\n' "${NANO_TEL_INSTALLATION_ID:-}"
+    } > "$_nano_state_file" 2>/dev/null
+    chmod 600 "$_nano_state_file" 2>/dev/null
+    unset _nano_state_dir _nano_state_file
+  fi
 fi
 
 unset _nano_tel_lib _nano_skill_dir _nano_skill_name

--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -341,9 +341,14 @@ _nano_tel_rotate_if_large() {
 
 # Drop .pending-* markers older than 7 days. Runs in init regardless of
 # tier so markers do not accumulate across long `off` periods.
+# Also reaps .active-<skill>.env state files written by skill-preamble.sh
+# but never cleared because finalize did not run (crash, agent exit, etc.).
 _nano_tel_prune_old_markers() {
   [ -d "$NANO_TEL_ANALYTICS_DIR" ] || return 0
   find "$NANO_TEL_ANALYTICS_DIR" -maxdepth 1 -name '.pending-*' -type f \
+    -mtime +7 -delete 2>/dev/null || true
+  [ -d "$NANO_TEL_HOME" ] || return 0
+  find "$NANO_TEL_HOME" -maxdepth 1 -name '.active-*.env' -type f \
     -mtime +7 -delete 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Root cause

In agents like Claude Code, each Bash tool invocation starts a fresh shell process. Environment variables and shell functions set in the preamble's bash call are NOT inherited by the separate finalize bash call.

Before this fix, `skill-finalize.sh` relied on `command -v nano_telemetry_finalize` to detect whether telemetry was loaded. In the real multi-process flow, `telemetry.sh` was never sourced in the finalize shell, so finalize silently no-oped. Pending markers accumulated, JSONL was never written, the async sender never fired, and D1 received nothing.

**PR #111 / #112 QA missed this because every test ran inside a single `bash -c '...'`** where state did persist.

## Evidence

User dogfood test today:
1. Opted into `community` tier successfully (installation-id generated).
2. Ran `/think` in a fresh agent session.
3. Skill completed visibly OK.
4. Pending marker `.pending-43668-1776784016` stayed orphaned on disk (preamble ran).
5. `skill-usage.jsonl` never created (finalize silently no-oped).
6. D1 event count: 0.

Reproduction with two separate `bash -c` calls (matching Claude Code's process model):

```sh
$ bash -c 'export FOO=x; echo set'
set
$ bash -c 'echo "${FOO:-EMPTY}"'
EMPTY     # <-- state lost
```

## Fix

Persist session state to disk between preamble and finalize.

`skill-preamble.sh` now writes `~/.nanostack/.active-<skill>.env` after init, containing `NANO_TEL_SESSION_ID`, `NANO_TEL_START_EPOCH`, `NANO_TEL_TIER`, `NANO_TEL_INSTALLATION_ID`. Mode 0600.

`skill-finalize.sh`:
1. Respects kill switches independently (same as preamble).
2. Sources `telemetry.sh` from the sibling dir or the standard install path instead of relying on `command -v`.
3. Restores state from `.active-<skill>.env` and removes the file.

`telemetry.sh` `_nano_tel_prune_old_markers` now also reaps `.active-*.env` files older than 7 days so abandoned state files do not accumulate on crashed runs.

## Tier refresh is preserved

Tier is intentionally NOT pinned at preamble time. `nano_telemetry_finalize` calls `_nano_tel_refresh_tier` which re-reads from the config file. This preserves the mid-run opt-in scenario — if a user flips from `off` to `community` while a skill is running, the sprint's event still gets recorded correctly.

## Verification

Test simulating Claude Code's process model with three separate `bash -c` invocations (preamble, opt-in, finalize):

```
=== State file written? ===
-rw-------  /tmp/.../.active-think.env
NANO_TEL_SESSION_ID=44924-1776784271
NANO_TEL_START_EPOCH=1776784271
NANO_TEL_TIER=off
NANO_TEL_INSTALLATION_ID=

=== Opt in (separate process) ===
tier after opt-in: community

=== Process 2: Finalize (different PID) ===
finalize ran (silent success)

=== JSONL written ===
{"v":1,"skill":"think","session_id":"44924-1776784271",
 "outcome":"success","duration_s":3,
 "installation_id":"e6599804-..."}    # community iid correctly picked up

=== Pending marker cleaned? ===   yes
=== State file cleaned? ===       yes
```

- Session_id matches preamble (no divergence).
- Duration calculated from preamble's start_epoch.
- Tier refreshed mid-run to `community`, installation_id attached correctly.
- Both transient files cleaned.

## Scope

3 files, +85 / -7. No SKILL.md changes needed — the one-line invocation in each SKILL.md stays the same. This is a pure implementation fix of the two helper scripts.

## Urgency

High. Without this fix, telemetry produces zero events regardless of tier setting. The feature is DOA in any real agent flow.