### PR TITLE
Surface the prompt decision under NANOSTACK_DEBUG

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -15,6 +15,7 @@ If your symptom is not here, open an issue: https://github.com/garagon/nanostack
 - [Skill name conflicts with another set (gstack, superpowers)](#skill-name-conflicts-with-another-set-gstack-superpowers)
 - [Cannot install or upgrade behind a corporate proxy](#cannot-install-or-upgrade-behind-a-corporate-proxy)
 - [The agent runs the same skill twice in autopilot](#the-agent-runs-the-same-skill-twice-in-autopilot)
+- [The telemetry opt-in prompt never appears on a fresh install](#the-telemetry-opt-in-prompt-never-appears-on-a-fresh-install)
 
 ---
 
@@ -291,6 +292,31 @@ Look for `phase_complete` events. If the second-to-last review has no `phase_com
 Then continue the sprint.
 
 If this keeps happening across sprints, file an issue with the audit log excerpt. It is a bug in the skill, not in your project.
+
+---
+
+## The telemetry opt-in prompt never appears on a fresh install
+
+You installed nanostack and ran `/think` on a fresh machine, but the opt-in prompt (community / anonymous / off) never showed up. You want to know which branch of the detection logic fired.
+
+Set `NANOSTACK_DEBUG=1` and run any skill. One line is printed to stderr explaining which decision was taken and why.
+
+```sh
+NANOSTACK_DEBUG=1 /think "test"
+# [telemetry:prompt] skip=0 reason=fresh-install caller-should-prompt=yes
+# or
+# [telemetry:prompt] skip=1 reason=marker-present path=~/.nanostack/.telemetry-prompted
+# or
+# [telemetry:prompt] skip=1 reason=pre-v5 home=~/.nanostack
+```
+
+Three possible outcomes:
+
+- `skip=0 reason=fresh-install`: detection worked, the prompt should appear on the next skill run. If it still does not, check that the skill you ran actually calls the prompt (today only `/think` does).
+- `skip=1 reason=marker-present`: the marker file `~/.nanostack/.telemetry-prompted` already exists, so you were prompted in a prior run. Delete the marker and re-run if you want to see the prompt again.
+- `skip=1 reason=pre-v5`: detection thinks you had a nanostack install from before April 2026. Contents of `~/.nanostack/` include at least one entry whose mtime predates the V5 merge. Confirm by running `ls -la ~/.nanostack/` and checking dates. If the classification is wrong (files were touched by a backup or restore that reset mtimes), delete the marker and re-run.
+
+The debug flag never sends anything over the network, and it is silent by default. Your production installs stay quiet.
 
 ---
 

--- a/bin/lib/telemetry.sh
+++ b/bin/lib/telemetry.sh
@@ -295,14 +295,25 @@ nano_telemetry_init() {
   # Decide if the caller should show the opt-in prompt.
   # Precedence: marker present → never prompt again. Pre-V5 install → silent
   # off + mark prompted. Otherwise (fresh V5 install) → caller should prompt.
+  #
+  # When NANOSTACK_DEBUG=1, emit one line to stderr explaining which branch
+  # fired. Silent by default so production installs see no noise, but an
+  # explicit env var flips a diagnostic path that would have caught the
+  # PR #124 pre-V5 false positive on first run.
   if [ -f "$NANO_TEL_PROMPTED_MARKER" ]; then
     NANO_TEL_SKIP_PROMPT=1
+    [ "${NANOSTACK_DEBUG:-0}" = "1" ] && \
+      printf '[telemetry:prompt] skip=1 reason=marker-present path=%s\n' "$NANO_TEL_PROMPTED_MARKER" >&2
   elif nano_tel_is_pre_v5_user; then
     [ ! -f "$NANO_TEL_CONFIG" ] && nano_tel_set_tier off
     touch "$NANO_TEL_PROMPTED_MARKER" 2>/dev/null
     NANO_TEL_SKIP_PROMPT=1
+    [ "${NANOSTACK_DEBUG:-0}" = "1" ] && \
+      printf '[telemetry:prompt] skip=1 reason=pre-v5 home=%s\n' "$NANO_TEL_HOME" >&2
   else
     NANO_TEL_SKIP_PROMPT=0
+    [ "${NANOSTACK_DEBUG:-0}" = "1" ] && \
+      printf '[telemetry:prompt] skip=0 reason=fresh-install caller-should-prompt=yes\n' >&2
   fi
 
   NANO_TEL_TIER=$(nano_tel_get_tier)


### PR DESCRIPTION
## Summary

- `NANOSTACK_DEBUG=1` now prints one line to stderr from `nano_telemetry_init` explaining which branch of the pre-V5 detection fired and why.
- Silent by default; production installs see no change unless the flag is flipped explicitly.
- New TROUBLESHOOTING entry maps the three possible debug outputs to concrete next steps (delete the marker to re-prompt, check mtimes if pre-V5 classification looks wrong, etc.).

## Why this matters

PR #124 fixed a bug where 12 fresh installs were silently classified as pre-V5 for three days, producing zero opt-ins across the fleet. The failure was invisible because no one could see which branch the detector took. One log line would have surfaced the bug on the first run.

This is the infrastructure graduation for the rule: the decision used to be latent (prompt-based, trust the model to notice), now it is deterministic (a flag any user or maintainer can flip to see the decision in plain text).

## Debug output examples

```
[telemetry:prompt] skip=0 reason=fresh-install caller-should-prompt=yes
[telemetry:prompt] skip=1 reason=marker-present path=~/.nanostack/.telemetry-prompted
[telemetry:prompt] skip=1 reason=pre-v5 home=~/.nanostack
```

## Test plan

- [x] Syntax check on `telemetry.sh`.
- [x] Four scenarios verified locally: fresh install, marker-present, pre-V5, debug off (silent).
- [x] Privacy-contract lint passes.
- [x] Em-dash lint passes on top-level MDs.
- [x] TROUBLESHOOTING.md adds an entry with actionable next steps per output.

## Notes

- No telemetry is sent as a result of `NANOSTACK_DEBUG=1`. The flag only affects stderr output.
- No enum extensions or schema changes.