### PR TITLE
Add observational_fired to telemetry schema

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -73,7 +73,8 @@ Every recorded event is one JSON object on one line in `~/.nanostack/analytics/s
   "duration_s": 180,
   "outcome": "success",
   "error_class": null,
-  "installation_id": "a3f7c2e1-4b9d-4e8a-b21c-d8f92c4a7e1b"
+  "installation_id": "a3f7c2e1-4b9d-4e8a-b21c-d8f92c4a7e1b",
+  "observational_fired": 0
 }
 ```
 
@@ -92,6 +93,7 @@ Field by field:
 | `outcome` | enum `success`, `error`, `abort`, `unknown` | Success rate metric. | always |
 | `error_class` | enum from a whitelist or `other`, or null | Triage signal. Whitelist prevents leaking error strings. | when outcome is `error` |
 | `installation_id` | UUID v4 or null | Stable identity for the installation, random, not derived. | community tier only |
+| `observational_fired` | int `0` or `1`, or null | `/think` feature firing rate. `1` = the brief included a "What I noticed" observational block, `0` = it did not. Null when the skill does not implement the feature (every skill other than `/think`). Content of observations is never sent. | `/think` only |
 
 The enum whitelists are enforced in `bin/lib/telemetry.sh` and checked by CI. Any value outside the enum collapses to the fallback (`unknown`, `other`). This guards against accidental leakage of a string that contains user-specific information.
 

--- a/bin/lib/skill-finalize.sh
+++ b/bin/lib/skill-finalize.sh
@@ -3,10 +3,14 @@
 #
 # Usage from a SKILL.md:
 #   _F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
-#   [ -f "$_F" ] && . "$_F" <skill-name> <outcome>
+#   [ -f "$_F" ] && . "$_F" <skill-name> <outcome> [observational_fired]
 #   unset _F
 #
 # Outcome is one of: success, error, abort, unknown. Defaults to success.
+#
+# Optional 3rd arg: observational_fired. "1" if /think included the
+# observational feedback block, "0" if not. Only /think uses this; every
+# other skill leaves it empty and the field lands null in the event.
 #
 # Unlike a naive wrapper, this file CANNOT rely on nano_telemetry_finalize
 # already being defined. In agents like Claude Code, each Bash tool call
@@ -27,16 +31,17 @@
 
 _nano_skill_name="${1:-unknown}"
 _nano_skill_outcome="${2:-success}"
+_nano_skill_observational="${3:-}"
 
 # Kill switches. Same order and semantics as skill-preamble.sh so there is
 # no scenario where the preamble runs but finalize is blocked (or vice versa).
 if [ -n "${NANOSTACK_NO_TELEMETRY:-}" ]; then
-  unset _nano_skill_name _nano_skill_outcome
+  unset _nano_skill_name _nano_skill_outcome _nano_skill_observational
   return 0 2>/dev/null || true
 fi
 
 if [ -f "${NANO_TEL_HOME:-$HOME/.nanostack}/.telemetry-disabled" ]; then
-  unset _nano_skill_name _nano_skill_outcome
+  unset _nano_skill_name _nano_skill_outcome _nano_skill_observational
   return 0 2>/dev/null || true
 fi
 
@@ -66,9 +71,9 @@ if [ -n "$_nano_tel_lib" ]; then
   fi
 
   command -v nano_telemetry_finalize >/dev/null 2>&1 && \
-    nano_telemetry_finalize "$_nano_skill_name" "$_nano_skill_outcome" 2>/dev/null
+    nano_telemetry_finalize "$_nano_skill_name" "$_nano_skill_outcome" "" "$_nano_skill_observational" 2>/dev/null
 
   unset _nano_state_file
 fi
 
-unset _nano_tel_lib _nano_skill_dir _nano_skill_name _nano_skill_outcome
+unset _nano_tel_lib _nano_skill_dir _nano_skill_name _nano_skill_outcome _nano_skill_observational

--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -10,7 +10,7 @@
 #
 # The frozen v1 schema is declared here on a single machine-parseable
 # line so CI can verify the jq filters below only use these fields.
-# TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id
+# TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id observational_fired
 #
 # Enum whitelists:
 #   os           {darwin, linux, unknown}
