### PR TITLE
Add PreToolUse guard for Write, Edit, and MultiEdit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -423,3 +423,64 @@ jobs:
           # it must not trip G-007/G-008.
           run_case 0 'git push --force-with-lease'
           exit $fail
+
+  write-guard-regression:
+    name: Write/Edit guard regression cases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run write-guard matrix
+        run: |
+          set +e
+          set -u
+          script=guard/bin/check-write.sh
+          fail=0
+          run_case() {
+            local expected="$1" path="$2"
+            (bash "$script" "$path" >/dev/null 2>&1)
+            local got=$?
+            if [ "$got" != "$expected" ]; then
+              echo "FAIL: '$path' expected exit $expected, got $got"
+              fail=1
+            else
+              printf '  ok   exit=%s  %s\n' "$got" "$path"
+            fi
+          }
+          # Blocked: secrets by basename + system paths.
+          run_case 1 '.env'
+          run_case 1 '.env.local'
+          run_case 1 '.env.production'
+          run_case 1 './secrets/key.pem'
+          run_case 1 'path/to/authorized_keys'
+          run_case 1 'config.key'
+          run_case 1 '/etc/passwd'
+          run_case 1 '/var/log/auth.log'
+          run_case 1 '/usr/bin/ls'
+          run_case 1 "$HOME/.ssh/id_rsa"
+          run_case 1 "$HOME/.aws/credentials"
+          # Allowed: templates + regular project files.
+          run_case 0 '.env.example'
+          run_case 0 '.env.sample'
+          run_case 0 '.env.template'
+          run_case 0 'README.md'
+          run_case 0 'src/config.js'
+          run_case 0 'package.json'
+          run_case 0 '/tmp/scratch.txt'
+          # JSON input path (Claude Code PreToolUse contract).
+          if ! echo '{"tool_name":"Write","tool_input":{"file_path":".env"}}' \
+            | bash "$script" >/dev/null 2>&1; then
+            printf '  ok   stdin-json blocks .env\n'
+          else
+            echo "FAIL: JSON stdin did not block .env"
+            fail=1
+          fi
+          if echo '{"tool_name":"Edit","tool_input":{"file_path":"README.md"}}' \
+            | bash "$script" >/dev/null 2>&1; then
+            printf '  ok   stdin-json allows README.md\n'
+          else
+            echo "FAIL: JSON stdin did not allow README.md"
+            fail=1
+          fi
+          exit $fail

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,12 +75,48 @@ Installs that existed before the narrowing got `Bash(rm:*)` written to their `.c
 
 `/nano-doctor` surfaces a warning when a broad `Bash(rm:*)` entry is present. To migrate, edit `.claude/settings.json`, remove the `Bash(rm:*)` line, and re-run `init-project.sh` to pick up the narrow defaults.
 
+### Write and Edit are hooked too
+
+Coding agents need to write code, so `Write(*)` and `Edit(*)` stay broad in the permission list. The safety boundary for those tools lives in a dedicated PreToolUse hook: `guard/bin/check-write.sh`. It runs before every Write, Edit, and MultiEdit call and rejects a narrow denylist:
+
+- Environment files with real secrets (`.env`, `.env.local`, `.env.production`, `.env.staging`, `.env.development`, `.env.dev`, `.env.prod`). Template files like `.env.example`, `.env.sample`, `.env.template` are allowed.
+- Private cryptographic material (`*.pem`, `*.key`, `*.p12`, `*.pfx`).
+- SSH keys and config (`id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, their `.pub` pairs, `authorized_keys`, `known_hosts`).
+- Shell history (`.bash_history`, `.zsh_history`, `.python_history`).
+- System directories (`/etc`, `/var`, `/usr/bin`, `/usr/sbin`, `/usr/lib`, `/System`, `/private/etc`).
+- User secret directories (`~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.gcp`, `~/.config/gcloud`, `~/.kube`).
+
+Fresh installs receive this hook wired automatically. Existing installs are not modified and need to wire it manually to gain the Write/Edit layer.
+
+### Manual wire-up for existing installs
+
+Add the following to your project's `.claude/settings.json`. The paths assume a standard install at `~/.claude/skills/nanostack`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "$HOME/.claude/skills/nanostack/guard/bin/check-dangerous.sh"}]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [{"type": "command", "command": "$HOME/.claude/skills/nanostack/guard/bin/check-write.sh"}]
+      }
+    ]
+  }
+}
+```
+
+Run `/nano-doctor` to verify; it warns when the hooks are missing.
+
 ### Defense layers
 
 | Layer | Purpose | Failure mode |
 |---|---|---|
 | Permissions (`.claude/settings.json`) | Cheap gate, no network call. | User can grant broad perms manually. |
-| Guard hooks (`guard/bin/check-dangerous.sh`) | Pattern match against block rules before any command runs. | If hooks are disabled, permissions become the only gate. |
+| Guard hooks (`check-dangerous.sh`, `check-write.sh`) | Pattern match against block rules before a Bash, Write, or Edit call runs. | If hooks are disabled, permissions become the only gate. |
 | Audit trail (`.nanostack/audit.log`) | Record every blocked and allowed command for post-hoc review. | If the store path is missing, logging silently no-ops; guard still blocks. |
 
 Each layer is independent. The audit trail works even when the store path is unresolved; the guard works even when permissions are broad; the permissions work even if the guard is missing. That independence is the point.

--- a/bin/init-project.sh
+++ b/bin/init-project.sh
@@ -71,8 +71,13 @@ if [ -f "$SETTINGS" ]; then
   echo "$UPDATED" | jq '.' > "$SETTINGS"
   echo "Updated: $SETTINGS (merged permissions)"
 else
-  # Create new settings
-  cat > "$SETTINGS" << 'EOF'
+  # Create new settings. Fresh installs get the PreToolUse hooks wired
+  # automatically so Bash, Write, and Edit all pass through the guard.
+  # Existing installs are left alone; see SECURITY.md for the manual
+  # wire-up and /nano-doctor for a warning when the hooks are missing.
+  _GUARD_CHECK_DANGEROUS="$HOME/.claude/skills/nanostack/guard/bin/check-dangerous.sh"
+  _GUARD_CHECK_WRITE="$HOME/.claude/skills/nanostack/guard/bin/check-write.sh"
+  cat > "$SETTINGS" << EOF
 {
   "permissions": {
     "allow": [
@@ -107,10 +112,22 @@ else
       "Write(*)",
       "Edit(*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "$_GUARD_CHECK_DANGEROUS"}]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [{"type": "command", "command": "$_GUARD_CHECK_WRITE"}]
+      }
+    ]
   }
 }
 EOF
-  echo "Created: $SETTINGS"
+  echo "Created: $SETTINGS (with PreToolUse hooks for Bash, Write, Edit)"
 fi
 
 # Add .nanostack/ to .gitignore if not already there

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# check-write.sh — PreToolUse hook for Write and Edit tools.
+#
+# Claude Code's Bash tool already runs through check-dangerous.sh. The
+# Write and Edit tools did not have an equivalent gate, which meant an
+# agent with Write(*)/Edit(*) permissions could touch ~/.ssh/id_rsa,
+# /etc/passwd, or .env.production with no guard involvement. This hook
+# adds a narrow denylist so those paths stay off-limits regardless of
+# how broad the permission list is.
+#
+# Input contract:
+#   Claude Code PreToolUse hooks receive JSON on stdin with shape:
+#     {"tool_name": "Write" | "Edit" | "MultiEdit",
+#      "tool_input": {"file_path": "<path>", ...}}
+#   For direct invocation (tests, local checks) accept the path as $1.
+#
+# Exit codes:
+#   0  = allow
+#   1  = block (path matches deny pattern)
+#
+# Philosophy: narrow denylist, not broad allowlist. Coding agents need
+# to write code freely within the project. The goal is to keep them
+# away from secrets and system files, not to reshape the permission
+# model around every working directory.
+
+set -u
+
+# ─── Extract file path ─────────────────────────────────────────────────
+
+INPUT="${1:-}"
+if [ -z "$INPUT" ] && [ -p /dev/stdin ]; then
+  INPUT=$(cat)
+fi
+
+FILE_PATH=""
+if [ -n "$INPUT" ]; then
+  # If it parses as JSON, pull tool_input.file_path. Otherwise treat the
+  # whole input as the path (supports both the hook contract and direct
+  # invocation from tests or CI).
+  if printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1; then
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '
+      .tool_input.file_path
+      // .tool_input.notebook_path
+      // .file_path
+      // empty
+    ')
+  else
+    FILE_PATH="$INPUT"
+  fi
+fi
+
+# Nothing to check means nothing to block. Agents that call Write/Edit
+# with no file_path will fail later in the tool itself.
+[ -n "$FILE_PATH" ] || exit 0
+
+# Expand ~ to $HOME for path-prefix matching.
+case "$FILE_PATH" in
+  "~"*) FILE_PATH="$HOME${FILE_PATH#~}" ;;
+esac
+
+# ─── Deny patterns ─────────────────────────────────────────────────────
+# Each entry is a POSIX extended regex evaluated against the absolute or
+# relative file path. Intentionally narrow: false positives train users
+# to ignore the block, and this hook cannot afford that.
+
+# Basename-based patterns (match any path ending in this filename).
+BASENAME_DENY=(
+  # Environment files that typically contain real secrets.
+  '\.env$'
+  '\.env\.local$'
+  '\.env\.production$'
+  '\.env\.prod$'
+  '\.env\.staging$'
+  '\.env\.development$'
+  '\.env\.dev$'
+  # Private cryptographic material.
+  '\.pem$'
+  '\.key$'
+  '\.p12$'
+  '\.pfx$'
+  # SSH keys and config.
+  'id_rsa$'
+  'id_rsa\.pub$'
+  'id_ed25519$'
+  'id_ed25519\.pub$'
+  'id_ecdsa$'
+  'id_dsa$'
+  'authorized_keys$'
+  'known_hosts$'
+  # Shell history (often contains secrets).
+  '\.bash_history$'
+  '\.zsh_history$'
+  '\.python_history$'
+)
+
+# Path-prefix patterns (match if the absolute path starts with this).
+PATH_PREFIX_DENY=(
+  '^/etc/'
+  '^/var/'
+  '^/usr/bin/'
+  '^/usr/sbin/'
+  '^/usr/lib/'
+  '^/System/'
+  '^/private/etc/'
+  "^$HOME/\\.ssh/"
+  "^$HOME/\\.gnupg/"
+  "^$HOME/\\.aws/"
+  "^$HOME/\\.gcp/"
+  "^$HOME/\\.config/gcloud/"
+  "^$HOME/\\.kube/"
+)
+
+# ─── Evaluate ──────────────────────────────────────────────────────────
+
+MATCHED_RULE=""
+
+# Basename check: match against both absolute form and basename to catch
+# relative paths (./.env) and absolute paths (/project/.env) uniformly.
+for pat in "${BASENAME_DENY[@]}"; do
+  if printf '%s' "$FILE_PATH" | grep -qE -- "$pat"; then
+    MATCHED_RULE="secret_basename:$pat"
+    break
+  fi
+done
+
+# Path-prefix check only if basename did not match. Prefix patterns are
+# tighter so they rarely overlap; short-circuit keeps the message simple.
+if [ -z "$MATCHED_RULE" ]; then
+  for pat in "${PATH_PREFIX_DENY[@]}"; do
+    if printf '%s' "$FILE_PATH" | grep -qE -- "$pat"; then
+      MATCHED_RULE="system_path:$pat"
+      break
+    fi
+  done
+fi
+
+if [ -n "$MATCHED_RULE" ]; then
+  cat >&2 <<EOF
+BLOCKED [W-001] Write or Edit to a protected path
+Category: ${MATCHED_RULE%%:*}
+Path:     $FILE_PATH
+Rule:     ${MATCHED_RULE#*:}
+
+This file holds secrets or system state. Coding agents should not
+modify it. Edit the file by hand if the change is intentional, or
+tell the agent to write to a non-protected path.
+
+See SECURITY.md "Permission model" for the full list.
+EOF
+  exit 1
+fi
+
+# Allowed. Write/Edit tool proceeds normally.
+exit 0


### PR DESCRIPTION
## Summary

Round 3 audit (2026-04-24) flagged that the guard was authoritative for Bash but invisible to Write/Edit. An agent holding `Write(*)`/`Edit(*)` could touch `~/.ssh/id_rsa`, `.env.production`, or `/etc/` without the guard or the audit trail ever seeing it. This PR adds a dedicated hook that closes the gap while keeping existing projects untouched.

## Changes

### New: `guard/bin/check-write.sh`

PreToolUse hook for Write, Edit, MultiEdit. Reads Claude Code's JSON-on-stdin contract (or accepts a plain path as `$1` for tests). Two deny passes:

1. **Secrets by basename** — `.env` and variants with real secrets, `.pem`, `.key`, `.p12`, `.pfx`, SSH keys, shell history. Templates (`.env.example`, `.env.sample`, `.env.template`) are allowed.
2. **System and user-secret paths** — `/etc/`, `/var/`, `/usr/bin/`, `/usr/sbin/`, `/usr/lib/`, `/System/`, `/private/etc/`, `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.gcp/`, `~/.config/gcloud/`, `~/.kube/`.

Exit 1 on match with a labeled `BLOCKED [W-001]` message naming the rule; 0 otherwise.

### Fresh installs get both hooks wired

`init-project.sh` for NEW settings now writes:

```json
{
  "hooks": {
    "PreToolUse": [
      {"matcher": "Bash",              "hooks": [{"type": "command", "command": ".../check-dangerous.sh"}]},
      {"matcher": "Write|Edit|MultiEdit","hooks": [{"type": "command", "command": ".../check-write.sh"}]}
    ]
  }
}
```

Merge path is unchanged: existing projects keep what they have. Opt-in migration via a copy-paste block in `SECURITY.md`.

### SECURITY.md

- New section "Write and Edit are hooked too" enumerates the denylist.
- New "Manual wire-up for existing installs" section gives the exact JSON to paste.
- Defense-layers table now names both hook scripts.

### CI: new `write-guard-regression` job

19 scenarios:

| Blocked | Allowed |
|---|---|
| `.env` | `.env.example` |
| `.env.local` | `.env.sample` |
| `.env.production` | `.env.template` |
| `./secrets/key.pem` | `README.md` |
| `path/to/authorized_keys` | `src/config.js` |
| `config.key` | `package.json` |
| `/etc/passwd` | `/tmp/scratch.txt` |
| `/var/log/auth.log` | |
| `/usr/bin/ls` | |
| `$HOME/.ssh/id_rsa` | |
| `$HOME/.aws/credentials` | |

Plus the JSON-on-stdin contract: `{"tool_name":"Write","tool_input":{"file_path":".env"}}` must block and the same shape with `README.md` must pass.

## Test plan

- [x] 16 positional-argument cases pass (11 block, 5 allow).
- [x] Tilde expansion: `~/.ssh/id_rsa`, `~/.aws/credentials` blocked.
- [x] JSON contract: Write `.env` blocks, Edit `README.md` allows.
- [x] Fresh `init-project.sh` writes the expected hooks block.
- [x] YAML workflow parses.
- [x] Em-dash lint passes.

## Existing installs

Unchanged. The hook is not retroactively wired; see `SECURITY.md` for the manual block to paste. `/nano-doctor` will warn when it is absent (follow-up PR).

## Related

Internal audit, 2026-04-24, round 3. Addresses P1 "nuevas instalaciones siguen con escritura global".