### PR TITLE
Fix opt-in prompt missing on fresh installs

### DIFF
--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -233,21 +233,38 @@ _nano_tel_error_class() {
 # content (sessions, config, etc.). They get default silent `off` — no
 # prompt. New installs have an empty or missing ~/.nanostack/ on first
 # skill run, which triggers the opt-in prompt (handled by the skill).
+#
+# V5 merge epoch: 2026-04-21 13:35:43 UTC, commit 59209a5. Any entry in
+# ~/.nanostack/ older than this predates V5 and is real pre-V5 evidence.
+# Anything newer belongs to a fresh install and must NOT be classified
+# as pre-V5 — a fresh install legitimately creates session.json, audit
+# logs, skill artifact dirs, etc. during its very first skill run.
+NANO_TEL_V5_EPOCH=1776778543
+
 nano_tel_is_pre_v5_user() {
-  # A user is pre-V5 if ~/.nanostack/ exists AND has content OTHER than
-  # what this helper would create on a new install (the helper creates
-  # user-config.json and analytics/). Anything else that pre-exists is
-  # evidence of prior installation.
   [ -d "$NANO_TEL_HOME" ] || return 1
   local found_prior=0
-  # Look for any file or dir that wasn't created by telemetry itself.
   while IFS= read -r entry; do
-    local base
+    local base mt
     base=$(basename "$entry")
     case "$base" in
-      user-config.json|analytics|installation-id|.telemetry-prompted) : ;;
-      *) found_prior=1; break ;;
+      # Created by this telemetry helper itself.
+      user-config.json|analytics|installation-id|.telemetry-prompted|.telemetry-disabled|.config-lock)
+        continue ;;
+      # Created by the installer (create-nanostack / setup.sh) on every
+      # fresh V5 install. Whitelisting these lets the temporal check
+      # below do its job without being shadowed by known-safe entries.
+      setup.json|.cache)
+        continue ;;
     esac
+    # Non-whitelisted entry. Only treat as pre-V5 evidence if its mtime
+    # predates the V5 merge. Post-V5 entries (session.json, audit.log,
+    # skill artifact dirs) are normal runtime state on a fresh install.
+    mt=$(_nano_tel_mtime "$entry")
+    if [ "$mt" -gt 0 ] 2>/dev/null && [ "$mt" -lt "$NANO_TEL_V5_EPOCH" ] 2>/dev/null; then
+      found_prior=1
+      break
+    fi
   done < <(find "$NANO_TEL_HOME" -mindepth 1 -maxdepth 1 2>/dev/null)
   [ $found_prior -eq 1 ] && return 0 || return 1
 }


### PR DESCRIPTION
## Summary

- Pre-V5 detection in `bin/lib/telemetry.sh` was whitelisting only 4 helper-created files, but fresh installs create several more legitimately (`setup.json` from the installer, `.cache/`, and post-V5 runtime state like `session.json`, `audit.log`, skill artifact dirs). As a result, the opt-in prompt never appeared on any fresh install since V5 shipped.
- Fix combines two orthogonal signals: whitelist covers known installer/helper files, and a temporal check requires any remaining entry to predate the V5 merge epoch (`1776778543`, 2026-04-21 13:35:43 UTC, commit 59209a5) before it counts as pre-V5 evidence.
- Fresh installs on any post-V5 machine now fall through to the prompt. Genuine pre-V5 installs (with March 2026 artifact dirs) continue to get the silent-off default.

## Why this matters

The V5 privacy contract promises two things: pre-V5 users stay silent-off forever, and fresh installs see the opt-in prompt on first skill run. The whitelist-only heuristic satisfied the first promise but silently broke the second. This PR restores the second without weakening the first.

## Test plan

Verified 6 scenarios locally with a disposable `NANO_TEL_HOME`:

- [x] Empty `~/.nanostack/` → fresh
- [x] Installer files only (`setup.json` + `.cache`) → fresh
- [x] Installer files + post-V5 runtime state (`session.json`, `audit.log`, `sessions/`, `think/`, `plan/`) → fresh
- [x] Backdated March 2026 artifact dirs (`conductor`, `know-how`, `review`) → pre-V5
- [x] Only whitelisted helper files → fresh
- [x] Missing directory → fresh
- [x] Real maintainer `~/.nanostack/` (legacy user with March 2026 dirs) → pre-V5 (backward compatible)

## Notes

- `NANO_TEL_V5_EPOCH` is declared as a top-level constant with a comment explaining why; future helpers can reuse it.
- Whitelist now covers `.telemetry-disabled` and `.config-lock` too (both are created by the helper and would otherwise be post-V5 mtimes on a legacy install that just toggled the kill switch).
- Comment inside `case` documents which files come from which source (helper vs installer).