### PR TITLE
Portable stat in enforce-sprint.sh and verified reads in resolve.sh

### DIFF
--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -123,7 +123,12 @@ for entry in $UPSTREAM; do
       age="$o_age"
     fi
   done
-  RESULT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$age" 2>/dev/null) || RESULT=""
+  # --verify rejects artifacts whose stored content hash does not match
+  # on read, so a tampered file in .nanostack/ cannot become the source
+  # of truth for downstream phases (gates, review context, conflict
+  # precedence). find-artifact.sh returns empty on a verify failure;
+  # that is fine and equivalent to "no artifact for this phase".
+  RESULT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$age" --verify 2>/dev/null) || RESULT=""
   if [ -n "$RESULT" ]; then
     $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
     ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":\"$RESULT\""

--- a/feature/bin/enforce-sprint.sh
+++ b/feature/bin/enforce-sprint.sh
@@ -19,9 +19,16 @@ MISSING=""
 
 # Find the most recent code change timestamp
 LAST_CODE_CHANGE=$(git log -1 --format=%ct 2>/dev/null || echo 0)
-# If no commits yet, use the newest source file modification time
+# If no commits yet, use the newest source file modification time.
+# Try BSD stat (-f %m) first, then fall back to GNU stat (-c %Y) so the
+# gate works on Linux agents, not just macOS. Mirrors the portable
+# pattern already in guard/bin/phase-gate.sh.
 if [ "$LAST_CODE_CHANGE" -eq 0 ]; then
-  LAST_CODE_CHANGE=$(find . -name '*.js' -o -name '*.ts' -o -name '*.html' -o -name '*.css' -o -name '*.py' -o -name '*.go' 2>/dev/null | head -20 | xargs stat -f %m 2>/dev/null | sort -rn | head -1 || echo 0)
+  _srcs=$(find . -name '*.js' -o -name '*.ts' -o -name '*.html' -o -name '*.css' -o -name '*.py' -o -name '*.go' 2>/dev/null | head -20)
+  LAST_CODE_CHANGE=$(echo "$_srcs" | xargs stat -f %m 2>/dev/null | sort -rn | head -1)
+  [ -z "$LAST_CODE_CHANGE" ] && LAST_CODE_CHANGE=$(echo "$_srcs" | xargs stat -c %Y 2>/dev/null | sort -rn | head -1)
+  [ -z "$LAST_CODE_CHANGE" ] && LAST_CODE_CHANGE=0
+  unset _srcs
 fi
 
 # Check for artifacts that are newer than the last code change


### PR DESCRIPTION
## Summary

Two small hygiene items from the round 3 audit (2026-04-24), shipped together. Independent, both under ten lines.

## Changes

### 1. `feature/bin/enforce-sprint.sh`

The pre-commit gate computed newest-source mtime with `xargs stat -f %m`, which is BSD-only. On Linux that returned empty, compared against zero, and let commits through without the artifact freshness check. Mirror the portable pattern already in `guard/bin/phase-gate.sh`:

```
# BSD stat first, fall back to GNU stat, land on 0 if both fail.
```

### 2. `bin/resolve.sh`

Pass `--verify` when calling `find-artifact.sh`. The verify flag already existed in `find-artifact.sh` and tests exercised it, but the resolver itself was not using it. Without verify, a tampered artifact in `.nanostack/` could become the source of truth for gates, review context, and conflict precedence. With verify, `find-artifact.sh` returns empty on hash mismatch and the resolver already handles empty as "no artifact for this phase".

## Test plan

- [x] `bash -n` on both files.
- [x] `tests/run.sh`: 44/44 pass, including guard regressions and scope drift.
- [x] `enforce-sprint.sh` fallback chain returns the correct mtime on macOS via BSD stat.
- [x] Em-dash lint passes.

## Related

Internal audit, 2026-04-24, round 3. Addresses P2 "gate legacy de feature no es portable" and P2 "integridad de artefactos existe pero no se exige".