### PR TITLE
Document latent vs deterministic lens in /think and /nano

### DIFF
--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -119,6 +119,7 @@ Before presenting, validate the plan against these engineering concerns:
 - **Failure modes:** What happens when each external call fails? (DB down, API timeout, disk full). If the plan doesn't address this, it's incomplete.
 - **Scaling bottleneck:** Is there a single point that won't handle 10x load? (synchronous loop, unbatched DB queries, in-memory state). Name it.
 - **Test matrix:** For each step, what's the minimum test that proves it works? If you can't name it, the step is too vague.
+- **Latent vs deterministic steps:** Classify each step. A deterministic step has a verification command that returns 0. A latent step relies on the model doing the right thing without a check. Latent is fine for taste work; for anything that gates correctness it needs a deterministic partner (a test, a lint rule, a hook). See `think/references/latent-vs-deterministic.md` for the full framing.
 - **Rollback:** Can you undo each step independently? If not, mark which steps are one-way doors.
 
 Skip this for Small scope — it's overkill for a 3-file change.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -296,6 +296,8 @@ Challenge the fundamental premise:
 
 Apply CEO cognitive patterns from `think/references/cognitive-patterns.md` (Inversion, Customer Obsession, 10x vs 10%, Starting Point).
 
+Then apply the **latent vs deterministic lens** from `think/references/latent-vs-deterministic.md`. Ask: which parts of this plan rely on the model doing the right thing (latent) versus which parts are backed by a test, a hook, or a check (deterministic)? If every mitigation against Key Risk reads "remember to X" or "document Y," the plan is latent and will decay. Flag at least one risk that needs deterministic infrastructure.
+
 Then **argue the opposite**: construct the strongest case this should NOT be built. If the opposite argument is stronger, say so. If the original holds, it's battle-tested.
 
 ### Phase 5: Scope Mode Selection

