### PR TITLE
Upgrade telemetry-worker to wrangler v4

### DIFF
--- a/telemetry-worker/package.json
+++ b/telemetry-worker/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260101.0",
     "typescript": "^5.4.0",
-    "wrangler": "^3.60.0"
+    "wrangler": "^4.85.0"
   }
 }


### PR DESCRIPTION
## Summary

Internal security audit (2026-04-24) flagged the `telemetry-worker` dev toolchain. `bun audit` reported 6 advisories (2 high, 4 moderate) sourced from wrangler v3's bundled miniflare (old `undici`) and `@esbuild-plugins/node-modules-polyfill` (old `esbuild`). All dev-surface only, but reachable from `wrangler dev` locally.

Wrangler v4 ships a cleaner miniflare without the old pins. Bumping `wrangler` from `^3.60.0` to `^4.85.0` resolves the audit.

## Verification

```
$ bun audit
# before: 6 vulnerabilities (2 high, 4 moderate)
# after:  No vulnerabilities found
```

- `bun install`: clean resolution, 25 packages.
- `tsc --noEmit`: passes with the existing Worker source.
- `wrangler deploy --dry-run`: parses `wrangler.toml`, resolves KV (`RATE_LIMIT`) and D1 (`nanostack-telemetry`) bindings, builds the artifact, exits cleanly. **Did not deploy.**

No Worker source changes and no schema changes. The live Worker keeps running the current bundle until the next `wrangler deploy` runs, at which point it will be built under wrangler v4.

## Test plan

- [x] Audit clean on the new version.
- [x] TypeScript compile clean.
- [x] Dry-run deploy resolves bindings correctly.
- [x] No source file changes outside `package.json`.

## Deploy note

When convenient, re-run:

```sh
cd telemetry-worker
wrangler deploy
```

Not required as part of merging this PR; there is no migration, no URL change, no schema change. The only surface this PR affects is the local dev experience and the output of `bun audit`.

## Related

Internal audit, 2026-04-24, finding MEDIUM-4.