### PR TITLE
Run guard block rules before the allowlist and tighten G-007

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -403,9 +403,23 @@ jobs:
           run_case 1 'git reset --hard'
           run_case 1 'git push --force'
           run_case 1 'git push -f origin main'
+          # Blocked via allowlist-precedence fix: binaries on the allowlist
+          # (find, cat, head, tail) still hit block patterns for known-bad
+          # arguments. Covers find-delete, find-exec-rm, .env / .pem reads.
+          run_case 1 'find . -delete'
+          run_case 1 'find . -exec rm -rf {} +'
+          run_case 1 'cat .env'
+          run_case 1 'head .env'
+          run_case 1 'tail secrets.pem'
           # Allowed: specific in-project subpaths + allowlist commands.
           run_case 0 'rm -rf ./docs'
           run_case 0 'rm -rf ./docs/foo'
           run_case 0 'ls -la'
           run_case 0 'git status'
+          run_case 0 'find . -name "*.sh"'
+          run_case 0 'cat README.md'
+          run_case 0 'head -5 script.sh'
+          # --force-with-lease is the guard's own recommended alternative;
+          # it must not trip G-007/G-008.
+          run_case 0 'git push --force-with-lease'
           exit $fail

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -51,35 +51,14 @@ audit_trail_append() {
     >> "$AUDIT_LOG" 2>/dev/null || true
 }
 
-# ─── Tier 1: Allowlist ──────────────────────────────────────
-# Extract first token of the command (the binary/builtin)
 CMD_BASE=$(echo "$CMD" | awk '{print $1}' | sed 's|.*/||')
 
