### PR TITLE
v0.8 Sprint 3: setup prints protection level per host

### DIFF
--- a/setup
+++ b/setup
@@ -96,6 +96,7 @@ fi
 HOST="claude"
 LOCAL_INSTALL=0
 RENAMES=""
+VERBOSE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --host)  [ -z "${2:-}" ] && echo "Missing value for --host" >&2 && exit 1; HOST="$2"; shift 2 ;;
@@ -104,6 +105,7 @@ while [ $# -gt 0 ]; do
     --rename) [ -z "${2:-}" ] && echo "Missing value for --rename" >&2 && exit 1; RENAMES="$2"; shift 2 ;;
     --rename=*) RENAMES="${1#--rename=}"; shift ;;
     --list) LIST_SKILLS=1; shift ;;
+    --verbose|-v) VERBOSE=1; shift ;;
     --help)
       cat <<'HELP'
 Usage: ./setup [OPTIONS]
@@ -114,6 +116,7 @@ Options:
   --rename <map>    Rename skills to avoid collisions (comma-separated old=new pairs)
   --rename reset    Restore all skills to their original names
   --list            Show installed skills and their current names
+  --verbose, -v     Show the full skill list and workflow line after install
   --help            Show this help
 
 Install methods:
@@ -557,47 +560,95 @@ write_setup_config
 echo ""
 echo "  config: ~/.nanostack/setup.json"
 
-echo ""
-echo "Available skills:"
-for skill in "${SKILLS[@]}"; do
-  pname=$(skill_public_name "$skill")
-  if [ "$pname" != "$skill" ]; then
-    echo "  /$pname (renamed from /$skill)"
-  else
-    echo "  /$skill"
+# ─── Per-host protection level summary ──────────────────────
+# Read each installed host's adapter file and report the declared
+# capability in user-facing wording. The adapter is the source of
+# truth for what nanostack actually enforces on that host. Honest
+# summary instead of a uniform "ready" line that would mask the
+# Claude vs everyone-else gap.
+
+_proto_label() {
+  case "$1" in
+    enforced)          echo "full guard support (commands and writes blocked when unsafe)" ;;
+    hooked)            echo "hooked, blocking depends on host" ;;
+    detectable)        echo "detectable issues only" ;;
+    instructions_only) echo "guided workflow only (no automatic blocking)" ;;
+    unsupported)       echo "no nanostack support" ;;
+    *)                 echo "$1" ;;
+  esac
+}
+
+_print_protection_for() {
+  local host="$1" pretty="$2"
+  local adapter="$SOURCE_DIR/adapters/$host.json"
+  if [ ! -f "$adapter" ]; then
+    echo "  $pretty: adapter file missing (reinstall recommended)"
+    return
   fi
-done
+  local bash_cap write_cap
+  bash_cap=$(jq -r '.bash_guard'  "$adapter" 2>/dev/null)
+  write_cap=$(jq -r '.write_guard' "$adapter" 2>/dev/null)
+  if [ "$bash_cap" = "$write_cap" ]; then
+    echo "  $pretty: $(_proto_label "$bash_cap")"
+  else
+    echo "  $pretty: bash $(_proto_label "$bash_cap"); write $(_proto_label "$write_cap")"
+  fi
+}
+
 echo ""
-# Build workflow line with renames applied
-w_think=$(skill_public_name "think")
-w_nano=$(skill_public_name "nano")
-w_review=$(skill_public_name "review")
-w_qa=$(skill_public_name "qa")
-w_security=$(skill_public_name "security")
-w_ship=$(skill_public_name "ship")
-w_guard=$(skill_public_name "guard")
-echo "Workflow: /$w_think → /$w_nano → build → /$w_review → /$w_qa → /$w_security → /$w_ship"
-echo "Safety:   /$w_guard (activate on-demand)"
-echo "Start:    /nano-run (first-time setup)"
-echo ""
-echo "Per-project setup (run once in each project):"
-echo "  ~/.claude/skills/nanostack/bin/init-project.sh"
-echo ""
-echo "Update:    ~/.claude/skills/nanostack/bin/upgrade.sh"
+echo "Protection level:"
+[ "$INSTALL_CLAUDE" -eq 1 ]   && _print_protection_for "claude"   "Claude Code"
+[ "$INSTALL_CODEX" -eq 1 ]    && _print_protection_for "codex"    "Codex"
+[ "$INSTALL_CURSOR" -eq 1 ]   && _print_protection_for "cursor"   "Cursor"
+[ "$INSTALL_OPENCODE" -eq 1 ] && _print_protection_for "opencode" "OpenCode"
+[ "$INSTALL_GEMINI" -eq 1 ]   && _print_protection_for "gemini"   "Gemini CLI"
 
 # ─── Per-agent activation guidance ───────────────────────────
 # Tell the user how to actually see the skills in the agents they installed
 # for. Cursor and Codex need a restart that the install step does not perform.
 echo ""
