### PR TITLE
Make /feature autopilot explicit, refresh guard docs, name agent gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,19 +411,25 @@ AI agents make mistakes. They run `rm -rf` when they mean `rm -r`, force push to
 
 ### Six tiers
 
-Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through six tiers:
+Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every Bash command through six tiers in this order:
 
-**Tier 1: Allowlist.** Commands like `git status`, `ls`, `cat`, `jq` skip all checks. They can't cause damage.
+**Tier 1: Block rules.** Patterns for mass deletion, history destruction, database drops, production deploys, remote code execution, secret reads, security degradation and safety bypasses run first. A match exits 1 immediately, even if the command's binary is on the allowlist below. This ordering closes the bypass class where `find . -delete` or `cat .env` slipped past Tier 2 because `find` and `cat` were on the allowlist. 35 block rules total.
 
-**Tier 2: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
+**Tier 2: Allowlist.** After block rules clear, commands like `git status`, `ls`, `cat`, `jq` skip the remaining checks. They are read-only or otherwise side-effect-free for safe arguments.
 
-**Tier 2.5: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
+**Tier 3: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
 
-**Tier 2.75: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security and qa artifacts exist and are fresher than the latest code change. This is the enforcement that prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
+**Tier 4: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
 
-**Tier 2.8: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but can't execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
+**Tier 5: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security, and qa artifacts exist and are fresher than the latest code change. This prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
 
-**Tier 3: Pattern matching.** Everything else is checked against block and warn rules. 33 block rules cover mass deletion, history destruction, database drops, production deploys, remote code execution, security degradation and safety bypasses. 9 warn rules cover operations that need attention but not blocking.
+**Tier 6: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but cannot execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
+
+Plus a Tier 7 of warn rules for operations that need attention but not blocking. 9 warn rules total.
+
+### Write and Edit are hooked too
+
+`Write`, `Edit`, and `MultiEdit` go through their own PreToolUse hook (`guard/bin/check-write.sh`) that denies a narrow list of paths: secret files (`.env` and variants, `*.pem`, `*.key`, SSH keys, shell history) and system or user-secret directories (`/etc`, `/var`, `/usr/bin`, `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.gcp`, `~/.kube`). Symlinks are resolved before matching so `mylink/config -> ~/.ssh/config` is treated as the resolved target. See [`SECURITY.md`](SECURITY.md) for the full denylist and the manual wire-up for installs that predate the hook.
 
 ### Deny-and-continue
 
@@ -452,6 +458,22 @@ All rules live in [`guard/rules.json`](guard/rules.json). Each rule has an ID, r
   "alternative": "terraform plan -destroy first to review what would be removed"
 }
 ```
+
+### What enforces on which agent
+
+Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today.
+
+| Agent | Skills | Hook enforcement | What this means |
+|---|---|---|---|
+| Claude Code | yes | yes (Bash, Write, Edit, MultiEdit) | Block rules and the Write/Edit denylist run before every tool call. The user does not have to read the rules; the hook does. |
+| Cursor | yes | no | Skills are exposed as rules text. The agent reads the rules and is expected to follow them. There is no pre-tool-use hook on Cursor today. |
+| OpenAI Codex | yes | no | Same as Cursor: instructions only. |
+| OpenCode | yes | no | Same. |
+| Gemini CLI / Antigravity / Amp / Cline | yes | no | Same. |
+
+When hooks are not available, the protection downgrades from "blocked at the system call" to "agent should know better." Run `/nano-doctor` after install on any agent to see the actual state. If you want hard enforcement, use Claude Code; if you accept agent-level discipline, the rest still ship the same workflow.
+
+This gap is the single biggest known caveat in the framework. The roadmap is to add the same enforcement layer per agent as their tooling exposes the right hooks.
 
 ## Install
 

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -39,10 +39,10 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 
 ## Session
 
-Initialize the sprint session:
+Initialize the sprint session with autopilot. The `--autopilot` flag writes `autopilot: true` into the session, which downstream skills (`/nano`, `/review`, `/security`, `/qa`, `/ship`) read to skip approval pauses. Without this flag, `/nano` would present the plan and wait for explicit approval, which contradicts the orchestrator contract below.
 
 ```bash
