### PR TITLE
Rewrite Features grid in plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,44 +58,44 @@ Every step is enforced. You cannot `/ship` without `/review`, `/security`, and `
 <table>
 <tr>
 <td align="center" width="33%">
-<h3>🧠 Scope Challenge</h3>
-<code>/think</code> pushes back before code exists. The smallest thing worth building is often smaller than you thought.
+<h3>🧠 Pushes back before you build</h3>
+<code>/think</code> challenges your idea before a single line of code. Most features ship smaller than you pitched them. That usually means you saved a week.
 </td>
 <td align="center" width="33%">
-<h3>📋 Named Plans</h3>
-<code>/nano</code> names every file and every risk. "Write tests" is not a step. <code>src/auth/webhook.ts: add HMAC verification</code> is.
+<h3>📋 A real plan, not "add a feature"</h3>
+<code>/nano</code> lists every file the agent will touch and every thing that could go wrong. A plan you can read, argue with, and check off.
 </td>
 <td align="center" width="33%">
-<h3>🔍 Scope Drift Detection</h3>
-<code>/review</code> reads the plan artifact. If the PR touches files the plan did not declare, you hear about it.
+<h3>🔍 Catches when the agent adds extras</h3>
+<code>/review</code> compares what got built with what you agreed to build. If the agent quietly added five extra things, you find out before you ship.
 </td>
 </tr>
 <tr>
 <td align="center">
-<h3>🛡️ Security on Every Ship</h3>
-OWASP A01-A10 plus STRIDE before every merge. Graded A-F. Not a quarterly calendar block.
+<h3>🛡️ Security before every release</h3>
+<code>/security</code> checks for the mistakes that leak passwords, open doors to attackers, or crash your app. Graded A through F. Not once a quarter. Every release.
 </td>
 <td align="center">
-<h3>🧪 Real QA</h3>
-Browser (Playwright), native app, CLI, or root-cause debug. Fixes are atomic commits, before and after screenshots when visual.
+<h3>🧪 Actually opens your app and clicks</h3>
+<code>/qa</code> opens your app like a real user. Clicks buttons. Takes screenshots. When it finds a bug, it fixes it, shows you before-and-after, and moves on.
 </td>
 <td align="center">
-<h3>📦 Honest PRs</h3>
-<code>/ship</code> writes <em>why</em> the change exists, not just what files changed. CI verified, canary checked, sprint journal saved.
+<h3>📦 PRs that explain <em>why</em></h3>
+<code>/ship</code> writes a PR description that explains why the change exists, not just what files changed. Your team (or future you) reads it and actually understands.
 </td>
 </tr>
 <tr>
 <td align="center">
-<h3>🎯 Phase Gate</h3>
-<code>git commit</code> is blocked until <code>/review</code>, <code>/security</code>, and <code>/qa</code> pass. The pipeline is enforced in shell, not wished for.
+<h3>🎯 Can't skip the hard steps</h3>
+The sprint runs in order: think, plan, build, review, security, qa, ship. Trying to ship before reviewing is blocked. No accidental Friday 5pm surprises.
 </td>
 <td align="center">
-<h3>🔐 Opt-in Telemetry</h3>
-Default off. Three independent disable mechanisms. Code, prompts, repo names, and paths never leave your machine.
+<h3>🔐 Your code stays on your computer</h3>
+Nothing leaves unless you opt in. Your code, your prompts, your project names, your file paths. All local. Three ways to turn any sharing off.
 </td>
 <td align="center">
-<h3>⚡ Zero Deps, Zero Build</h3>
-Markdown plus bash. Your agent reads files on disk. No daemon, no SaaS, no API key. Inspectable, auditable, portable.
+<h3>⚡ No accounts, no servers, no cloud</h3>
+The skills are plain text files on your computer. You can open any of them and read exactly what it does. No login, no SaaS, no vendor lock-in.
 </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Every step is enforced. You cannot `/ship` without `/review`, `/security`, and `
 <table>
 <tr>
 <td align="center" width="33%">
-<h3>🧠 Pushes back before you build</h3>
-<code>/think</code> challenges your idea before a single line of code. Most features ship smaller than you pitched them. That usually means you saved a week.
+<h3>🧠 Thinks with you, pushes back when needed</h3>
+<code>/think</code> is the thinking partner most solo builders don't have. Asks the questions that take an idea from vague to concrete. Challenges without dismissing. You finish with clarity about what to build and why.
 </td>
 <td align="center" width="33%">
 <h3>📋 A real plan, not "add a feature"</h3>
@@ -73,7 +73,7 @@ Every step is enforced. You cannot `/ship` without `/review`, `/security`, and `
 <tr>
 <td align="center">
 <h3>🛡️ Security before every release</h3>
-<code>/security</code> checks for the mistakes that leak passwords, open doors to attackers, or crash your app. Graded A through F. Not once a quarter. Every release.
+<code>/security</code> looks for password leaks, broken logins, and the kind of mistakes that make headlines. Every release, not once a quarter. Your users' data stays where it belongs.
 </td>
 <td align="center">
 <h3>🧪 Actually opens your app and clicks</h3>


### PR DESCRIPTION
## What changes

Nine feature cards rewritten with language that reads without a security or DevOps background. Same grid, same nine concepts, more accessible copy. The sprint table in "What is Nanostack?" stays technical on purpose: it is the spec, for readers who want to verify what each skill does. The Features grid is the at-a-glance pitch, for a wider audience.

## Why

Nanostack's audience includes indie hackers, founders, and anyone building with AI who is not a full time senior engineer. The merged version (#118) used vocabulary like OWASP A01-A10, STRIDE, Playwright, HMAC, artifact, canary, and daemon. Accurate, but opaque to a big part of the audience.

## Diff snapshot

Before (samples):

- `OWASP A01-A10 plus STRIDE before every merge. Graded A-F.`
- `Browser (Playwright), native app, CLI, or root-cause debug. Fixes are atomic commits, before and after screenshots when visual.`
- `git commit is blocked until /review, /security, and /qa pass. The pipeline is enforced in shell, not wished for.`

After:

- `Security before every release. /security checks for the mistakes that leak passwords, open doors to attackers, or crash your app. Graded A through F. Not once a quarter. Every release.`
- `Actually opens your app and clicks. /qa opens your app like a real user. Clicks buttons. Takes screenshots. When it finds a bug, it fixes it, shows you before-and-after, and moves on.`
- `Can't skip the hard steps. The sprint runs in order: think, plan, build, review, security, qa, ship. Trying to ship before reviewing is blocked. No accidental Friday 5pm surprises.`

## What stayed

- The nine cards in the same 3x3 grid.
- Every slash command name (they are the public interface users type).
- Concrete promises that give the copy credibility ("graded A through F", "five extra things", "three ways to turn any sharing off").
- The sprint table in "What is Nanostack?" remains technical on purpose. Two audiences, two registers, same page.

## What was dropped

- OWASP, STRIDE, Playwright, HMAC, canary, daemon, atomic commits, artifact, and similar terms that needed background to parse.

## Verification

- Zero em-dashes in README.md.
- Grep for dropped jargon in the Features section returns nothing.
- Diff: one file, +18 / -18 lines. Net size unchanged.