### PR TITLE
Narrow default rm permissions and document the permission model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,3 +46,41 @@ We follow coordinated disclosure. We will:
 2. Develop a fix
 3. Release a patch
 4. Credit the reporter (unless anonymity is requested)
+
+## Permission model
+
+`bin/init-project.sh` writes entries to `.claude/settings.json` so autopilot can run without constant permission prompts. Nanostack treats the permission list as the first line of defense and the guard hooks as the authoritative one.
+
+### Default rm scope
+
+New installs receive:
+
+- `Bash(rm:.nanostack/**)` for sprint artifact cleanup
+- `Bash(rm:/tmp/**)` for temporary file cleanup
+
+Any `rm` outside these paths prompts the user. Destructive deletion of arbitrary paths should be a conscious choice, not a silent default.
+
+### Broad curl is kept
+
+`Bash(curl:*)` remains in the default list because curl is a common dev-path primitive (testing endpoints, fetching release artifacts, hitting localhost). The dangerous case, piping curl output into a shell, is caught by the guard as a block rule:
+
+- `G-023` blocks `curl ... | sh`
+- `G-024` blocks `curl ... | bash`
+
+The guard runs on every Bash tool use, ahead of the in-project fast-path, and logs every block to `.nanostack/audit.log`.
+
+### Existing installs
+
+Installs that existed before the narrowing got `Bash(rm:*)` written to their `.claude/settings.json`. Running `init-project.sh` a second time does NOT remove it. The install keeps what it had.
+
+`/nano-doctor` surfaces a warning when a broad `Bash(rm:*)` entry is present. To migrate, edit `.claude/settings.json`, remove the `Bash(rm:*)` line, and re-run `init-project.sh` to pick up the narrow defaults.
+
+### Defense layers
+
+| Layer | Purpose | Failure mode |
+|---|---|---|
+| Permissions (`.claude/settings.json`) | Cheap gate, no network call. | User can grant broad perms manually. |
+| Guard hooks (`guard/bin/check-dangerous.sh`) | Pattern match against block rules before any command runs. | If hooks are disabled, permissions become the only gate. |
+| Audit trail (`.nanostack/audit.log`) | Record every blocked and allowed command for post-hoc review. | If the store path is missing, logging silently no-ops; guard still blocks. |
+
+Each layer is independent. The audit trail works even when the store path is unresolved; the guard works even when permissions are broad; the permissions work even if the guard is missing. That independence is the point.

--- a/bin/init-project.sh
+++ b/bin/init-project.sh
@@ -3,6 +3,16 @@
 # Creates .claude/settings.json with permissions for uninterrupted autopilot
 # and .gitignore entry for .nanostack/
 # Usage: Run once in any project directory
+#
+# Permission model:
+#   New installs receive narrow rm permissions (.nanostack/** and /tmp/**).
+#   Anything outside those paths prompts the user. The defense-in-depth
+#   story is documented in SECURITY.md under "Permission model".
+#
+#   When merging into an existing .claude/settings.json, we only ADD
+#   entries; we never remove what the user already has. Existing installs
+#   with Bash(rm:*) keep it until the user opts into narrowing manually.
+#   /nano-doctor surfaces a warning when broad rm is present in settings.
 set -e
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -32,7 +42,8 @@ if [ -f "$SETTINGS" ]; then
       "Bash(ls:*)",
       "Bash(cp:*)",
       "Bash(mv:*)",
-      "Bash(rm:*)",
+      "Bash(rm:.nanostack/**)",
+      "Bash(rm:/tmp/**)",
       "Bash(git:*)",
       "Bash(go:*)",
       "Bash(npm:*)",
@@ -71,7 +82,8 @@ else
       "Bash(ls:*)",
       "Bash(cp:*)",
       "Bash(mv:*)",
-      "Bash(rm:*)",
+      "Bash(rm:.nanostack/**)",
+      "Bash(rm:/tmp/**)",
       "Bash(git:*)",
       "Bash(go:*)",
       "Bash(npm:*)",

--- a/bin/nano-doctor.sh
+++ b/bin/nano-doctor.sh
@@ -230,7 +230,35 @@ else
   add_check fail detection pre_v5 "telemetry.sh missing at $_tel_lib"
 fi
 
