### PR TITLE
Resolve symlinks in check-write and broaden secrets-read rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -422,6 +422,23 @@ jobs:
           # --force-with-lease is the guard's own recommended alternative;
           # it must not trip G-007/G-008.
           run_case 0 'git push --force-with-lease'
+          # G-030 now covers more readers (grep, rg, jq, awk, sed, strings,
+          # od, xxd, hexdump). G-031 covers env / printenv standalone.
+          run_case 1 'grep SECRET .env'
+          run_case 1 'rg SECRET .env'
+          run_case 1 'jq . .env'
+          run_case 1 'awk /=/ .env'
+          run_case 1 'sed s/x/y/ .env.production'
+          run_case 1 'strings secrets.pem'
+          run_case 1 'env'
+          run_case 1 'printenv'
+          run_case 1 'env | grep PATH'
+          # env VAR=value cmd is a legitimate way to set a variable for
+          # one command; G-031 must not trip on it.
+          run_case 0 'env VAR=val cmd'
+          run_case 0 'envsubst < template'
+          run_case 0 'jq . package.json'
+          run_case 0 'awk NR==1 file.csv'
           exit $fail
 
   write-guard-regression:
@@ -483,4 +500,27 @@ jobs:
             echo "FAIL: JSON stdin did not allow README.md"
             fail=1
           fi
+
+          # Symlink resolution: a symlink whose target is a protected
+          # path must be blocked even when the textual path does not
+          # match the denylist.
+          tmp_link_dir="$RUNNER_TEMP/symlink-test"
+          mkdir -p "$tmp_link_dir"
+          ln -sfn /etc "$tmp_link_dir/etclink"
+          if ! bash "$script" "$tmp_link_dir/etclink/passwd" >/dev/null 2>&1; then
+            printf '  ok   symlink etclink/passwd blocks (resolves to /etc)\n'
+          else
+            echo "FAIL: symlink to /etc bypassed denylist"
+            fail=1
+          fi
+          # And a symlink that does NOT point at a protected target stays
+          # allowed (regression: do not over-block legitimate symlinks).
+          ln -sfn "$RUNNER_TEMP" "$tmp_link_dir/safelink"
+          if bash "$script" "$tmp_link_dir/safelink/notes.txt" >/dev/null 2>&1; then
+            printf '  ok   symlink to safe target allows\n'
+          else
+            echo "FAIL: symlink to safe target was blocked"
+            fail=1
+          fi
+          rm -rf "$tmp_link_dir"
           exit $fail

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -58,6 +58,33 @@ case "$FILE_PATH" in
   "~"*) FILE_PATH="$HOME${FILE_PATH#~}" ;;
 esac
 
+# Resolve symlinks. A repo-controlled symlink like myfile -> /etc/passwd
+# or sshlink -> ~/.ssh otherwise lets a Write/Edit reach a protected
+# target whose textual path does not match any denylist entry. The fix
+# is to evaluate the denylist against BOTH the original path and its
+# resolved form; if either matches, block. Falls back to a pure-bash
+# parent-realpath when the realpath binary is missing or refuses
+# missing leaves (Write to a not-yet-existing file).
+RESOLVED_PATH=""
+if command -v realpath >/dev/null 2>&1; then
+  RESOLVED_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null) \
+    || RESOLVED_PATH=$(realpath --canonicalize-missing "$FILE_PATH" 2>/dev/null) \
+    || RESOLVED_PATH=""
+fi
+if [ -z "$RESOLVED_PATH" ]; then
+  # Pure-bash fallback. cd into the parent (which IS a real dir even
+  # when the leaf is being created) and re-attach the basename. pwd -P
+  # follows symlinks at the parent level, which catches sshlink/...
+  _parent=$(dirname "$FILE_PATH")
+  _base=$(basename "$FILE_PATH")
+  if RESOLVED_PARENT=$(cd "$_parent" 2>/dev/null && pwd -P); then
+    RESOLVED_PATH="$RESOLVED_PARENT/$_base"
+  else
+    RESOLVED_PATH="$FILE_PATH"
+  fi
+  unset _parent _base RESOLVED_PARENT
+fi
+
 # ─── Deny patterns ─────────────────────────────────────────────────────
 # Each entry is a POSIX extended regex evaluated against the absolute or
 # relative file path. Intentionally narrow: false positives train users
@@ -111,27 +138,36 @@ PATH_PREFIX_DENY=(
 )
 
 # ─── Evaluate ──────────────────────────────────────────────────────────
+# Run the denylist against both the original FILE_PATH and the symlink
+# RESOLVED_PATH. Either match blocks. This closes the symlink-bypass
+# class where a path like /tmp/sshlink/config (sshlink -> ~/.ssh) does
+# not textually match ^$HOME/.ssh/ but resolves to a protected target.
 
 MATCHED_RULE=""
+MATCHED_PATH=""
 
