### PR TITLE
Validate rename input before path resolution in setup

### DIFF
--- a/setup
+++ b/setup
@@ -30,6 +30,61 @@ skill_dir() {
   esac
 }
 
+# Accept only skill public names that are valid command identifiers:
+# lowercase letter first, then lowercase letters, digits, or hyphens,
+# up to 40 chars total. Rejects path components (/, ..), quotes, shell
+# metacharacters, whitespace, and empty strings. Rename values are
+# persisted and later interpolated into paths and sed expressions, so
+# this check must be strict even when the source is a trusted-looking
+# setup.json (an attacker who can write that file could otherwise flow
+# user input into a path delete or a sed command).
+is_valid_skill_name() {
+  local name="$1"
+  [ -n "$name" ] || return 1
+  printf '%s' "$name" | LC_ALL=C grep -qE '^[a-z][a-z0-9-]{0,39}$'
+}
+
+# Walk the current RENAMES string (comma-separated old=new pairs) and
+# make sure every pair is safe. Rejects the whole input on the first
+# violation so partial application cannot happen. Writes a single line
+# to stderr naming the offending pair.
+validate_renames() {
+  local source="${1:-cli}"
+  [ -z "$RENAMES" ] && return 0
+  local pair old new
+  # Split on commas without touching existing whitespace semantics.
+  local OIFS="$IFS"
+  IFS=','
+  # shellcheck disable=SC2086
+  set -f
+  for pair in $RENAMES; do
+    set +f
+    IFS="$OIFS"
+    # Trim surrounding whitespace only.
+    pair="${pair# }"; pair="${pair% }"
+    [ -z "$pair" ] && continue
+    case "$pair" in
+      *=*) ;;
+      *)
+        echo "ERROR: invalid rename entry '$pair' (expected old=new) from $source" >&2
+        exit 1 ;;
+    esac
+    old="${pair%%=*}"
+    new="${pair#*=}"
+    if ! is_valid_skill_name "$old"; then
+      echo "ERROR: invalid source skill name '$old' from $source (allowed: [a-z][a-z0-9-]{0,39})" >&2
+      exit 1
+    fi
+    if ! is_valid_skill_name "$new"; then
+      echo "ERROR: invalid rename target '$new' from $source (allowed: [a-z][a-z0-9-]{0,39})" >&2
+      exit 1
+    fi
+    IFS=','
+  done
+  set +f
+  IFS="$OIFS"
+}
+
 # sed -i portability (BSD vs GNU)
 if sed --version >/dev/null 2>&1; then
   sed_inplace() { sed -i "$@"; }
@@ -156,7 +211,11 @@ if [ -z "$RENAMES" ]; then
   if [ -f "$HOME/.nanostack/setup.json" ]; then
     saved_renames=$(jq -r '.renames // {} | to_entries[] | "\(.key)=\(.value)"' "$HOME/.nanostack/setup.json" 2>/dev/null | tr '\n' ',')
     RENAMES="${saved_renames%,}"
+    validate_renames "$HOME/.nanostack/setup.json"
   fi
+else
+  # Passed via --rename on the command line.
+  validate_renames "--rename flag"
 fi
 
 if [ -n "$RENAMES" ]; then