-# Single jq call: check if command matches any allowlist entry
-# Returns "pass" if allowed, empty if not
-TIER1=$(jq -r --arg cmd "$CMD" --arg base "$CMD_BASE" '
-  .tiers.allowlist.commands[] |
-  split(" ")[0] | gsub(".*/"; "") |
-  select(. == $base)' "$RULES_FILE" 2>/dev/null | head -1)
-
-if [ -n "$TIER1" ]; then
-  # Base matches. For multi-word entries, verify full match
-  MULTI=$(jq -r --arg base "$CMD_BASE" '
-    .tiers.allowlist.commands[] |
-    select((split(" ")[0] | gsub(".*/"; "")) == $base and (split(" ") | length) > 1)' "$RULES_FILE" 2>/dev/null | head -1)
-  if [ -z "$MULTI" ]; then
-    # Single-word entry: base match is enough
-    exit 0
-  elif echo "$CMD" | grep -qF "$MULTI" 2>/dev/null; then
-    exit 0
-  fi
-fi
-
-# ─── Tier 1.5: Block rules (run before in-project fast-path) ──
-# Block patterns must take precedence over the in-project shortcut.
-# Otherwise destructive commands like `rm -rf ./` slip through because
-# their target resolves inside the repo, even though they wipe .git
-# along with everything else. Audit finding from April 2026.
+# ─── Tier 1: Block rules (authoritative, no exceptions) ─────
+# Block patterns run before the allowlist so commands whose binary
+# happens to be on the allowlist (cat, find, head, tail) still get
+# evaluated against known-bad patterns such as reading .env or
+# find . -delete. Previous ordering let allowlisted binaries short
+# circuit past block rules; audit finding from April 2026.
 BLOCK_PATTERNS=$(jq -r '.tiers.block.rules[] | .pattern' "$RULES_FILE" 2>/dev/null)
 BLOCK_COMBINED=$(echo "$BLOCK_PATTERNS" | paste -sd'|' -)
 if [ -n "$BLOCK_COMBINED" ] && echo "$CMD" | grep -qiE -- "$BLOCK_COMBINED" 2>/dev/null; then
@@ -103,6 +82,28 @@ if [ -n "$BLOCK_COMBINED" ] && echo "$CMD" | grep -qiE -- "$BLOCK_COMBINED" 2>/d
     fi
     BLOCK_IDX=$((BLOCK_IDX + 1))
   done <<< "$BLOCK_PATTERNS"
+fi
+
+# ─── Tier 2: Allowlist ──────────────────────────────────────
+# Runs only after block rules had a chance to fire. For commands
+# that matched no block, a matching allowlist entry short-circuits
+# the remaining tiers.
+TIER1=$(jq -r --arg cmd "$CMD" --arg base "$CMD_BASE" '
+  .tiers.allowlist.commands[] |
+  split(" ")[0] | gsub(".*/"; "") |
+  select(. == $base)' "$RULES_FILE" 2>/dev/null | head -1)
+
+if [ -n "$TIER1" ]; then
+  # Base matches. For multi-word entries, verify full match
+  MULTI=$(jq -r --arg base "$CMD_BASE" '
+    .tiers.allowlist.commands[] |
+    select((split(" ")[0] | gsub(".*/"; "")) == $base and (split(" ") | length) > 1)' "$RULES_FILE" 2>/dev/null | head -1)
+  if [ -z "$MULTI" ]; then
+    # Single-word entry: base match is enough
+    exit 0
+  elif echo "$CMD" | grep -qF "$MULTI" 2>/dev/null; then
+    exit 0
+  fi
 fi
 
 # ─── Tier 2: In-project operations ──────────────────────────

--- a/guard/rules.json
+++ b/guard/rules.json
@@ -81,7 +81,7 @@
         },
         {
           "id": "G-007",
-          "pattern": "git push --force",
+          "pattern": "git push.*--force([[:space:]]|$)",
           "category": "history-destruction",
           "description": "Force push overwrites remote history",
           "alternative": "git push --force-with-lease (safer, fails if remote changed)"


### PR DESCRIPTION
## Summary

Internal audit round 3 (2026-04-24) flagged that commands whose binary was on the Tier 1 allowlist (`find`, `cat`, `head`, `tail`) short-circuited past the block-rule tier. Verified locally: `find . -delete`, `find . -exec rm -rf {} +`, `cat .env`, `head .env`, `tail secrets.pem` all returned exit 0 despite rules G-005, G-006, and G-030 existing for those cases. A follow-up flagged that G-007 also tripped on `git push --force-with-lease`, which is literally the alternative the rule recommends.

## Changes

### 1. Reorder tiers

Block rules now run before the allowlist. The allowlist still short-circuits the in-project fast-path, but only for inputs that did not match any block pattern. This turns the allowlist into "known-safe for common invocations" instead of "bypass all other checks".

Before:
```
Tier 1: Allowlist  -> exit 0 on match
Tier 1.5: Block    -> exit 1 on match
Tier 2: In-project
...
```

After:
```
Tier 1: Block      -> exit 1 on match
Tier 2: Allowlist  -> exit 0 on match
Tier 3: In-project
...
```

### 2. Tighten G-007 pattern

From `git push --force` to `git push.*--force([[:space:]]|$)`. The previous pattern matched `--force` as a prefix, which meant `git push --force-with-lease` tripped the block even though the rule's own `alternative` message recommends it.

| Command | Before | After |
|---|---|---|
| `git push --force` | BLOCK | BLOCK |
| `git push --force origin main` | BLOCK | BLOCK |
| `git push origin main --force` | BLOCK | BLOCK |
| `git push --force-with-lease` | BLOCK | allow |
| `git push origin main` | allow | allow |

### 3. CI matrix expanded from 12 to 21 cases

New blocked cases (caught by the reorder):

- `find . -delete`
- `find . -exec rm -rf {} +`
- `cat .env`
- `head .env`
- `tail secrets.pem`

New allowed cases (regression coverage for the reorder + --force fix):

- `find . -name "*.sh"`
- `cat README.md`
- `head -5 script.sh`
- `git push --force-with-lease`

Existing twelve cases from PR #131 preserved.

## Test plan

- [x] Reproduction of round-3 findings: five previously-bypassed commands now block.
- [x] Safe allowlist commands still pass (ls, cat README, find -name, head script).
- [x] `--force-with-lease` now passes; `--force` variants still block.
- [x] Full regression matrix (21 cases) passes locally and in CI.
- [x] Em-dash lint and bash syntax.

## Related

Internal audit, 2026-04-24, round 3. Addresses P1 "allowlist anula reglas de bloqueo" and P2 "--force-with-lease queda bloqueado".