-# Basename check: match against both absolute form and basename to catch
-# relative paths (./.env) and absolute paths (/project/.env) uniformly.
-for pat in "${BASENAME_DENY[@]}"; do
-  if printf '%s' "$FILE_PATH" | grep -qE -- "$pat"; then
-    MATCHED_RULE="secret_basename:$pat"
-    break
-  fi
-done
-
-# Path-prefix check only if basename did not match. Prefix patterns are
-# tighter so they rarely overlap; short-circuit keeps the message simple.
-if [ -z "$MATCHED_RULE" ]; then
-  for pat in "${PATH_PREFIX_DENY[@]}"; do
-    if printf '%s' "$FILE_PATH" | grep -qE -- "$pat"; then
-      MATCHED_RULE="system_path:$pat"
-      break
+check_path() {
+  local p="$1" pat
+  for pat in "${BASENAME_DENY[@]}"; do
+    if printf '%s' "$p" | grep -qE -- "$pat"; then
+      MATCHED_RULE="secret_basename:$pat"
+      MATCHED_PATH="$p"
+      return 0
     fi
   done
+  for pat in "${PATH_PREFIX_DENY[@]}"; do
+    if printf '%s' "$p" | grep -qE -- "$pat"; then
+      MATCHED_RULE="system_path:$pat"
+      MATCHED_PATH="$p"
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_path "$FILE_PATH"
+if [ -z "$MATCHED_RULE" ] && [ -n "$RESOLVED_PATH" ] && [ "$RESOLVED_PATH" != "$FILE_PATH" ]; then
+  check_path "$RESOLVED_PATH"
 fi
 
 if [ -n "$MATCHED_RULE" ]; then
@@ -139,6 +175,8 @@ if [ -n "$MATCHED_RULE" ]; then
 BLOCKED [W-001] Write or Edit to a protected path
 Category: ${MATCHED_RULE%%:*}
 Path:     $FILE_PATH
+Resolved: $RESOLVED_PATH
+Matched:  $MATCHED_PATH
 Rule:     ${MATCHED_RULE#*:}
 
 This file holds secrets or system state. Coding agents should not

--- a/guard/rules.json
+++ b/guard/rules.json
@@ -242,10 +242,17 @@
         },
         {
           "id": "G-030",
-          "pattern": "(cat|less|head|tail|vi|vim|nano|code)\\s+.*\\.(env|pem|key|credentials|keystore)",
+          "pattern": "(cat|less|more|view|head|tail|vi|vim|nano|code|grep|egrep|fgrep|rg|ag|jq|yq|awk|sed|od|xxd|hexdump|strings|sort|uniq|wc|file|stat|tr)\\s+([^|;]*\\s)?[^|;]*\\.(env|env\\.[a-z]+|pem|key|p12|pfx|credentials|keystore|secrets)([[:space:]]|$)",
           "category": "secrets-access",
           "description": "Reading or editing secrets files directly",
-          "alternative": "Use the project's secrets management or read specific non-secret fields with jq/grep"
+          "alternative": "Use the project's secrets management. Do not read .env or key files into the agent transcript at all."
+        },
+        {
+          "id": "G-031",
+          "pattern": "(^|[[:space:]]|;|&&|\\|\\|)(env|printenv)([[:space:]]*$|[[:space:]]*\\|)",
+          "category": "secrets-access",
+          "description": "Dumping environment variables (may contain credentials)",
+          "alternative": "Read the specific variable you need with echo \"$VAR_NAME\". Do not pipe full env into the model."
         },
         {
           "id": "G-031",


### PR DESCRIPTION
## Summary

Round 4 audit (2026-04-25) found two distinct paths to a protected target that the existing rules did not catch.

### 1. Symlink bypass in `check-write.sh`

A repo-controlled symlink like `/tmp/sshlink -> ~/.ssh` let `Write` to `/tmp/sshlink/config` slip past the prefix match for `^$HOME/.ssh/`. Same for symlinks pointing at `/etc`, `/var`, or any other protected prefix.

**Fix:** resolve the path with `realpath -m` (or `--canonicalize-missing`) and apply the denylist to both the original and resolved form. Either match blocks. Pure-bash fallback uses `cd parent + pwd -P + basename` so it still follows symlinks at the parent level when realpath is unavailable.

### 2. Allowlisted readers reaching secrets

`G-030` covered `cat`/`less`/`head`/`tail`/`vi`/`vim`/`nano`/`code` on `.env`/`.pem`/`.key`. It did not cover `grep`/`rg`/`ag`/`jq`/`yq`/`awk`/`sed`/`od`/`xxd`/`hexdump`/`strings`/`sort`/`uniq`/`wc`/`file`/`stat`/`tr`. Each leaks the file into the agent transcript just as effectively.

**Fix:** broaden G-030 to cover all those readers. New G-031 covers `env` / `printenv` when invoked standalone or piped. `env VAR=value cmd` (a legitimate one-shot variable-set) is left allowed.

## CI matrix additions

**guard-regression** (now 35 cases total):

- 9 new block cases: `grep SECRET .env`, `rg SECRET .env`, `jq . .env`, `awk /=/ .env`, `sed s/x/y/ .env.production`, `strings secrets.pem`, `env`, `printenv`, `env | grep PATH`.
- 4 new allow cases: `env VAR=val cmd`, `envsubst < template`, `jq . package.json`, `awk NR==1 file.csv`.

**write-guard-regression**:

- New symlink-block case: `etclink -> /etc` then writing to `etclink/passwd` must block.
- New symlink-allow regression: `safelink -> $RUNNER_TEMP` then writing to `safelink/notes.txt` must pass.

## Verification

| Class | Result |
|---|---|
| Symlink to `~/.ssh` | now blocks (was allow) |
| Symlink to `/etc` | now blocks (was allow) |
| `grep SECRET .env` | now blocks |
| `env`, `printenv` standalone | now blocks |
| `env VAR=value cmd` | still allowed |
| `cat README.md`, `grep foo file.txt` | still allowed |
| `tests/run.sh` | 44/44 pass |
| Em-dash, YAML lint | pass |

## Related

Internal audit, 2026-04-25, round 4. Addresses P1 "Write/Edit guard bypass por symlinks" and P2 "Secrets aún se pueden leer con comandos allowlisted".