### PR TITLE
Escape audit log fields and make session lock fail closed

### DIFF
--- a/bin/lib/audit.sh
+++ b/bin/lib/audit.sh
@@ -24,9 +24,16 @@ audit_log() {
   local log="$store/audit.log"
   [ -d "$store" ] || return 0
 
-  printf '{"at":"%s","event":"%s","resource":"%s","detail":"%s"}\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    "$event" \
-    "$resource" \
-    "$detail" >> "$log" 2>/dev/null || true
+  # Build the line with jq so quotes, backslashes, and newlines in any
+  # field are escaped and cannot corrupt the log or inject extra keys.
+  # Falls back silently (|| true) if jq is unavailable; the audit log
+  # is advisory, not a compliance artifact, so logging failures never
+  # block the caller.
+  jq -cn \
+    --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg event "$event" \
+    --arg resource "$resource" \
+    --arg detail "$detail" \
+    '{at:$at, event:$event, resource:$resource, detail:$detail}' \
+    >> "$log" 2>/dev/null || true
 }

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -101,17 +101,41 @@ cmd_phase_start() {
   fi
 
   local lockdir="${SESSION_FILE}.lockdir"
+  local owner_pid=""
   local waited=0
   while ! mkdir "$lockdir" 2>/dev/null; do
     waited=$((waited + 1))
-    if [ "$waited" -gt 50 ]; then
-      # Stale lock or true contention: clear and proceed (best effort).
-      rmdir "$lockdir" 2>/dev/null || true
-      echo "WARN: session lock held >5s, proceeding without it" >&2
-      break
+
+    # Once per second, check whether the current lockholder is still alive.
+    # If the owner file names a PID that no longer exists, the lock is
+    # stale (the holder crashed or exited mid-write) and we reclaim it.
+    # If the PID is still alive, we are in live contention and keep
+    # waiting. Missing owner file is treated as live (conservative).
+    if [ $((waited % 10)) -eq 0 ] && [ -f "$lockdir/owner" ]; then
+      owner_pid=$(cat "$lockdir/owner" 2>/dev/null)
+      if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
+        rm -rf "$lockdir" 2>/dev/null || true
+        echo "INFO: previous session lockholder (pid $owner_pid) is gone, reclaiming" >&2
+        continue
+      fi
+    fi
+
+    if [ "$waited" -gt 300 ]; then
+      # 30 seconds of live contention. Fail closed rather than race the
+      # writer: conductor mode specifically needs consistent session.json
+      # state. The user can retry or remove the lockdir manually after
+      # confirming no other agent is running.
+      echo "ERROR: session lock held >30s (owner pid ${owner_pid:-unknown}). Retry after the other agent finishes, or remove $lockdir if nothing is running." >&2
+      exit 1
     fi
     sleep 0.1
   done
+
+  # Record ownership so other agents can detect a stale lock if we crash.
+  # Best-effort: if the write fails, the lock still works for liveness
+  # (other agents fall back to conservative "live" treatment). Removed
+  # together with the lockdir on release.
+  echo "$$" > "$lockdir/owner" 2>/dev/null || true
 
   # Re-check inside the lock (idempotent under concurrency)
   local existing
@@ -119,7 +143,7 @@ cmd_phase_start() {
     '[.phase_log[] | select(.phase == $p and (.status == "completed" or .status == "in_progress"))] | length' \
     "$SESSION_FILE" 2>/dev/null || echo "0")
   if [ "$existing" -gt 0 ]; then
-    rmdir "$lockdir" 2>/dev/null || true
+    rm -rf "$lockdir" 2>/dev/null || true
     echo "OK: $phase already in log"
     return 0
   fi
@@ -143,7 +167,7 @@ cmd_phase_start() {
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
-  rmdir "$lockdir" 2>/dev/null || true
+  rm -rf "$lockdir" 2>/dev/null || true
 
   audit_log "phase_start" "$phase"
   echo "OK: $phase started"


### PR DESCRIPTION
## Summary

Two findings from the internal security audit (2026-04-24), both labeled MEDIUM. Shipped together because they are both small hygiene fixes with similar shape.

## Audit log: escape fields via jq

`bin/lib/audit.sh` built every record with `printf "%s"` interpolation, so quotes, backslashes, or newlines in any field could close the current string and inject extra keys. Reproduced locally:

```
audit_log "test" 'foo","injected":"yes' "detail"

# before
{"resource":"foo","injected":"yes","detail":"detail"}

# after
{"resource":"foo\",\"injected\":\"yes","detail":"detail"}
```

Fix: build the record with `jq -cn --arg` so every value is escaped by the JSON writer. Kept the existing `|| true` fallback so a missing `jq` still silently no-ops; the audit log is advisory, not a compliance artifact.

## Session lock: fail closed, verify owner liveness

`bin/session.sh phase-start` broke the lock and proceeded after 5 seconds with a `WARN: ... proceeding without it` message. In conductor mode this can race a live writer and corrupt `session.json` without any signal.

Fix: record the owner PID inside the lockdir on acquisition. During contention, poll the owner once per second. `kill -0` checks whether the owner is still alive.

- Owner gone: lock is stale, reclaim it (covers crash recovery).
- Owner alive: keep waiting up to 30 seconds total.
- After 30 seconds: exit 1 with a message naming the owner PID and the lock path so the user can check manually.
- Missing owner file: treat as live (conservative; a racing writer between mkdir and echo-owner should be given the benefit of the doubt).

Cleanup paths switched from `rmdir` to `rm -rf` so the owner file does not block release.

## Verification

### Audit log

Four scenarios, every line parsed as valid JSON and `resource` contains the literal text instead of spawning extra keys:

| Input | Resource value on disk |
|---|---|
| `foo","injected":"yes` | `foo\",\"injected\":\"yes` |
| `foo\nbar` (actual newline) | `foo\nbar` |
| `foo\\bar` (backslash) | `foo\\bar` |
| `phase1` | `phase1` |

### Session lock

| Scenario | Result |
|---|---|
| Stale lock, owner PID 999999 (does not exist) | Reclaimed, message logged, phase-start succeeded |
| Live lock, owner = current bash PID | 2s timeout confirmed the loop kept waiting instead of silently proceeding; 30s would exit 1 with the helpful message |

## Test plan

- [x] `bash -n` on both files.
- [x] Audit injection repro turns into valid escaped output.
- [x] Session lock: stale owner reclaim and live owner wait both verified.
- [x] Em-dash lint on top-level docs passes.
- [x] `jq -c` output parses with `jq .` for every record.

## Related

Internal audit, 2026-04-24. Findings MEDIUM-2 (audit log) and MEDIUM-3 (session lock).