### PR TITLE
nano-doctor --fix wires missing hooks; JSON output keeps pipes intact

### DIFF
--- a/bin/nano-doctor.sh
+++ b/bin/nano-doctor.sh
@@ -55,9 +55,15 @@ NANO_WORKER_URL="${NANO_WORKER_URL:-https://nanostack-telemetry.remoto.workers.d
 
 # ─── Check registry ────────────────────────────────────────────────────
 # Each check appends a line to CHECK_LINES of the form:
-#   <status>|<category>|<name>|<detail>
+#   <status>\t<category>\t<name>\t<detail>
+# Uses a tab separator instead of `|` so detail strings that include the
+# pipe character (e.g. "Write|Edit|MultiEdit", "curl | sh") survive the
+# round-trip into the JSON output without being truncated. Round 4
+# audit caught this on a settings file with no hooks: the JSON detail
+# ended at "Add the Write" because awk -F'|' split on the first |.
 # status: pass | warn | fail
 
+_NANO_DOCTOR_SEP=$'\t'
 CHECK_LINES=""
 FIX_LINES=""
 PASS=0
@@ -66,7 +72,7 @@ FAIL=0
 
 add_check() {
   local status="$1" category="$2" name="$3" detail="$4"
-  CHECK_LINES="$CHECK_LINES$status|$category|$name|$detail
+  CHECK_LINES="$CHECK_LINES$status$_NANO_DOCTOR_SEP$category$_NANO_DOCTOR_SEP$name$_NANO_DOCTOR_SEP$detail
 "
   case "$status" in
     pass) PASS=$((PASS + 1)) ;;
@@ -364,23 +370,102 @@ else
   fi
 fi
 
