### PR TITLE
v0.8 Sprint 1: host adapter schema and capability files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -524,3 +524,79 @@ jobs:
           fi
           rm -rf "$tmp_link_dir"
           exit $fail
+
+  host-adapter-schema:
+    name: Host adapter schema
+    runs-on: ubuntu-latest
+    # Each adapters/*.json declares the real capability level for one
+    # host. Setup, doctor, and the README all read from these files;
+    # if the schema drifts, every downstream claim drifts with it.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate adapter files
+        run: |
+          set -e
+          fail=0
+          required='host schema_version last_verified verification skill_discovery bash_guard write_guard phase_gate install_target doctor_checks'
+          allowed_caps='unsupported instructions_only detectable hooked enforced host_dependent native rules_file skill_folder extension'
+          for f in adapters/*.json; do
+            [ -f "$f" ] || continue
+            if ! jq -e '.' "$f" >/dev/null 2>&1; then
+              echo "FAIL: $f is not valid JSON"
+              fail=1
+              continue
+            fi
+            for field in $required; do
+              if ! jq -e --arg k "$field" 'has($k)' "$f" >/dev/null 2>&1; then
+                echo "FAIL: $f missing required field '$field'"
+                fail=1
+              fi
+            done
+            expected=$(basename "$f" .json)
+            actual=$(jq -r '.host' "$f")
+            if [ "$expected" != "$actual" ]; then
+              echo "FAIL: $f declares host '$actual' but filename suggests '$expected'"
+              fail=1
+            fi
+            schema_version=$(jq -r '.schema_version' "$f")
+            if [ "$schema_version" != "1" ]; then
+              echo "FAIL: $f has schema_version '$schema_version' (expected '1')"
+              fail=1
+            fi
+            for cap_field in skill_discovery bash_guard write_guard phase_gate; do
+              val=$(jq -r --arg k "$cap_field" '.[$k]' "$f")
+              ok=0
+              for allowed in $allowed_caps; do
+                [ "$val" = "$allowed" ] && ok=1
+              done
+              if [ "$ok" -eq 0 ]; then
+                echo "FAIL: $f.$cap_field has unknown value '$val'"
+                fail=1
+              fi
+            done
+            method=$(jq -r '.verification.method' "$f")
+            case "$method" in
+              ci|manual|unknown) ;;
+              *)
+                echo "FAIL: $f.verification.method is '$method' (expected ci|manual|unknown)"
+                fail=1 ;;
+            esac
+            evidence=$(jq -r '.verification.evidence // ""' "$f")
+            if [ -z "$evidence" ]; then
+              echo "FAIL: $f.verification.evidence is empty"
+              fail=1
+            fi
+          done
+          # Filename uniqueness: every JSON in adapters/ must be a real
+          # adapter file (no leftovers).
+          for f in adapters/*.json; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f" .json)
+            case "$base" in
+              claude|codex|cursor|opencode|gemini) ;;
+              *) echo "WARN: $f is for an unknown host '$base'" ;;
+            esac
+          done
+          exit $fail

--- a/README.md
+++ b/README.md
@@ -411,19 +411,25 @@ AI agents make mistakes. They run `rm -rf` when they mean `rm -r`, force push to
 
 ### Six tiers
 
-Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every command through six tiers:
+Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every Bash command through six tiers in this order:
 
-**Tier 1: Allowlist.** Commands like `git status`, `ls`, `cat`, `jq` skip all checks. They can't cause damage.
+**Tier 1: Block rules.** Patterns for mass deletion, history destruction, database drops, production deploys, remote code execution, secret reads, security degradation and safety bypasses run first. A match exits 1 immediately, even if the command's binary is on the allowlist below. This ordering closes the bypass class where `find . -delete` or `cat .env` slipped past Tier 2 because `find` and `cat` were on the allowlist. 35 block rules total.
 
-**Tier 2: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
+**Tier 2: Allowlist.** After block rules clear, commands like `git status`, `ls`, `cat`, `jq` skip the remaining checks. They are read-only or otherwise side-effect-free for safe arguments.
 
-**Tier 2.5: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
+**Tier 3: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
 
-**Tier 2.75: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security and qa artifacts exist and are fresher than the latest code change. This is the enforcement that prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
+**Tier 4: Phase-aware concurrency.** During read-only phases (review, qa, security), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
 
-**Tier 2.8: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but can't execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
+**Tier 5: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security, and qa artifacts exist and are fresher than the latest code change. This prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
 
-**Tier 3: Pattern matching.** Everything else is checked against block and warn rules. 33 block rules cover mass deletion, history destruction, database drops, production deploys, remote code execution, security degradation and safety bypasses. 9 warn rules cover operations that need attention but not blocking.
+**Tier 6: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but cannot execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
+
+Plus a Tier 7 of warn rules for operations that need attention but not blocking. 9 warn rules total.
+
+### Write and Edit are hooked too
+
+`Write`, `Edit`, and `MultiEdit` go through their own PreToolUse hook (`guard/bin/check-write.sh`) that denies a narrow list of paths: secret files (`.env` and variants, `*.pem`, `*.key`, SSH keys, shell history) and system or user-secret directories (`/etc`, `/var`, `/usr/bin`, `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.gcp`, `~/.kube`). Symlinks are resolved before matching so `mylink/config -> ~/.ssh/config` is treated as the resolved target. See [`SECURITY.md`](SECURITY.md) for the full denylist and the manual wire-up for installs that predate the hook.
 
 ### Deny-and-continue
 
@@ -452,6 +458,22 @@ All rules live in [`guard/rules.json`](guard/rules.json). Each rule has an ID, r
   "alternative": "terraform plan -destroy first to review what would be removed"
 }
 ```
+
+### What enforces on which agent
+
+Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today.
+
+| Agent | Skills | Hook enforcement | What this means |
+|---|---|---|---|
+| Claude Code | yes | yes (Bash, Write, Edit, MultiEdit) | Block rules and the Write/Edit denylist run before every tool call. The user does not have to read the rules; the hook does. |
+| Cursor | yes | no | Skills are exposed as rules text. The agent reads the rules and is expected to follow them. There is no pre-tool-use hook on Cursor today. |
+| OpenAI Codex | yes | no | Same as Cursor: instructions only. |
+| OpenCode | yes | no | Same. |
+| Gemini CLI / Antigravity / Amp / Cline | yes | no | Same. |
+
+When hooks are not available, the protection downgrades from "blocked at the system call" to "agent should know better." Run `/nano-doctor` after install on any agent to see the actual state. If you want hard enforcement, use Claude Code; if you accept agent-level discipline, the rest still ship the same workflow.
+
+This gap is the single biggest known caveat in the framework. The roadmap is to add the same enforcement layer per agent as their tooling exposes the right hooks.
 
 ## Install
 

--- a/adapters/claude.json
+++ b/adapters/claude.json
@@ -1,0 +1,15 @@
+{
+  "host": "claude",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "ci",
+    "evidence": ".github/workflows/lint.yml: guard-regression and write-guard-regression jobs exercise check-dangerous.sh and check-write.sh on every PR"
+  },
+  "skill_discovery": "native",
+  "bash_guard": "enforced",
+  "write_guard": "enforced",
+  "phase_gate": "enforced",
+  "install_target": ".claude/settings.json",
+  "doctor_checks": ["hooks", "permissions", "commands"]
+}

--- a/adapters/codex.json
+++ b/adapters/codex.json
@@ -1,0 +1,15 @@
+{
+  "host": "codex",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "manual",
+    "evidence": "setup install_codex symlinks skill directories under ~/.codex/skills/nanostack-<skill> but does not register any pre-action hook. Verified by reading setup lines 401-427 on 2026-04-25."
+  },
+  "skill_discovery": "native",
+  "bash_guard": "instructions_only",
+  "write_guard": "instructions_only",
+  "phase_gate": "instructions_only",
+  "install_target": "~/.codex/skills/nanostack",
+  "doctor_checks": ["commands"]
+}

--- a/adapters/cursor.json
+++ b/adapters/cursor.json
@@ -1,0 +1,15 @@
+{
+  "host": "cursor",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "manual",
+    "evidence": "setup install_cursor writes a single rules file at .cursor/rules/nanostack.md telling the agent to read SKILL.md files. No PreToolUse hook integration is configured. Verified by reading setup lines 429-451 on 2026-04-25."
+  },
+  "skill_discovery": "rules_file",
+  "bash_guard": "instructions_only",
+  "write_guard": "instructions_only",
+  "phase_gate": "instructions_only",
+  "install_target": ".cursor/rules/nanostack.md",
+  "doctor_checks": ["commands"]
+}

--- a/adapters/gemini.json
+++ b/adapters/gemini.json
@@ -1,0 +1,15 @@
+{
+  "host": "gemini",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "manual",
+    "evidence": "setup install_gemini installs nanostack as a Gemini extension. The extension exposes skills but does not register PreToolUse hooks for shell or write actions. Verified by reading setup lines 466-477 on 2026-04-25."
+  },
+  "skill_discovery": "extension",
+  "bash_guard": "instructions_only",
+  "write_guard": "instructions_only",
+  "phase_gate": "instructions_only",
+  "install_target": "gemini extension",
+  "doctor_checks": ["commands"]
+}

--- a/adapters/opencode.json
+++ b/adapters/opencode.json
@@ -1,0 +1,15 @@
+{
+  "host": "opencode",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "manual",
+    "evidence": "setup install_opencode symlinks the source dir under ~/.agents/skills/nanostack. OpenCode reads the skill folder natively but no pre-action hook integration exists. Verified by reading setup lines 453-464 on 2026-04-25."
+  },
+  "skill_discovery": "skill_folder",
+  "bash_guard": "instructions_only",
+  "write_guard": "instructions_only",
+  "phase_gate": "instructions_only",
+  "install_target": "~/.agents/skills/nanostack",
+  "doctor_checks": ["commands"]
+}

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -39,10 +39,10 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 
 ## Session
 
-Initialize the sprint session:
+Initialize the sprint session with autopilot. The `--autopilot` flag writes `autopilot: true` into the session, which downstream skills (`/nano`, `/review`, `/security`, `/qa`, `/ship`) read to skip approval pauses. Without this flag, `/nano` would present the plan and wait for explicit approval, which contradicts the orchestrator contract below.
 
 ```bash
-~/.claude/skills/nanostack/bin/session.sh init feature
+~/.claude/skills/nanostack/bin/session.sh init feature --autopilot
 ```
 
 Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
@@ -50,6 +50,8 @@ Then run `session.sh phase-start plan`. This activates the phase gate — `git c
 ## Process
 
 You are an autonomous orchestrator. You run the entire sprint without stopping between phases. Do NOT wait for user input between steps. Do NOT ask "should I continue?" or "ready for review?". Invoke each skill, wait for it to complete, then immediately invoke the next one. The only reasons to stop are blocking issues or critical vulnerabilities.
+
+**AUTOPILOT contract for sub-skills.** The session was initialized with `--autopilot`, so `/nano`, `/review`, `/security`, `/qa`, and `/ship` all read `session.json.autopilot == true` and behave accordingly: present briefly, do not pause for approval. If you ever see one of them ask "ready to proceed?", treat it as a regression in that skill, not a signal to stop. Carry "AUTOPILOT is active" in your own context across every Skill invocation in this sprint.
 
 ### Step 1: Context
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -37,6 +37,17 @@ If the output shows `"active":false`, create a session:
 
 Then run `session.sh phase-start plan`.
 
+**AUTOPILOT detection.** This skill checks "if AUTOPILOT is active" in several places below. Treat it as active when ANY of the following is true:
+
+1. The caller (e.g. `/think --autopilot`, `/feature`) said so in context.
+2. `session.json` reports it. Verify with:
+   ```bash
+   jq -r '.autopilot // false' .nanostack/session.json 2>/dev/null
+   ```
+   `true` means autopilot. Anything else means manual.
+
+If neither is true, behave as manual: present the plan and wait for explicit approval.
+
 **Local mode:** Run `source bin/lib/git-context.sh && detect_git_mode`. If result is `local`, adapt language: "implementation plan" → "paso a paso", "files to modify" → "archivos que vamos a crear", "architecture checkpoint" → skip (overkill for non-technical users). Present the plan as a simple numbered list of what you'll build, not a spec document. Same rigor, accessible words. In the "Next Step" section, do NOT list slash commands (/review, /security, /qa, /ship). Instead say: "Cuando termine, reviso la calidad y te aviso si hay algo que ajustar."
 
 ## Process

--- a/reference/agent-agnostic-delivery-spec.md
+++ b/reference/agent-agnostic-delivery-spec.md
@@ -1,0 +1,780 @@
+# SPEC: Agent-Agnostic Delivery Workflow
+
+## Status
+
+Draft for implementation planning.
+
+## Positioning
+
+Nanostack is an AI coding agent team skills layer for the full engineering workflow.
+
+It turns a single coding agent into a repeatable delivery process: idea challenge, planning, implementation, review, security, QA, shipping, and learning capture.
+
+The product must work for two audiences:
+
+- Technical users who want stricter delivery quality without building their own process.
+- Non-technical users who want professional outcomes without needing to understand git, hooks, CI, artifacts, or security jargon.
+
+The product must be agent-agnostic. Claude Code can be the strongest first adapter, but the architecture cannot assume Claude Code semantics are universal.
+
+## Problem
+
+Nanostack was built primarily through Claude Code and Opus, so the current product shape inherits Claude-specific assumptions:
+
+- Hooks are treated as if every agent can enforce them.
+- Slash-command skill invocation is treated as universal.
+- The docs sometimes say "enforced" when another host only receives instructions.
+- Users upgrading from older installs get warnings instead of a safe migration path.
+- Non-technical users are still exposed to implementation concepts such as artifacts, JSON, hooks, PRs, CI, and phase names.
+
+This creates a trust gap. The product promises professional delivery, but the actual guarantees vary by host and install path.
+
+## Product Goal
+
+Make Nanostack feel like a professional delivery partner, not a folder of prompts.
+
+The user should experience:
+
+1. "I say what I need."
+2. "The agent challenges scope when useful."
+3. "The agent builds the smallest correct version."
+4. "Review, security, and QA happen automatically or visibly."
+5. "The result is delivered with proof."
+6. "If something is unsafe or unsupported, Nanostack says so plainly."
+
+The implementation should make guarantees deterministic where possible and honest where not possible.
+
+## Non-Goals
+
+- Do not build a SaaS control plane.
+- Do not require users to adopt one specific coding agent.
+- Do not hide advanced controls from technical users.
+- Do not claim host-level enforcement where the host adapter cannot provide it.
+- Do not turn Nanostack into a heavy framework with a daemon requirement.
+
+## Core Principle
+
+Every promise must map to a capability level.
+
+| Level | Name | Meaning | User-facing wording |
+|---|---|---|---|
+| L0 | Instructions only | Agent is told what to do, but nothing enforces it. | "Guided" |
+| L1 | Detectable | Nanostack can inspect state and report issues. | "Checked" |
+| L2 | Hooked | Host runs Nanostack before actions. | "Guarded" |
+| L3 | Enforced | Nanostack can block unsafe actions deterministically. | "Blocked when unsafe" |
+| L4 | CI-asserted | CI or local tests prove the guarantee still holds in this release. | "Continuously verified" |
+
+Marketing, README tables, doctor output, and onboarding must use these terms consistently.
+
+## User Personas
+
+### Non-Technical Builder
+
+Wants an app, landing page, automation, internal tool, or prototype. Does not want to learn git, CI, or security process.
+
+Needs:
+
+- Plain-language flow.
+- One obvious next action.
+- Visible proof that the result works.
+- Safe defaults.
+- No manual JSON editing.
+
+Success:
+
+- User says what they want.
+- Nanostack builds and shows how to try it.
+- Security/QA results are summarized as "safe to try", "needs fix", or "not verified".
+
+### Technical Builder
+
+Already uses agents daily. Wants a stronger process and fewer skipped steps.
+
+Needs:
+
+- Inspectable artifacts.
+- CI-friendly scripts.
+- Strict guardrails.
+- Fast mode for small changes.
+- Escape hatches with explicit risk labels.
+
+Success:
+
+- User can wire Nanostack into existing repo workflows.
+- Review/security/QA output is actionable.
+- CI catches regressions in the process itself.
+
+### Team Lead / Founder
+
+Wants consistent delivery quality from agents or junior builders.
+
+Needs:
+
+- Repeatable workflow.
+- Evidence trail.
+- Shareable briefs and sprint journals.
+- Clear risk language.
+- Compatibility matrix across agents.
+
+Success:
+
+- They can say which guarantees exist in each environment.
+- They can trust a sprint journal as a delivery record.
+
+## Product Modes
+
+### Guided Mode
+
+Default for non-technical projects and for any host whose adapter cannot enforce hooks.
+
+Guided Mode is about the user's experience and the trust level of the host. It can exist inside a git repo.
+
+Behavior:
+
+- Avoid slash-command lists unless asked.
+- Avoid git, PR, branch, diff, artifact, hook, CI language.
+- Say what the user has, how to try it, and what remains unverified.
+- Use progressive disclosure.
+
+Example close:
+
+> Listo. Ya tenes la version inicial. Para verla, abri `index.html`. Revise que carga, que el boton principal funciona y que no hay secretos expuestos. Queda pendiente publicarla.
+
+### Professional Mode
+
+Default for git projects with technical signals.
+
+Behavior:
+
+- Show phases and evidence.
+- Include commands, files, test results, PR status.
+- Use review/security/QA terminology.
+- Preserve strict gates.
+
+### Autopilot Mode
+
+Runs end to end after initial alignment.
+
+Autopilot must be explicit in session state and inherited by child phases. A phase cannot infer autopilot from prose alone.
+
+### Report-Only Mode
+
+For audits and review without changes.
+
+Behavior:
+
+- No file edits.
+- Findings first.
+- Each finding has proof and fix direction.
+
+## Architecture
+
+```
+User intent
+  |
+  v
+Nanostack Skill Layer
+  |-- think
+  |-- nano
+  |-- build handoff
+  |-- review
+  |-- security
+  |-- qa
+  |-- ship
+  |-- compound
+  |
+  v
+Workflow Core
+  |-- session state
+  |-- artifact store
+  |-- resolver
+  |-- phase gate
+  |-- doctor
+  |-- telemetry client
+  |
+  v
+Host Adapter Layer
+  |-- Claude Code adapter
+  |-- Codex adapter
+  |-- Cursor adapter
+  |-- OpenCode adapter
+  |-- Gemini adapter
+  |
+  v
+Host capabilities
+  |-- skill discovery
+  |-- pre-action hooks
+  |-- file write interception
+  |-- shell command interception
+```
+
+Subagent orchestration and browser QA may become adapter capabilities later, but they are out of the first adapter schema until a script consumes them.
+
+## Host Adapter Contract
+
+Each host adapter must declare capabilities in a machine-readable file.
+
+Proposed file:
+
+```json
+{
+  "host": "claude",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "ci|manual|unknown",
+    "evidence": "path or command that proved the claim"
+  },
+  "skill_discovery": "native",
+  "bash_guard": "enforced",
+  "write_guard": "enforced",
+  "phase_gate": "enforced",
+  "install_target": ".claude/settings.json",
+  "doctor_checks": ["hooks", "permissions", "commands"]
+}
+```
+
+Capability values:
+
+- `unsupported`
+- `instructions_only`
+- `detectable`
+- `hooked`
+- `enforced`
+- `host_dependent`
+
+Nanostack must never print "enforced" for a host whose adapter reports `instructions_only`.
+
+Adapter files are declarations, not eternal truth. They must include `last_verified`, and CI should validate any host capability that can be checked locally. If install-time observation contradicts the file, doctor/setup must report the observed lower capability instead of repeating the stale declaration.
+
+## Current Capability Target
+
+| Host | Skill discovery | Bash guard | Write/Edit guard | Phase gate | Product wording |
+|---|---:|---:|---:|---:|---|
+| Claude Code | Native | Enforced | Enforced | Enforced | Full guard support |
+| Codex | Native skill files | Unknown / adapter needed | Unknown / adapter needed | Instruction-only unless adapter exists | Guided workflow |
+| Cursor | Rules file | Instruction-only | Instruction-only | Instruction-only | Guided workflow |
+| OpenCode | Skill folder | Unknown / adapter needed | Unknown / adapter needed | Instruction-only unless adapter exists | Guided workflow |
+| Gemini CLI | Extension | Unknown / adapter needed | Unknown / adapter needed | Instruction-only unless adapter exists | Guided workflow |
+
+This table is a product requirement, not a permanent limitation. The next release should replace "unknown" with verified adapter behavior.
+
+## Delivery Guarantees
+
+### Guaranteed Only When Host Supports Hooks
+
+- Blocking destructive shell commands.
+- Blocking unsafe Write/Edit destinations.
+- Blocking commits before review/security/QA.
+- Budget gate hard stop.
+- Read-only phase write blocking.
+
+### Always Available
+
+- Skill instructions.
+- Artifact saving.
+- Resolver context.
+- Review/security/QA reports.
+- Sprint journal.
+- Doctor diagnostics.
+- Local scripts run manually by user or agent.
+
+### Must Be Reworded
+
+Current wording like "Every step is enforced" should become:
+
+> Nanostack enforces the workflow when your agent supports hooks. Otherwise it guides the workflow and tells you which protections are advisory.
+
+## Installation Flow
+
+### Fresh Install
+
+1. Detect host.
+2. Install skills.
+3. Install host adapter if available.
+4. Run `nano-doctor --json`.
+5. Show one result:
+   - Full protection enabled.
+   - Guided mode enabled, protection advisory.
+   - Install incomplete, fix required.
+
+For non-technical users, do not print a long command list by default.
+
+### Project Init
+
+`init-project.sh` should be idempotent and safe for both fresh and existing settings.
+
+Required behavior:
+
+- Create `.nanostack/`.
+- Create `.claude/settings.json` when missing.
+- Merge hooks into existing `.claude/settings.json` with a backup.
+- Narrow broad permissions when user passes `--migrate-permissions`.
+- Print plain-language outcome.
+
+Proposed flags:
+
+```bash
+bin/init-project.sh --check
+bin/init-project.sh --migrate-hooks
+bin/init-project.sh --migrate-permissions
+bin/init-project.sh --repair
+```
+
+`--repair` should:
+
+- Back up current settings.
+- Add missing hooks.
+- Add narrow rm rules.
+- Leave broad entries untouched unless `--migrate-permissions` is present.
+- Re-run doctor.
+
+### Upgrade
+
+`upgrade.sh` should not stop at pulling files.
+
+Required post-upgrade flow:
+
+1. Pull/update Nanostack.
+2. Re-run setup for installed hosts.
+3. Check only the current project unless the user explicitly opted into a project registry.
+4. Tell user:
+   - "Nanostack updated."
+   - "Your current project still needs hook migration."
+   - "Run: `bin/init-project.sh --repair`."
+
+For non-technical flows, `/nano-doctor` should offer to run repair rather than asking the user to edit JSON.
+
+Privacy constraint: Nanostack should not maintain a central list of user projects by default. A project registry such as `~/.nanostack/projects.json` is allowed only with explicit opt-in during project init.
+
+## Safety Model
+
+### Bash Guard
+
+Block rules run before allowlist.
+
+Required coverage:
+
+- Mass deletion.
+- Git history destruction.
+- Curl-to-shell.
+- Secret file reads.
+- Secret disclosure via grep/rg/jq/env/printenv.
+- Production deploys.
+- Safety bypass flags.
+
+### Write/Edit Guard
+
+The guard must evaluate both:
+
+- Original path exactly as received.
+- Resolved path after following symlinks.
+
+Rules:
+
+- Block protected basenames.
+- Block protected absolute prefixes.
+- Block resolved paths under protected prefixes.
+- Optionally block writes outside project unless an explicit host/user mode allows it.
+
+Recommended default:
+
+- In Guided Mode: project-only writes plus `/tmp`, behind a configurable guard setting. This should ship with clear messaging and real-world validation because legitimate CLIs may need to write under `~/.config`.
+- In Professional Mode: project-only writes plus configured extra paths.
+- Global writes require explicit user approval.
+
+### Secret Read Policy
+
+Secret protection is not "cat-specific". The policy is:
+
+> Any command that can print secret-bearing files or environment variables must be blocked or require explicit confirmation.
+
+This covers:
+
+- `cat .env`
+- `head .env`
+- `tail secrets.pem`
+- `grep TOKEN .env`
+- `rg TOKEN .env`
+- `jq . .env`
+- `env`
+- `printenv`
+
+Possible exception:
+
+- Allow `env | grep SAFE_PREFIX` only when configured.
+
+## Workflow State Model
+
+Session state is the source of sprint progress.
+
+Required fields:
+
+```json
+{
+  "session_id": "project-yyyymmdd-hhmmss",
+  "host": "claude",
+  "mode": "guided|professional|autopilot|report_only",
+  "capabilities": {
+    "bash_guard": "enforced",
+    "write_guard": "enforced",
+    "phase_gate": "enforced"
+  },
+  "current_phase": "review",
+  "completed_phases": ["think", "plan", "build"],
+  "pending_phases": ["review", "security", "qa", "ship"],
+  "evidence": {
+    "tests": [],
+    "security": [],
+    "qa": []
+  }
+}
+```
+
+The user-facing UI should be derived from this state, not from hard-coded next-step prose in each skill.
+
+## Product Flow
+
+### New Non-Technical Project
+
+1. User runs install.
+2. User says what they want.
+3. Nanostack asks at most one clarifying question at a time.
+4. Nanostack summarizes:
+   - What will be built.
+   - What will not be built yet.
+   - How the user will try it.
+5. Nanostack builds.
+6. Nanostack verifies.
+7. Nanostack shows:
+   - Result.
+   - How to open it.
+   - What was checked.
+   - What remains optional.
+
+No PR/CI/git language unless the user asks or the project has a remote.
+
+### Existing Technical Project
+
+1. User runs `/feature`.
+2. Nanostack loads recent artifacts and code context.
+3. Nanostack creates an implementation plan.
+4. `/feature` is always autopilot. The plan is auto-approved and recorded as such.
+5. Build happens.
+6. Review/security/QA run.
+7. Ship creates PR after preview and approval.
+
+Manual feature work should use `/think` + `/nano`, not `/feature --manual`. Two paths, two contracts.
+
+### Audit-Only Flow
+
+1. User asks for audit.
+2. Nanostack enters report-only mode.
+3. No files are edited.
+4. Findings include:
+   - Product risk.
+   - Architecture risk.
+   - Security risk.
+   - User-flow risk.
+5. A spec or implementation plan can be generated after the audit.
+
+## UX Requirements
+
+### Language Levels
+
+Every major output should support two layers.
+
+Plain:
+
+> Esto esta listo para probar. El formulario guarda datos y muestra errores claros si falta algo.
+
+Technical:
+
+> QA passed 12/12. Security grade A. No staged secrets. PR #42 ready.
+
+### Doctor Output
+
+Doctor should produce three outputs:
+
+- Human technical.
+- Human plain.
+- Machine JSON.
+
+Machine JSON must be built with `jq`, not delimiter parsing.
+
+Required schema:
+
+```json
+{
+  "overall": "pass|warn|fail",
+  "checks": [
+    {
+      "status": "pass|warn|fail",
+      "category": "permissions",
+      "name": "write_guard",
+      "detail": "check-write.sh wired",
+      "fix_available": true,
+      "fix_command": "bin/init-project.sh --repair"
+    }
+  ]
+}
+```
+
+### Setup Output
+
+The setup script should end with:
+
+```text
+Nanostack is installed.
+
+Protection level:
+  Claude Code: full guard support
+  Cursor: guided workflow only
+
+Next:
+  1. Restart Cursor
+  2. In your project, run /nano-run
+```
+
+Do not print every skill unless user passes `--verbose`.
+
+## Technical Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Host abstraction | Adapter capability files | Avoid Claude-specific assumptions |
+| Enforcement wording | Capability-level language | Prevent overpromising |
+| Existing installs | Repair command with backup | Non-technical users should not edit JSON |
+| Write guard | Resolve symlinks and project scope | Denylist on raw path is bypassable |
+| Doctor JSON | Build with jq arrays | Avoid delimiter truncation |
+| Feature fast path | Explicit auto-approved plan state | Avoid contradiction with `/nano` approval |
+| Local mode vs Guided Mode | Local mode always implies Guided Mode; Guided Mode can also apply in git repos | Avoid conflating "no git" with "non-technical user" |
+| CI | Matrix over scripts and product contracts | Catch workflow regressions |
+
+## Implementation Plan
+
+### Phase 1: Truthful Guarantees
+
+Files:
+
+- `README.md`
+- `README.es.md`
+- `SECURITY.md`
+- `guard/SKILL.md`
+- `setup`
+
+Changes:
+
+- Add capability levels.
+- Replace universal "enforced" claims.
+- Add host capability matrix.
+- Mark non-hook hosts as guided until adapters prove enforcement.
+
+Verification:
+
+- Grep docs for "Every step is enforced" and confirm qualified wording.
+- Ensure README and Spanish README do not diverge on guarantees.
+
+### Phase 2: Host Adapter Model
+
+Files:
+
+- `reference/host-adapter-schema.md`
+- `adapters/claude.json`
+- `adapters/codex.json`
+- `adapters/cursor.json`
+- `adapters/opencode.json`
+- `adapters/gemini.json`
+- `setup`
+- `bin/nano-doctor.sh`
+
+Changes:
+
+- Add adapter capability schema.
+- Setup writes detected host capability summary.
+- Doctor reports protection level per host.
+- Keep the first schema minimal: skill discovery, Bash guard, Write/Edit guard, phase gate, install target, doctor checks, last verified, verification evidence.
+- Defer subagents, browser QA, and other non-consumed capabilities until there is code that reads them.
+
+Verification:
+
+- `setup --host claude --dry-run` shows full guard support.
+- `setup --host cursor --dry-run` shows guided workflow unless real hooks exist.
+- Adapter declarations include `last_verified`.
+- CI validates any declared local capability it can observe.
+
+### Phase 3: Repair Existing Installs
+
+Files:
+
+- `bin/init-project.sh`
+- `bin/upgrade.sh`
+- `bin/nano-doctor.sh`
+- `TROUBLESHOOTING.md`
+
+Changes:
+
+- Add `--check`, `--repair`, `--migrate-hooks`, `--migrate-permissions`.
+- Back up settings before mutation.
+- Add missing hooks to existing settings.
+- Doctor suggests repair command with fix metadata.
+
+Verification:
+
+- Existing settings without hooks are repaired.
+- Existing broad rm remains unless migration flag is present.
+- Backup file is created.
+- Doctor moves from warn to pass after repair.
+
+### Phase 4: Harden Guard
+
+Files:
+
+- `guard/bin/check-write.sh`
+- `guard/bin/check-dangerous.sh`
+- `guard/rules.json`
+- `.github/workflows/lint.yml`
+- `tests/run.sh`
+
+Changes:
+
+- Resolve symlinks in Write/Edit guard.
+- Add configurable outside-project write blocking. Default ON for Guided Mode only after validating common CLI flows; default OFF for Professional Mode.
+- Add secret disclosure rules for grep/rg/jq/env/printenv.
+- Add regression tests for symlink bypass and secret disclosure variants.
+
+Verification:
+
+- `check-write.sh /tmp/link-to-etc/passwd` exits 1.
+- `check-write.sh /tmp/link-to-ssh/config` exits 1.
+- `check-dangerous.sh 'grep SECRET .env'` exits 1.
+- `check-dangerous.sh 'env'` exits 1 or warns based on configured mode.
+
+### Phase 5: Workflow Orchestration State
+
+Files:
+
+- `bin/session.sh`
+- `bin/next-step.sh`
+- `feature/SKILL.md`
+- `plan/SKILL.md`
+- `ship/SKILL.md`
+
+Changes:
+
+- Store mode and host capability in session.
+- Store explicit `plan_approval: user|auto|not_required`.
+- `/feature` always sets auto-approved planning. Manual users should use `/think` + `/nano`.
+- Next-step guidance is generated from session state.
+
+Verification:
+
+- `/feature` no longer conflicts with `/nano` approval.
+- Manual `/nano` still waits for approval.
+- Autopilot status survives across phases.
+
+### Phase 6: Non-Technical Delivery Experience
+
+Files:
+
+- `start/SKILL.md`
+- `think/SKILL.md`
+- `plan/SKILL.md`
+- `qa/SKILL.md`
+- `ship/SKILL.md`
+- `doctor/SKILL.md`
+- `README.es.md`
+
+Changes:
+
+- Add a shared "plain language output contract".
+- Replace phase-heavy next steps with one-action guidance in Guided Mode.
+- Add "what was checked" and "what is not verified" blocks.
+- Ensure Spanish docs are first-class, not partial.
+
+Verification:
+
+- In a no-git project, no output mentions PR, CI, branch, diff, hook, artifact, or phase unless user asks.
+- Ship output tells user exactly how to try the result.
+
+## Acceptance Criteria
+
+| Area | Criteria | How to verify |
+|---|---|---|
+| Agent agnosticism | Every supported host has declared capability levels | Adapter files + doctor output |
+| Honest positioning | Docs do not claim enforcement where host lacks hooks | Grep docs + capability matrix |
+| Existing installs | User can repair hooks without editing JSON | Temp settings test |
+| Write safety | Symlink targets to protected dirs are blocked | Regression test |
+| Secret safety | Secret-bearing files cannot be printed through common read commands | Guard matrix |
+| Non-technical flow | No-git project gets plain next action and proof | Local-mode transcript test |
+| Feature flow | `/feature` does not wait on `/nano` approval accidentally | Session test |
+| Doctor JSON | No truncation when details include pipes/newlines | JSON schema test |
+| CI coverage | Workflow runs guard, write guard, doctor JSON, install repair, frozen install, audit, typecheck | GitHub Actions |
+
+## Metrics
+
+Product metrics should be local-first and optional.
+
+Useful aggregate metrics:
+
+- Time from idea to first runnable output.
+- Percent of sprints with review/security/QA artifacts.
+- Percent of sprints stopped by guard.
+- Percent of installs with full guard support.
+- Percent of doctor runs that report repairable warnings.
+- Autopilot completion rate.
+- Non-technical flow completion rate.
+
+Never collect:
+
+- Code.
+- Prompts.
+- File paths.
+- Repo names.
+- Hostnames.
+- Secrets.
+
+## Release Plan
+
+### v0.8: Honest Capabilities
+
+Ship as four small PRs:
+
+1. Adapter schema and capability JSON files only.
+2. CI/schema validation for adapter files.
+3. README/SECURITY/setup wording that consumes the capability vocabulary.
+4. Doctor/setup protection-level output.
+
+### v0.9: Repair and Guard Hardening
+
+- `init-project.sh --repair`.
+- Symlink-safe Write/Edit guard.
+- Secret disclosure guard variants.
+- CI matrix expanded.
+
+### v1.0: Delivery Experience
+
+- Guided Mode polished.
+- Feature autopilot contract fixed.
+- Session state owns next-step guidance.
+- Spanish docs complete.
+- Public positioning updated to: "AI coding agent team skills for the full engineering workflow, with enforced guardrails where your agent supports hooks and guided delivery everywhere else."
+
+## Open Questions
+
+1. Which non-Claude hosts can support true pre-action hooks today?
+2. Should Nanostack ship a lightweight wrapper command for hosts without hooks?
+3. Which real Guided Mode flows break if outside-project writes are blocked by default?
+4. Should `env` and `printenv` be blocked by default or downgraded to warning?
+
+## Recommended Next Sprint
+
+Build v0.8 Sprint 1 first: adapter schema and five capability files only.
+
+Why:
+
+- It reduces Claude-specific bias.
+- It forces explicit values instead of assumptions.
+- It is low-risk: new docs/JSON only.
+- It unblocks doctor, setup, README, and CI work.
+- If the larger v0.8 stalls, the repo still gains honest capability artifacts.

--- a/reference/host-adapter-schema.md
+++ b/reference/host-adapter-schema.md
@@ -1,0 +1,110 @@
+# Host Adapter Schema
+
+Each host that nanostack supports declares its real capabilities in a JSON file under `adapters/`. The schema is the contract between the workflow core (skills, doctor, setup, README) and the host (Claude Code, Cursor, Codex, OpenCode, Gemini, future).
+
+The point is to stop overpromising. Setup, doctor, and the README must read these files before claiming "enforced" or "guarded" anywhere. If a host's adapter says `instructions_only`, the user-facing wording is "guided", not "enforced".
+
+## File location
+
+```
+adapters/<host>.json
+```
+
+One file per host. Filename matches the `host` field. Existing host names: `claude`, `codex`, `cursor`, `opencode`, `gemini`.
+
+## Schema (v1)
+
+```json
+{
+  "host": "claude",
+  "schema_version": "1",
+  "last_verified": "2026-04-25",
+  "verification": {
+    "method": "ci|manual|unknown",
+    "evidence": "path or command that proved the claim"
+  },
+  "skill_discovery": "native",
+  "bash_guard": "enforced",
+  "write_guard": "enforced",
+  "phase_gate": "enforced",
+  "install_target": ".claude/settings.json",
+  "doctor_checks": ["hooks", "permissions", "commands"]
+}
+```
+
+### Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Must match the filename without `.json`. |
+| `schema_version` | string | Currently `"1"`. Bump on breaking schema changes. |
+| `last_verified` | string (ISO date) | When a maintainer last confirmed the declared capabilities match the host. Stale dates lower trust; CI may downgrade displayed capability. |
+| `verification` | object | How the claim was proved. See below. |
+| `skill_discovery` | capability | How the host finds skills (see capability values). |
+| `bash_guard` | capability | Enforcement level for shell commands. |
+| `write_guard` | capability | Enforcement level for Write/Edit/MultiEdit. |
+| `phase_gate` | capability | Enforcement level for the phase-aware commit gate. |
+| `install_target` | string | The path setup writes the host's config to (advisory; for diagnostics). |
+| `doctor_checks` | string[] | The check categories `nano-doctor` should run for this host. |
+
+### `verification` field
+
+```json
+{
+  "method": "ci",
+  "evidence": ".github/workflows/lint.yml:guard-regression"
+}
+```
+
+- `method`: one of `ci`, `manual`, `unknown`.
+  - `ci` means CI runs a job that exercises the capability.
+  - `manual` means a human ran a check and signed off; the evidence string should name the check or the commit.
+  - `unknown` means nobody has confirmed; the host's claims must be conservative.
+- `evidence`: short pointer to where the proof lives. A file path with optional anchor, a command, or a URL.
+
+### Capability values
+
+| Value | Meaning | Wording |
+|---|---|---|
+| `unsupported` | The host cannot do this at all. | "Not available" |
+| `instructions_only` | The host reads skill text and is expected to follow it; no programmatic gate. | "Guided" |
+| `detectable` | Nanostack can inspect state and report issues, but cannot block. | "Checked" |
+| `hooked` | The host invokes a nanostack hook before the action; the hook runs. | "Guarded" |
+| `enforced` | The hook can block the action and the host honors the block. | "Blocked when unsafe" |
+| `host_dependent` | Capability varies by host configuration that nanostack cannot detect. | Use only when the host config truly varies (e.g. browser QA depends on a desktop environment). |
+
+The capability hierarchy maps directly to the L0..L4 levels in the V1 SPEC:
+
+- `unsupported` and `instructions_only` are L0 ("Guided")
+- `detectable` is L1 ("Checked")
+- `hooked` is L2 ("Guarded")
+- `enforced` is L3 ("Blocked when unsafe")
+- L4 ("Continuously verified") is not a capability value but a property of the `verification` block: when `method == "ci"`, the declared capability is L4-asserted.
+
+## Observation overrides declaration
+
+The adapter file is a declaration, not eternal truth. A host upgrade can break the assumption.
+
+The runtime contract:
+
+1. `setup` and `nano-doctor` should observe the actual install state when feasible (file presence, `jq -e` over `.claude/settings.json`, version checks).
+2. If observed state contradicts the adapter file, the runtime must report the **lower** capability and surface the discrepancy as a warning. It must never echo the file's value when the file is wrong.
+3. The discrepancy should be actionable: prefer pointing the user at `init-project.sh --repair` over telling them to edit JSON.
+
+## Guarantees that the schema must support
+
+The first version of the schema covers the four guarantees that already exist in nanostack:
+
+- skill discovery (the agent finds and invokes skills)
+- bash guard (PreToolUse on shell commands)
+- write guard (PreToolUse on Write/Edit/MultiEdit)
+- phase gate (Bash hook that blocks commits before review/security/QA)
+
+Subagent orchestration, browser QA, and other capabilities are intentionally **not** in v1. They get added when (and only when) a script or a doctor check actually consumes them. Adding capabilities without a consumer trains everyone to treat the schema as decoration.
+
+## Adding a new host
+
+1. Create `adapters/<host>.json` with conservative defaults (`instructions_only` for everything until proven otherwise).
+2. Run the `setup --host <host>` flow on a real machine; observe whether hooks actually fire.
+3. Update the adapter file with the observed value. Set `last_verified` to the date of observation. Set `verification.method` to `manual` and `verification.evidence` to the commit SHA or audit log line.
+4. If a CI job can prove the capability, add it under `.github/workflows/`, then update `verification.method` to `ci` and point `evidence` at the job.


### PR DESCRIPTION
## Summary

First sprint of the v0.8 release path described in `reference/agent-agnostic-delivery-spec.md`. Pure docs + JSON + CI; no runtime changes yet. The contract this PR introduces unblocks every downstream sprint (doctor reading the file, setup output, README rewrite, README.es alignment).

## Why this first

Today the README and docs claim enforcement on multiple agents. In practice only Claude Code wires PreToolUse hooks; Cursor/Codex/OpenCode/Gemini get instruction text. Round 4 audit (PR #146) flagged this gap honestly in prose; this PR moves the honesty into a machine-readable contract so the docs, the doctor, and CI all read from the same source of truth.

## New files

### `reference/agent-agnostic-delivery-spec.md`

The full V1 spec. Capability levels L0..L4, host adapter model, product modes (Guided / Professional / Autopilot / Report-only), repair flow, acceptance criteria, release plan.

### `reference/host-adapter-schema.md`

Schema doc for `adapters/<host>.json`. Names every required field, the capability vocabulary, the verification block, and the runtime rule that **observed install state overrides a stale declaration**.

### `adapters/{claude,codex,cursor,opencode,gemini}.json`

One file per supported host. Values grounded in what `setup install_<host>` actually does, verified by reading the setup script lines on 2026-04-25.

| Host | bash_guard | write_guard | phase_gate | verification |
|---|---|---|---|---|
| claude | `enforced` | `enforced` | `enforced` | `ci` (guard-regression + write-guard-regression) |
| codex | `instructions_only` | `instructions_only` | `instructions_only` | `manual` (setup:401-427) |
| cursor | `instructions_only` | `instructions_only` | `instructions_only` | `manual` (setup:429-451) |
| opencode | `instructions_only` | `instructions_only` | `instructions_only` | `manual` (setup:453-464) |
| gemini | `instructions_only` | `instructions_only` | `instructions_only` | `manual` (setup:466-477) |

### CI: `host-adapter-schema` job

Validates every `adapters/*.json` on every PR:

- All required fields present (`host`, `schema_version`, `last_verified`, `verification`, `skill_discovery`, `bash_guard`, `write_guard`, `phase_gate`, `install_target`, `doctor_checks`).
- `schema_version` is exactly `"1"`.
- Filename matches the `host` field.
- Capability values are in the allowed set.
- `verification.method` is `ci`, `manual`, or `unknown`.
- `verification.evidence` is non-empty.

A future change that "upgrades" a host's capability without backing it up with verification evidence fails CI before merge.

## What this enables (downstream sprints)

- **Sprint 2:** `nano-doctor` reads the adapter for the installed host and reports the protection level honestly.
- **Sprint 3:** `setup` prints "Claude Code: full guard support" vs "Cursor: guided workflow only" from the same file.
- **Sprint 4:** README rewrite consumes the file instead of asserting enforcement directly.

Future host upgrades update one file; everything downstream reflects the new state.

## Test plan

- [x] All five JSON files validate locally (`jq -e`, required-field check, capability-value check, host/filename match).
- [x] Em-dash lint clean on `reference/host-adapter-schema.md`.
- [x] `bash tests/run.sh`: 44/44 pass.
- [x] YAML workflow parses (`python3 yaml.safe_load`).

## Out of scope

- No code change to `setup`, `nano-doctor`, or `init-project.sh` in this PR. Those land in Sprints 2 and 3.
- No change to README wording. That is Sprint 4.
- Subagent and browser_qa capabilities intentionally NOT in v1 schema; they get added when a script consumes them.

## Related

`reference/agent-agnostic-delivery-spec.md` "Implementation Plan / Phase 2 / v0.8 Sprint 1".