-echo "Next step — activate the skills in your agent:"
+echo "Next step:"
 [ "$INSTALL_CLAUDE" -eq 1 ]   && echo "  Claude Code:  ready now. Type /nano-help to see all commands."
 [ "$INSTALL_CURSOR" -eq 1 ]   && echo "  Cursor:       restart Cursor (close and reopen), then type /nano-help."
 [ "$INSTALL_CODEX" -eq 1 ]    && echo "  Codex:        run \`codex\` in a new terminal, then type /nano-help."
 [ "$INSTALL_OPENCODE" -eq 1 ] && echo "  OpenCode:     restart your OpenCode session, then type /nano-help."
 [ "$INSTALL_GEMINI" -eq 1 ]   && echo "  Gemini CLI:   run \`gemini\` in a new terminal, then type /nano-help."
 
-# The `[ test ] && echo` lines above each return 1 for any agent the user
-# did NOT install. Without an explicit success at the end, the script's
-# exit code would be the last test's result — making a clean setup look
-# failed to upgrade.sh (which runs under `set -e`) and to any CI path.
+echo ""
+echo "Per-project setup (run once in each project):"
+echo "  ~/.claude/skills/nanostack/bin/init-project.sh"
+echo ""
+echo "Update: ~/.claude/skills/nanostack/bin/upgrade.sh"
+
+# ─── Verbose: full skill list and workflow line ──────────────
+# Default output stays tight so non-technical users are not greeted
+# with a wall of slash commands. Pass --verbose (or -v) to see the
+# legacy listing.
+if [ "$VERBOSE" -eq 1 ]; then
+  echo ""
+  echo "Available skills:"
+  for skill in "${SKILLS[@]}"; do
+    pname=$(skill_public_name "$skill")
+    if [ "$pname" != "$skill" ]; then
+      echo "  /$pname (renamed from /$skill)"
+    else
+      echo "  /$skill"
+    fi
+  done
+  echo ""
+  w_think=$(skill_public_name "think")
+  w_nano=$(skill_public_name "nano")
+  w_review=$(skill_public_name "review")
+  w_qa=$(skill_public_name "qa")
+  w_security=$(skill_public_name "security")
+  w_ship=$(skill_public_name "ship")
+  w_guard=$(skill_public_name "guard")
+  echo "Workflow: /$w_think → /$w_nano → build → /$w_review → /$w_qa → /$w_security → /$w_ship"
+  echo "Safety:   /$w_guard (activate on-demand)"
+  echo "Start:    /nano-run (first-time setup)"
+fi
+
+# Explicit success: previous `[ test ] && echo` lines return 1 for any
+# agent the user did NOT install, which would leak into upgrade.sh and
+# CI runs under `set -e`. End with exit 0.
 exit 0


### PR DESCRIPTION
## Summary

Sprint 3 of v0.8. Adapter files landed in #147; nano-doctor started consuming them in #148. Setup is the third reader: after install it prints a per-host protection summary from the same adapter files. The uniform "ready" line that masked the Claude vs everyone-else gap is gone.

## New default output

```
Nanostack ready (claude).
  skills: ~/.claude/skills

  config: ~/.nanostack/setup.json

Protection level:
  Claude Code: full guard support (commands and writes blocked when unsafe)
  Cursor: guided workflow only (no automatic blocking)
  Gemini CLI: guided workflow only (no automatic blocking)

Next step:
  Claude Code: ready now. Type /nano-help to see all commands.
  Cursor: restart Cursor (close and reopen), then type /nano-help.
  Gemini CLI: run `gemini` in a new terminal, then type /nano-help.

Per-project setup (run once in each project):
  ~/.claude/skills/nanostack/bin/init-project.sh

Update: ~/.claude/skills/nanostack/bin/upgrade.sh
```

The full skill list, workflow line, safety, and start hint now sit behind `--verbose` / `-v`. Default output is short and reads honestly; users who want the full menu opt in.

## Implementation

- New `_proto_label` and `_print_protection_for` helpers map adapter capability values to user-facing wording: `enforced` becomes "full guard support", `instructions_only` becomes "guided workflow only", and so on across the L0-L3 vocabulary.
- When `bash_guard` and `write_guard` differ for a host, the summary names both rather than averaging.
- Protection summary reads `adapters/<host>.json` directly. Missing file produces "adapter file missing (reinstall recommended)" so the failure is visible.
- New `--verbose` / `-v` flag. The legacy long listing only appears when the flag is present.
- Explicit `exit 0` at the end so a host the user did not install does not leak `[ test ] && echo` failing-on-empty into CI under `set -e`.

## Test plan

- [x] `bash -n setup` passes.
- [x] Simulated protection summary against current adapters: matches spec example wording for Claude / Cursor / Gemini.
- [x] `bash tests/run.sh`: 44/44 pass.
- [x] Em-dash lint clean.
- [x] The adapter contract from PR #147 already has CI coverage (`host-adapter-schema` job); this PR consumes those files and inherits the validation.

## What this enables

Sprint 4 of v0.8: README rewrite consumes the adapter files (or `doctor --json`) instead of asserting enforcement directly. With setup, doctor, and the README all reading from the same source, future host upgrades update one file and every downstream surface follows.

## Related

`reference/agent-agnostic-delivery-spec.md` "Implementation Plan / Phase 2 / Sprint 3" and "UX Requirements / Setup Output".