+# ─── 8. Hook wire-up under --fix ───────────────────────────────────────
+# When the user passes --fix and the bash_guard or write_guard rows
+# warned, write the missing PreToolUse entry into the local
+# .claude/settings.json. Round 4 audit asked for migration to be a
+# guided action, not "edit JSON by hand". This runs ONLY against the
+# project-local settings (not ~/.claude/settings.json) and only after
+# making a timestamped backup. jq merges into existing hooks rather
+# than replacing them.
+
+if $FIX_MODE && command -v jq >/dev/null 2>&1; then
+  _local_settings=".claude/settings.json"
+  if [ -f "$_local_settings" ]; then
+    _need_bash=0
+    _need_write=0
+    if ! jq -e '
+      (.hooks.PreToolUse // [])
+      | any(
+          (.matcher // "" | test("Bash"))
+          and ((.hooks // []) | any((.command // "") | contains("check-dangerous.sh")))
+        )
+    ' "$_local_settings" >/dev/null 2>&1; then
+      _need_bash=1
+    fi
+    if ! jq -e '
+      (.hooks.PreToolUse // [])
+      | any(
+          (.matcher // "" | test("Write|Edit"))
+          and ((.hooks // []) | any((.command // "") | contains("check-write.sh")))
+        )
+    ' "$_local_settings" >/dev/null 2>&1; then
+      _need_write=1
+    fi
+
+    if [ "$_need_bash" -eq 1 ] || [ "$_need_write" -eq 1 ]; then
+      _backup="$_local_settings.$(date +%Y%m%d-%H%M%S).bak"
+      if cp "$_local_settings" "$_backup" 2>/dev/null; then
+        _bashcmd="$HOME/.claude/skills/nanostack/guard/bin/check-dangerous.sh"
+        _writecmd="$HOME/.claude/skills/nanostack/guard/bin/check-write.sh"
+        _tmp="$_local_settings.tmp.$$"
+        if jq \
+            --arg bashcmd "$_bashcmd" \
+            --arg writecmd "$_writecmd" \
+            --argjson need_bash "$_need_bash" \
+            --argjson need_write "$_need_write" '
+          .hooks //= {}
+          | .hooks.PreToolUse //= []
+          | if $need_bash == 1 then
+              .hooks.PreToolUse += [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": $bashcmd}]
+              }]
+            else . end
+          | if $need_write == 1 then
+              .hooks.PreToolUse += [{
+                "matcher": "Write|Edit|MultiEdit",
+                "hooks": [{"type": "command", "command": $writecmd}]
+              }]
+            else . end
+        ' "$_local_settings" > "$_tmp" 2>/dev/null && mv "$_tmp" "$_local_settings"; then
+          _added=""
+          [ "$_need_bash" -eq 1 ] && _added="Bash"
+          [ "$_need_write" -eq 1 ] && _added="${_added:+$_added + }Write|Edit|MultiEdit"
+          add_fix "Wired $_added PreToolUse hook(s) into $_local_settings (backup: $_backup). Restart your agent to apply."
+        else
+          rm -f "$_tmp" 2>/dev/null
+          add_fix "Tried to wire hooks into $_local_settings but jq merge failed. Restored from backup not needed (original untouched)."
+        fi
+      else
+        add_fix "Tried to wire hooks but could not write backup of $_local_settings. Skipped."
+      fi
+    fi
+  fi
+fi
+
 # ─── Output ────────────────────────────────────────────────────────────
 
 if $JSON_OUTPUT; then
-  # Emit a JSON document with per-check rows and a summary.
-  _checks_json=$(printf '%s' "$CHECK_LINES" | awk -F'|' -v OFS='' '
-    /^$/ { next }
-    {
-      gsub(/"/, "\\\"", $4)
-      printf "%s{\"status\":\"%s\",\"category\":\"%s\",\"name\":\"%s\",\"detail\":\"%s\"}", (NR>1?",":""), $1, $2, $3, $4
-    }
-  ')
+  # Build the entire envelope with jq. Tab-separated CHECK_LINES split
+  # cleanly even when detail strings contain pipes or quotes. Round 4
+  # audit caught the previous awk -F'|' truncating "Write|Edit|MultiEdit"
+  # at the first |; jq -R -s split keeps the field intact.
   _overall="pass"
   if [ "$FAIL" -gt 0 ]; then _overall="fail"
   elif [ "$WARN" -gt 0 ]; then _overall="warn"
   fi
-  printf '{"overall":"%s","pass":%d,"warn":%d,"fail":%d,"checks":[%s]}\n' \
-    "$_overall" "$PASS" "$WARN" "$FAIL" "$_checks_json"
+  printf '%s' "$CHECK_LINES" | jq -R -s \
+    --arg overall "$_overall" \
+    --argjson pass "$PASS" \
+    --argjson warn "$WARN" \
+    --argjson fail "$FAIL" '
+      split("\n")
+      | map(select(length > 0))
+      | map(split("\t"))
+      | map({status:.[0], category:.[1], name:.[2], detail:.[3]}) as $checks
+      | {overall:$overall, pass:$pass, warn:$warn, fail:$fail, checks:$checks}
+    '
 else
   # Human-readable report.
   echo ""
@@ -392,7 +477,7 @@ else
   echo "  pass: $PASS  warn: $WARN  fail: $FAIL"
   echo "============================================"
   _last_cat=""
-  printf '%s' "$CHECK_LINES" | while IFS='|' read -r status category name detail; do
+  printf '%s' "$CHECK_LINES" | while IFS=$'\t' read -r status category name detail; do
     [ -z "$status" ] && continue
     if [ "$category" != "$_last_cat" ]; then
       echo ""

--- a/doctor/SKILL.md
+++ b/doctor/SKILL.md
@@ -35,7 +35,7 @@ Optional flags:
 
 - `--json` — machine-readable output. Use when invoked by another tool or when piping to `jq`.
 - `--offline` — skip Worker reachability. Use in air-gapped environments or during CI.
-- `--fix` — repair mechanical issues (`chmod 700` on `~/.nanostack/`, `chmod +x` on the sender). Never touches config or data.
+- `--fix` — repair mechanical issues. Currently covers: `chmod 700` on `~/.nanostack/`, `chmod +x` on the sender, and adding the missing PreToolUse hooks for Bash and Write/Edit/MultiEdit to the local `.claude/settings.json`. Always backs up the file first as `.claude/settings.json.YYYYMMDD-HHMMSS.bak`. Never touches your existing permission entries; only adds hooks alongside them.
 
 ## Interpreting the output
 
@@ -55,7 +55,7 @@ Exit codes:
 
 ## When to recommend `--fix`
 
-If the report shows warnings for `home permissions` or `sender_executable`, re-run with `--fix`. For any other warning or failure, surface the detail to the user and let them decide. Do NOT try to fix missing dependencies, missing VERSION files, or misconfigured tiers automatically.
+If the report shows warnings for `home permissions`, `sender_executable`, `bash_guard`, or `write_guard`, re-run with `--fix`. The `--fix` mode handles those four mechanically and leaves a backup. For any other warning or failure (missing VERSION, broad `Bash(rm:*)`, broken telemetry tier), surface the detail to the user and let them decide. Do NOT try to fix missing dependencies or rewrite permission lists automatically.
 
 ## When to recommend a reinstall
 


### PR DESCRIPTION
## Summary

Round 4 audit (2026-04-25) flagged two UX gaps in `nano-doctor`. Both fixed here.

### 1. JSON output truncated detail strings at the first `|`

`CHECK_LINES` used `|` as a field separator, then `awk -F'|'` split on it. Detail messages that contain `|` (`Write|Edit|MultiEdit`, `curl | sh`, ...) got cut at the first pipe. The machine-readable diagnosis lost exactly the remediation text the user needed.

**Fix:** switch the separator to tab, replace the awk + manual escape with a single `jq -R -s` expression that builds the envelope. All detail strings round-trip cleanly.

| Before | After |
|---|---|
| `"check-write.sh NOT wired. Add the Write"` | `"check-write.sh NOT wired. Add the Write\|Edit\|MultiEdit matcher from SECURITY.md 'Manual wire-up'."` |

### 2. Existing installs needed manual JSON surgery

Old flow: `nano-doctor` warns, user opens `.claude/settings.json`, copies the block from `SECURITY.md`, hopes the JSON parses, restarts the agent. Hard ask for non-technical users.

**New flow:** `nano-doctor --fix` detects which hooks are missing, backs up `.claude/settings.json` with a timestamped `.YYYYMMDD-HHMMSS.bak` suffix, then merges the matchers in via `jq`. Existing hooks and permissions stay untouched. Idempotent: a second `--fix` on already-wired settings does nothing and creates no extra backup.

The user's permission entries are never rewritten. `Bash(rm:*)` etc. survive the migration; the catastrophic gap (broad perm + no hook) closes in one command.

## Test plan

- [x] JSON output: `Write|Edit|MultiEdit` and `curl | sh` survive intact in `.checks[].detail`.
- [x] `--fix` on legacy settings (broad rm + `Write(*)` + `Edit(*)`, no hooks): writes backup, merges both matchers, leaves permissions alone.
- [x] After `--fix`: `bash_guard`, `write_guard`, `write_scope`, `allowlist_scope` all pass; `rm_scope` still warns with the softer "guard wired so it is still blocked" message.
- [x] `--fix` on already-wired settings: no backup, no modification.
- [x] `bash -n` passes.
- [x] `tests/run.sh` 44/44.
- [x] Em-dash lint passes.

## Related

Internal audit, 2026-04-25, round 4. Addresses P2 "nano-doctor JSON trunca detalles" and the migration side of P1 "Upgrades no migran instalaciones existentes".