-# ─── 6. Worker reachability ────────────────────────────────────────────
+# ─── 6. Permission scope ───────────────────────────────────────────────
+# Surface settings.json entries that grant broad filesystem deletion.
+# Current nanostack installs default to narrow rm permissions
+# (.nanostack/** and /tmp/**). Installs done before that change may
+# still have Bash(rm:*) in their settings. Flag it as a warning with
+# a concrete remediation so users can opt into narrowing.
+
+_settings_paths=""
+[ -f .claude/settings.json ]              && _settings_paths="$_settings_paths .claude/settings.json"
+[ -f "$HOME/.claude/settings.json" ]      && _settings_paths="$_settings_paths $HOME/.claude/settings.json"
+[ -f "$HOME/.claude/settings.local.json" ] && _settings_paths="$_settings_paths $HOME/.claude/settings.local.json"
+
+if [ -n "$_settings_paths" ] && command -v jq >/dev/null 2>&1; then
+  _broad=""
+  for _s in $_settings_paths; do
+    if jq -e '.permissions.allow // [] | any(. == "Bash(rm:*)")' "$_s" >/dev/null 2>&1; then
+      _broad="${_broad:+$_broad, }$_s"
+    fi
+  done
+  if [ -n "$_broad" ]; then
+    add_check warn permissions rm_scope "Bash(rm:*) present in $_broad; consider narrowing to Bash(rm:.nanostack/**) and Bash(rm:/tmp/**). See SECURITY.md."
+  else
+    add_check pass permissions rm_scope "no broad Bash(rm:*) entries found"
+  fi
+else
+  add_check pass permissions rm_scope "no settings.json to check"
+fi
+
+# ─── 7. Worker reachability ────────────────────────────────────────────
 
 if $OFFLINE_MODE; then
   add_check pass network worker_reachable "skipped (--offline)"


### PR DESCRIPTION
## Summary

Internal audit follow-up (2026-04-24) kept the HIGH finding about `init-project.sh` granting `Bash(rm:*)`. This PR narrows the default without disrupting existing installs, and documents the three-layer defense model so the decision is legible from the repo.

## Default rm scope

New installs receive:

```
Bash(rm:.nanostack/**)
Bash(rm:/tmp/**)
```

instead of `Bash(rm:*)`. Any `rm` outside those paths prompts the user, which is the intended friction for arbitrary deletion.

## Why `Bash(curl:*)` stays broad

Curl is a common dev primitive (localhost testing, release artifact fetching, endpoint checks). The dangerous case is `curl ... | sh`, which the guard already blocks at the hook layer via rules `G-023` and `G-024`. Narrowing curl would break legitimate flows without adding protection the guard does not already provide.

## No disruption for existing installs

The merge branch of `init-project.sh` only ADDS entries (jq `unique` dedupes); it never removes what the user already has. Installs that were created with `Bash(rm:*)` keep it until the user migrates manually.

## `/nano-doctor` warns on broad rm

New check `permissions.rm_scope` scans `.claude/settings.json`, `~/.claude/settings.json`, and `settings.local.json`. If any contains `Bash(rm:*)`, the report warns:

```
warn  rm_scope  Bash(rm:*) present in .claude/settings.json; consider narrowing to Bash(rm:.nanostack/**) and Bash(rm:/tmp/**). See SECURITY.md.
```

Remediation: remove the `Bash(rm:*)` line and re-run `init-project.sh` to pick up the narrow defaults.

## Documentation

`SECURITY.md` gains a "Permission model" section naming the three independent defense layers:

| Layer | Purpose | Failure mode |
|---|---|---|
| Permissions | Cheap gate, no network call | User can grant broad perms manually |
| Guard hooks | Pattern match before any command runs | If disabled, permissions become the only gate |
| Audit trail | Record blocked and allowed commands for review | If store path is missing, logging silently no-ops |

## Test plan

- [x] Fresh install scenario: new `settings.json` contains the two narrow rm entries only.
- [x] Merge scenario: existing `Bash(rm:*)` stays, narrow entries land alongside via jq unique.
- [x] `/nano-doctor` warns on simulated broad-rm settings with the remediation message naming the file.
- [x] `/nano-doctor` against the current maintainer settings: passes.
- [x] Em-dash lint on top-level docs passes.
- [x] `bash -n` on both modified scripts.

## Related

Internal audit, 2026-04-24. Addresses the HIGH finding on init-project permission scope.