@@ -393,6 +393,7 @@ _nano_tel_finalize_stale_markers() {
 # ─── Write a single event to the JSONL ─────────────────────────────────
 _nano_tel_write_event() {
   local skill="$1" duration="$2" outcome="$3" error_class="$4" ts_override="$5"
+  local observational="$6"
   local ts os arch version
   ts="${ts_override:-$(_nano_tel_ts)}"
   os=$(_nano_tel_os)
@@ -439,6 +440,15 @@ _nano_tel_write_event() {
   else
     filter="$filter + {installation_id:null}"
   fi
+
+  # observational_fired is optional. Only /think sets it; every other
+  # skill leaves it null. Accept strictly "0" or "1"; anything else
+  # collapses to null rather than rejecting the event.
+  case "$observational" in
+    0|1) jq_args+=(--argjson obs "$observational")
+         filter="$filter + {observational_fired:\$obs}" ;;
+    *)   filter="$filter + {observational_fired:null}" ;;
+  esac
 
   local line
   line=$(jq -c "${jq_args[@]}" "$filter" 2>/dev/null)
@@ -488,8 +498,12 @@ _nano_tel_send_async() {
 }
 
 # ─── Finalize (called at skill end) ────────────────────────────────────
+# Optional 4th arg: observational_fired. "1" if the /think brief included
+# the observational feedback block, "0" if not. Any other value (including
+# the default empty string) collapses to null. Only /think sets this; all
+# other skills leave it empty and the field lands as null in the event.
 nano_telemetry_finalize() {
-  local skill="$1" outcome="${2:-success}" error_class="${3:-}"
+  local skill="$1" outcome="${2:-success}" error_class="${3:-}" observational="${4:-}"
   _nano_tel_refresh_tier
   [ "$NANO_TEL_TIER" = "off" ] && {
     rm -f "$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID" 2>/dev/null
@@ -505,7 +519,7 @@ nano_telemetry_finalize() {
   else
     duration=""
   fi
-  _nano_tel_write_event "$skill" "$duration" "$outcome" "$error_class" ""
+  _nano_tel_write_event "$skill" "$duration" "$outcome" "$error_class" "" "$observational"
   rm -f "$NANO_TEL_ANALYTICS_DIR/.pending-$NANO_TEL_SESSION_ID" 2>/dev/null
   _nano_tel_finalize_stale_markers
 

--- a/telemetry-worker/migrations/0002_add_observational_fired.sql
+++ b/telemetry-worker/migrations/0002_add_observational_fired.sql
@@ -1,0 +1,12 @@
+-- 0002: add observational_fired column
+-- Added for /think observational feedback firing-rate measurement.
+-- Nullable because only /think ever sets it; other skills leave it null.
+-- Integer 0/1 instead of boolean because D1/SQLite prefers the idiom and
+-- CHECK constraints read cleanly.
+
+ALTER TABLE events ADD COLUMN observational_fired INTEGER
+  CHECK (observational_fired IS NULL OR observational_fired IN (0, 1));
+
+CREATE INDEX IF NOT EXISTS idx_events_observational
+  ON events (observational_fired)
+  WHERE observational_fired IS NOT NULL;

--- a/telemetry-worker/src/index.ts
+++ b/telemetry-worker/src/index.ts
@@ -20,7 +20,7 @@ export interface Env {
   MASTER_SALT: string;
 }
 
-// TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id
+// TELEMETRY_FIELDS_V1: v ts skill session_id nanostack_version os arch duration_s outcome error_class installation_id observational_fired
 // (kept in a comment so CI can verify client and server share the same list.)
 
 const MAX_PAYLOAD_BYTES = 50_000;
@@ -52,6 +52,11 @@ interface TelemetryEvent {
   outcome: string;
   error_class?: string | null;
   installation_id?: string | null;
+  // Optional /think-only signal. 1 = observational feedback block was
+  // included in the brief, 0 = not included, null = skill does not
+  // implement the feature. Stored as INTEGER in D1 for CHECK-constraint
+  // ergonomics.
+  observational_fired?: number | null;
 }
 
 export default {
@@ -150,8 +155,9 @@ export default {
     const stmt = env.DB.prepare(
       `INSERT INTO events
          (event_ts, skill, outcome, duration_s, nanostack_version,
-          os, arch, installation_id, session_id, error_class)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          os, arch, installation_id, session_id, error_class,
+          observational_fired)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     const batch = rows.map((r) =>
       stmt.bind(
@@ -165,6 +171,7 @@ export default {
         r.installation_id ?? null,
         r.session_id ?? null,
         r.error_class ?? null,
+        r.observational_fired ?? null,
       ),
     );
 
@@ -223,6 +230,16 @@ function validateEvent(raw: unknown): TelemetryEvent | null {
   const sessionId = typeof e.session_id === "string" ? e.session_id.slice(0, 64) : null;
   if (sessionId !== null && !/^[0-9]+-[0-9]+$/.test(sessionId)) return null;
 
+  // observational_fired is optional, nullable, and strictly 0 or 1. Any
+  // other shape (booleans, strings, numbers outside {0,1}) rejects the
+  // whole event rather than silently coercing. Defense in depth: the
+  // client already only ever writes 0 or 1.
+  let observationalFired: number | null = null;
+  if (e.observational_fired !== undefined && e.observational_fired !== null) {
+    if (e.observational_fired !== 0 && e.observational_fired !== 1) return null;
+    observationalFired = e.observational_fired as number;
+  }
+
   return {
     v: 1,
     ts: e.ts,
@@ -235,6 +252,7 @@ function validateEvent(raw: unknown): TelemetryEvent | null {
     nanostack_version: version,
     installation_id: installId,
     session_id: sessionId,
+    observational_fired: observationalFired,
   };
 }
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -385,15 +385,17 @@ Wait for the user to invoke `/nano`.
 
 ### Telemetry finalize
 
-Before handing control back to the user (or to `/nano` in autopilot), close out telemetry:
+Before handing control back to the user (or to `/nano` in autopilot), close out telemetry. Pass `1` as the third arg if the Think Summary you just wrote included a `## What I noticed` observational feedback block (any pattern fired with specific evidence). Pass `0` if it did not, or if the active preset opts out (`eng`). The flag lets us measure how often the observational block fires in the wild without sending any of its content.
 
 ```bash
 _F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
-[ -f "$_F" ] && . "$_F" think success
+[ -f "$_F" ] && . "$_F" think success 0   # 0 = no observational block this brief
+# or, when an observational block was included:
+# [ -f "$_F" ] && . "$_F" think success 1
 unset _F
 ```
 
-If the flow aborted (user interrupted, blocked on missing info, error in a phase), pass `abort` or `error` instead of `success`. The finalize helper is a no-op when telemetry is disabled, stripped, or tier is `off`.
+If the flow aborted (user interrupted, blocked on missing info, error in a phase), pass `abort` or `error` instead of `success`. The third arg is still optional; omit it if the run never got to the Think Summary. The finalize helper is a no-op when telemetry is disabled, stripped, or tier is `off`.
 
 For retro mode (`/think --retro`), same rule applies at the end of the retro brief output.
 


### PR DESCRIPTION
## Summary

- Adds an optional `observational_fired` field to the v1 telemetry schema so we can measure how often the observational feedback block (from PR #127) fires in the wild.
- The spec sets a target of under 30% of sessions. Without this field the target is unverifiable.
- Schema evolution, not break: field is nullable in D1, only `/think` ever sets it, every other skill leaves the column null.

## Why this matters

We just shipped a new brief section (observational feedback) with a firing-rate rule. If it fires 5% of the time it is too conservative. If it fires 60% of the time it is noise. Without this flag we are guessing.

Content of observations is never sent. The field is a single integer (0, 1, or null). The actual observation text lives in the local brief and nowhere else.

## Changes

- `telemetry-worker/migrations/0002_add_observational_fired.sql` adds the INTEGER column with `CHECK (0 or 1 or null)` and a scoped index on non-null rows.
- `telemetry-worker/src/index.ts`: strict validation (0, 1, or null), everything else rejects the event. INSERT and bind list extended.
- `bin/lib/telemetry.sh`: `_nano_tel_write_event` takes an optional 6th arg. `nano_telemetry_finalize` takes it as the 4th arg. Accepted values are `"0"` / `"1"`; anything else collapses to null.
- `bin/lib/skill-finalize.sh`: accepts optional 3rd positional arg, passes it through. Existing call sites unchanged.
- `think/SKILL.md`: finalize snippet updated to pass the flag, with a short note on when to pass `1` versus `0`.
- `TELEMETRY.md`: schema example and field-by-field table updated.

## Test plan

- [x] Client and Worker `TELEMETRY_FIELDS_V1` lists match (enforced by existing CI, verified locally).
- [x] Emitting `observational=1` yields `"observational_fired": 1` in the JSONL event.
- [x] Emitting `observational=0` yields `"observational_fired": 0`.
- [x] Leaving observational unset (other skills) yields `null`.
- [x] Garbage input (`"maybe"`) collapses to `null` without breaking the event.
- [x] Privacy contract lint passes locally.
- [x] Worker invariants (`HTTPS_ENFORCED`, `SCHEMA_STRICT`, `IP_NEVER_STORED`, `NO_BODY_LOGGING`) all present.
- [x] `tsc --noEmit` on the Worker passes with the new types.
- [x] Em-dash lint passes against top-level MDs and examples READMEs.

## Deploy note

**Migration 0002 must be applied to live D1 before the Worker code deploys.** If the code ships first, INSERTs fail until the column exists. When merging:

```sh
cd telemetry-worker
wrangler d1 migrations apply nanostack-telemetry
wrangler deploy
```

In that order.