@@ -185,10 +244,19 @@ install_renamed_skill() {
   local dir
   dir=$(skill_dir "$skill")
 
+  # Defense in depth: callers already validate but this function is exposed
+  # as an API for future callers, so re-check.
+  if ! is_valid_skill_name "$skill" || ! is_valid_skill_name "$public_name"; then
+    echo "ERROR: install_renamed_skill refused '$skill' -> '$public_name'" >&2
+    return 1
+  fi
+
   mkdir -p "$target_dir/$public_name"
 
-  # Copy SKILL.md with updated name field
-  sed "s/^name: .*/name: $public_name/" "$SOURCE_DIR/$dir/SKILL.md" > "$target_dir/$public_name/SKILL.md"
+  # Use sed with a controlled delimiter. public_name has already been
+  # constrained to [a-z0-9-] so it cannot inject sed metacharacters, but
+  # the explicit delimiter keeps this robust if the regex is ever loosened.
+  sed "s|^name: .*|name: $public_name|" "$SOURCE_DIR/$dir/SKILL.md" > "$target_dir/$public_name/SKILL.md"
 
   # Symlink everything else (references, templates, bin, etc.)
   for item in "$SOURCE_DIR/$dir"/*; do
@@ -197,6 +265,27 @@ install_renamed_skill() {
     [ "$basename" = "SKILL.md" ] && continue
     ln -snf "$item" "$target_dir/$public_name/$basename" 2>/dev/null || true
   done
+}
+
+# Return 0 if $1 resolves to a path under $2 (after following symlinks
+# and normalising .. / .), 1 otherwise. Used as a guard before rm -rf
+# on any path derived from user input. realpath is GNU/BSD-portable
+# enough for the platforms nanostack targets; when it is missing the
+# guard refuses rather than fall back to the unresolved path.
+path_is_under() {
+  local target="$1" root="$2"
+  [ -n "$target" ] && [ -n "$root" ] || return 1
+  local real_target real_root
+  if ! real_target=$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)/$(basename "$target"); then
+    return 1
+  fi
+  if ! real_root=$(cd "$root" 2>/dev/null && pwd -P); then
+    return 1
+  fi
+  case "$real_target" in
+    "$real_root"|"$real_root"/*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # ─── Auto-detect agents ──────────────────────────────────────
@@ -256,6 +345,14 @@ install_claude() {
     fi
 
     local target="$skills_dir/$public_name"
+
+    # Refuse to touch any path that does not resolve inside skills_dir.
+    # The rename map is already validated on entry, but this is the last
+    # chance before a rm -rf; treat it as an invariant and abort cleanly.
+    if ! path_is_under "$target" "$skills_dir"; then
+      echo "ERROR: target '$target' escapes skills directory '$skills_dir'; refusing to modify" >&2
+      continue
+    fi
 
     # Always remove stale symlink/dir at target to recreate cleanly
     [ -L "$target" ] && rm -f "$target"


### PR DESCRIPTION
## Summary

Internal security audit (2026-04-24) flagged a MEDIUM finding in `setup`: `--rename` values flowed into skills-directory path components without validation. A value containing `/` or `..` could make the resolved target point outside the skills directory, and the subsequent stale-directory cleanup would run `rm -rf` against that path. This PR adds input validation and a path containment guard before any file removal.

## Changes

Three layers of defense:

1. **Shape check (`is_valid_skill_name`).** Accepts only `[a-z][a-z0-9-]{0,39}`. Rejects path components, shell metacharacters, whitespace, uppercase, underscores, and empty strings. Matches the command-name convention the rest of the skill set uses.

2. **`validate_renames` at every entry point for rename data.**
   - `--rename` from the command line.
   - Saved renames loaded from `~/.nanostack/setup.json`. Anyone who could write that file would otherwise flow input into a path delete and a `sed` command.
   - The whole `RENAMES` string rejects on the first violation so partial application cannot happen. The error message names the source so users know which input to fix.

3. **`path_is_under` guard before `rm`.** Resolves the target and the expected root with `pwd -P`, then confirms the target is the root or sits under it. If the guard fails, the loop skips that entry with a clear message rather than deleting.

Also hardened `install_renamed_skill`: re-checks both names even though callers already validate, and the `sed` expression uses a pipe delimiter to block future sed metacharacter injection if the regex is ever loosened.

## Verification

### `is_valid_skill_name` — 15 cases

Valid: `valid-name`, `also-valid`, `a`, `ab`, `a-b-c`, `a123`.
Rejected: `9numstart`, `-dashstart`, `foo_bar`, `foo bar`, `foo.bar`, `foo/bar`, `..`, `./foo`, empty string.

### `validate_renames` — 9 cases

| Input | Result |
|---|---|
| `review=nano-review` | passes |
| `review=../../etc/passwd` | rejected (invalid rename target) |
| `review=..foo` | rejected |
| `review=foo;bar` | rejected |
| `review=NanoReview` | rejected |
| `review=` (empty RHS) | rejected |
| `ghost=foo` (shape-valid, unknown old) | passes shape, no-op at use |
| `../etc=foo` | rejected (invalid source skill) |
| 41-char target | rejected (length cap) |

### `path_is_under` — 4 cases

| Target | Root | Result |
|---|---|---|
| `/tmp/skills/foo` | `/tmp/skills` | UNDER |
| `/tmp/skills/sub/foo` | `/tmp/skills` | UNDER |
| `/tmp/other` | `/tmp/skills` | NOT_UNDER |
| `/tmp/skills/../other/foo` | `/tmp/skills` | NOT_UNDER |

## Test plan

- [x] `bash -n setup` passes.
- [x] 15 + 9 + 4 unit tests above all pass locally.
- [x] Em-dash lint on top-level docs passes.
- [x] Existing happy-path: `./setup --rename "review=nano-review"` still accepted.

## Out of scope

- `setup.json` corruption beyond rename-target content (no validation of top-level schema yet).
- Skills array is still a static list; a rename whose "old" key is not in the list is a no-op at use time, which is the intended behavior.

## Related

Internal audit, 2026-04-24, finding MEDIUM-1.