--- a/think/references/latent-vs-deterministic.md
+++ b/think/references/latent-vs-deterministic.md
@@ -1,0 +1,104 @@
+# Latent vs Deterministic: A Reliability Lens
+
+A heuristic for knowing when to trust the model and when to build infrastructure. Use it during `/think` to surface hidden reliability risks, and during `/nano` to decide which steps need a deterministic guard.
+
+Adapted from Garry Tan's "How to really stop your agents from making the same mistakes" (April 2026). Gratitude to the gstack community for naming the distinction.
+
+---
+
+## The two kinds of knowledge
+
+**Latent knowledge** lives in the LLM's weights and in the prompt. It is probabilistic. The model might remember, might forget, might hallucinate. It works most of the time and fails in ways that are hard to reproduce.
+
+**Deterministic knowledge** lives in scripts, tests, hooks, linters, types, and CI checks. It either runs correctly or fails loudly with a diff you can read. The same inputs always produce the same result.
+
+A prompt instruction is latent. A pre-commit hook is deterministic. Both can encode "don't commit secrets," but only one will still be enforcing that rule next Tuesday at 3am when the model is tired.
+
+---
+
+## Why the distinction matters
+
+The natural instinct when an agent makes a mistake is to fix the prompt: "be more careful about X," "remember to Y." That adds latent knowledge. It feels like progress because the next run is usually better. But the mistake has not been eliminated. It has been pushed into a probability tail that will surface again when the context shifts.
+
+Each time the same mistake surfaces, the right question is not "how do I word this better?" It is **"can this rule be moved out of the prompt and into infrastructure?"**
+
+---
+
+## Concrete examples
+
+| Rule | Latent version | Deterministic version |
+|------|----------------|-----------------------|
+| Don't commit secrets | "You must never commit API keys" in CLAUDE.md | Pre-commit hook greps for `sk-proj-`, `AKIA`, `ghp_` patterns |
+| Tests must pass | "Run tests before marking the task done" | CI required check; `/ship` aborts if tests fail |
+| Use `$HOME` not `/Users/dev` | "Paths must be portable" in every skill | Lint job greps for `/Users/` and fails the PR |
+| No em dashes in public copy | "Write without em dashes" in voice guide | CI job that greps the em-dash character in README and blog posts |
+| Schema fields are frozen | "Only use v1 fields" in telemetry docs | `jq -e` assertion in the Worker that rejects extra keys |
+| Attribution when adapting | "Remember to credit sources" | SKILL.md frontmatter field + lint check that it exists |
+
+Every row on the right started as a row on the left that failed.
+
+---
+
+## When latent is fine
+
+Not everything needs deterministic enforcement. The cost of building a check is real, and over-indexing on infrastructure slows the team down.
+
+Latent is the right call when:
+
+- The decision is a **taste call** (which button style looks professional, which word sounds sharper).
+- The rule is **context-dependent** and varies by situation (how terse should this copy be... depends on audience).
+- The consequence of failure is **cheap and visible** (the output looks wrong, you notice, you fix it).
+- You are in **exploratory mode** and rules are still forming.
+
+## When deterministic is required
+
+Build infrastructure when:
+
+- Failure is **invisible or delayed**: the mistake ships to users and you only learn about it from a support ticket. The PR #124 pre-V5 bug is the archetype: silently broken for days, zero signal.
+- Failure has a **security or trust cost**: a secret leaks, a privacy promise is broken, a payment is double-charged.
+- The same mistake has happened **twice**: once is a one-off, twice is a pattern, three times is a missing tool.
+- The rule is **objective** and can be encoded as a grep, a type check, or an assertion.
+
+---
+
+## Applying the lens in `/think`
+
+During Phase 5 (Risk analysis), sort risks into the two buckets:
+
+- **Latent risks** are assumptions that only hold if the model is careful. Flag them. Any mitigation that reads "the team will remember to X" or "we will document Y" is latent and decays.
+- **Deterministic risks** have a test, a check, or a hook that would catch the failure before it reaches users. Prefer these.
+
+Red flag: if every mitigation in the plan is a reminder or a doc, the risk section is theater. Something must graduate to infrastructure, or the risk is real.
+
+## Applying the lens in `/nano`
+
+During planning, classify each step:
+
+- **Deterministic step**: has a verification command (a test that passes, a script that returns 0, a visible output change). Example: "create `VERSION` file with content `0.5.0`, verify `cat VERSION` returns the string."
+- **Latent step**: relies on the model doing the right thing without a checkable output. Example: "update the copy to feel sharper."
+
+Latent steps are fine for taste work. But if a latent step gates correctness ("write the function to handle edge case X"), it needs a deterministic partner: a test that proves X is handled. Otherwise the step is a wish.
+
+---
+
+## The graduation pattern
+
+When a latent rule fails and the cost justifies the investment, graduate it:
+
+1. **First failure**: tighten the prompt. Add an example. Still latent.
+2. **Second failure**: tighten again, add a structured checklist, maybe a counter-example. Still latent, slightly better.
+3. **Third failure**: stop tightening. Build the check. Move the rule from prompt to infrastructure.
+
+The graduation step should feel like pulling teeth. If it feels easy, you are probably building infrastructure for a rule that is not actually failing often enough to justify it.
+
+---
+
+## Quick self-check
+
+Ask before trusting a rule:
+
+- Can a developer see this rule is being followed without reading the prompt? If no, it is latent.
+- Would a fresh clone of the repo still enforce this rule tomorrow, with a different model? If no, it is latent.
+- Does failure leave a trace (a failing CI check, a visible diff, a rejected commit)? If no, it is latent and failures will be invisible.
+
+Three nos means the rule is pure prompt engineering. That is fine for taste, risky for safety.


### PR DESCRIPTION
## Summary

- Adds `think/references/latent-vs-deterministic.md`, a reference that names when to trust the model (latent knowledge) versus when to build infrastructure (deterministic knowledge).
- Wires the lens into `/think` Phase 4 (Premise Challenge) and `/nano` Architecture Checkpoint so both skills surface the distinction at the right moment.
- Credits Garry Tan's April 2026 Skillify post inline. The framing is a direct application of the latent/deterministic idea from that essay.

## Why this matters

When an agent makes the same mistake twice, the instinct is to fix the prompt. That keeps the rule latent and the mistake lives in a probability tail, ready to resurface. The only durable fix is to move the rule into infrastructure: a test, a hook, a lint rule. This reference gives `/think` and `/nano` a shared vocabulary for that conversation so the graduation to infrastructure happens earlier and more explicitly.

PR #124 (pre-V5 detection) is the recent archetype this doc is built around. The original rule was latent ("ensure fresh installs see the prompt"), the failure was silent for three days, and the fix was deterministic (a whitelist plus a temporal check). Naming that pattern should help catch the next one earlier.

## Test plan

- [x] Reference file contains no em-dashes (house style).
- [x] `think/SKILL.md` references the new file in Phase 4 alongside the existing cognitive-patterns link.
- [x] `plan/SKILL.md` references it in section 5 (Architecture Checkpoint) as a new classification bullet.
- [x] Em-dash CI lint passes locally across all top-level and examples READMEs.
- [x] No changes to skill frontmatter.

## Notes

- Internal agent reference files are not under the em-dash lint scope, but this one follows the rule anyway for consistency.
- Attribution sits at the top of the reference, short and direct, matching the pattern we established in `think/presets/garry.md`.