-~/.claude/skills/nanostack/bin/session.sh init feature
+~/.claude/skills/nanostack/bin/session.sh init feature --autopilot
 ```
 
 Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
@@ -50,6 +50,8 @@ Then run `session.sh phase-start plan`. This activates the phase gate — `git c
 ## Process
 
 You are an autonomous orchestrator. You run the entire sprint without stopping between phases. Do NOT wait for user input between steps. Do NOT ask "should I continue?" or "ready for review?". Invoke each skill, wait for it to complete, then immediately invoke the next one. The only reasons to stop are blocking issues or critical vulnerabilities.
+
+**AUTOPILOT contract for sub-skills.** The session was initialized with `--autopilot`, so `/nano`, `/review`, `/security`, `/qa`, and `/ship` all read `session.json.autopilot == true` and behave accordingly: present briefly, do not pause for approval. If you ever see one of them ask "ready to proceed?", treat it as a regression in that skill, not a signal to stop. Carry "AUTOPILOT is active" in your own context across every Skill invocation in this sprint.
 
 ### Step 1: Context
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -37,6 +37,17 @@ If the output shows `"active":false`, create a session:
 
 Then run `session.sh phase-start plan`.
 
+**AUTOPILOT detection.** This skill checks "if AUTOPILOT is active" in several places below. Treat it as active when ANY of the following is true:
+
+1. The caller (e.g. `/think --autopilot`, `/feature`) said so in context.
+2. `session.json` reports it. Verify with:
+   ```bash
+   jq -r '.autopilot // false' .nanostack/session.json 2>/dev/null
+   ```
+   `true` means autopilot. Anything else means manual.
+
+If neither is true, behave as manual: present the plan and wait for explicit approval.
+
 **Local mode:** Run `source bin/lib/git-context.sh && detect_git_mode`. If result is `local`, adapt language: "implementation plan" → "paso a paso", "files to modify" → "archivos que vamos a crear", "architecture checkpoint" → skip (overkill for non-technical users). Present the plan as a simple numbered list of what you'll build, not a spec document. Same rigor, accessible words. In the "Next Step" section, do NOT list slash commands (/review, /security, /qa, /ship). Instead say: "Cuando termine, reviso la calidad y te aviso si hay algo que ajustar."
 
 ## Process


### PR DESCRIPTION
## Summary

Round 4 audit (2026-04-25) flagged three docs and contract issues. Bundled because they touch the same conceptual area: how the workflow runs across skills and across agents.

## Changes

### 1. `/feature` contradicted the `/nano` approval gate

`feature/SKILL.md` says "I run the entire sprint without stopping" but invoked `/nano` with a plain Skill call. By default `/nano` presents the plan and waits for explicit approval, so the orchestrator either stalled or silently broke the contract.

**Fix:** session init in `feature/SKILL.md` now passes `--autopilot`. `plan/SKILL.md` gains an explicit "AUTOPILOT detection" section that names two equally valid signals: caller said so, or `session.json` reports `autopilot:true`. The session-state path makes the handoff deterministic.

### 2. README guard tier order was stale

The README described Tier 1 as "allowlist skips all checks" and Tier 3 as "pattern matching at the end". PR #139 already changed the code so block rules run BEFORE the allowlist. The stale doc trained contributors to reintroduce the bypass.

**Fix:** Guard section rewritten with the current order:

| New Tier | What |
|---|---|
| 1 | Block rules (35) |
| 2 | Allowlist |
| 3 | In-project |
| 4 | Phase-aware concurrency |
| 5 | Phase gate |
| 6 | Budget gate |

Plus a new "Write and Edit are hooked too" subsection naming `check-write.sh` and the denylist scope.

### 3. Cross-agent enforcement gap was implicit

The README listed Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, Cline. The phrasing read as if the same enforcement runs everywhere. In practice only Claude Code wires PreToolUse hooks; other agents read rules as instructions.

**Fix:** new "What enforces on which agent" subsection with a per-agent table (Skills / Hook enforcement / What this means), an honest one-paragraph caveat naming this as the single biggest known gap, and a concrete next step (run `/nano-doctor`).

## Test plan

- [x] `tests/run.sh` 44/44 pass.
- [x] Em-dash lint passes on the README diff.
- [x] Manual read: `/feature` declares autopilot at session init; `/nano` detection block names the source of truth (`session.json.autopilot`).

## Related

Internal audit, 2026-04-25, round 4. Addresses P1 "Enforcement prometido no existe igual en todos los agentes", P2 "/feature contradice la aprobación de /nano", P3 "Docs de guard describen orden obsoleto".