### PR TITLE
v0.8 Sprint 4: README and README.es align with adapter contract

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -162,14 +162,34 @@ Los agentes cometen errores. Corren `rm -rf` cuando querían `rm -r`, hacen forc
 
 ### Seis tiers de seguridad
 
-1. **Allowlist**: comandos como `git status`, `ls`, `cat` pasan sin chequeo.
-2. **In-project**: operaciones que solo tocan archivos del repo actual pasan. El control de versiones es la red.
-3. **Concurrencia por fase**: durante fases read-only (review, qa, security), las operaciones de escritura quedan bloqueadas para evitar race conditions.
-4. **Phase gate**: cuando hay un sprint activo, `git commit` y `git push` quedan bloqueados hasta que existan artifacts frescos de review, security y qa.
-5. **Budget gate**: cuando el sprint tiene un presupuesto y se gastó 95%+, todos los comandos no-allowlist quedan bloqueados.
-6. **Pattern matching**: todo lo demás se chequea contra reglas de bloqueo y advertencia. 33 reglas para borrado masivo, destrucción de historia, drops de DB, deploys a producción, ejecución remota de código.
+Cada comando de Bash pasa por estos seis tiers, en este orden:
+
+1. **Block rules**: las reglas de bloqueo corren primero. 35 reglas cubren borrado masivo (`rm -rf .`, `find . -delete`), destrucción de historia (`git push --force`), lecturas de secretos (`.env`, `*.pem`), drops de DB, deploys a producción y ejecución remota (`curl | sh`). Una coincidencia bloquea aunque el binario esté en el allowlist de abajo.
+2. **Allowlist**: para comandos que pasaron las block rules, los allowlisteados (`git status`, `ls`, `cat`, `jq`, etc.) saltan el resto.
+3. **In-project**: operaciones que solo tocan archivos del repo actual pasan. El control de versiones es la red de seguridad.
+4. **Concurrencia por fase**: durante fases read-only (review, qa, security), las operaciones de escritura quedan bloqueadas para evitar race conditions.
+5. **Phase gate**: cuando hay un sprint activo, `git commit` y `git push` quedan bloqueados hasta que existan artifacts frescos de review, security y qa.
+6. **Budget gate**: cuando el sprint tiene un presupuesto y se gastó 95%+, todos los comandos no-allowlist quedan bloqueados.
+
+Plus 9 reglas de advertencia para operaciones que requieren atención sin llegar a bloqueo.
+
+Las herramientas Write, Edit y MultiEdit pasan por su propio hook (`guard/bin/check-write.sh`) que niega rutas protegidas: archivos de secretos (`.env` y variantes, `*.pem`, `*.key`, llaves SSH) y directorios de sistema o usuario-secreto (`/etc`, `/var`, `/usr/bin`, `~/.ssh`, `~/.aws`, `~/.kube`). Los symlinks se resuelven antes de matchear, así que un `mylink/config -> ~/.ssh/config` se trata como destino resuelto.
 
 Cuando guard bloquea un comando, no solo dice "no". Sugiere una alternativa segura. El agente la lee y reintenta.
+
+### Qué se aplica en cada agente
+
+Honestidad por host: nanostack manda los mismos archivos de skills a todos los agentes soportados, pero la capa de **enforcement** (los hooks que bloquean acciones antes de ejecutarse) depende de lo que cada host expone. Cada adapter en [`adapters/`](adapters/) declara su capacidad real; setup, doctor, y este cuadro leen de esos archivos. Niveles según [`reference/host-adapter-schema.md`](reference/host-adapter-schema.md):
+
+| Agente | Bash guard | Write/Edit guard | Phase gate | Qué significa |
+|---|---|---|---|---|
+| Claude Code | enforced (L3) | enforced (L3) | enforced (L3) | Hooks bloquean comandos peligrosos antes de correr. CI verifica continuamente. |
+| Cursor | guided (L0) | guided (L0) | guided (L0) | Skills se cargan como reglas de texto. El agente las lee y debe seguirlas. Sin pre-tool-use hook hoy. |
+| OpenAI Codex | guided (L0) | guided (L0) | guided (L0) | Skills disponibles, sin hooks de bloqueo. |
+| OpenCode | guided (L0) | guided (L0) | guided (L0) | Skills disponibles, sin hooks de bloqueo. |
+| Gemini CLI | guided (L0) | guided (L0) | guided (L0) | Instalado como extensión Gemini, sin hooks de bloqueo. |
+
+Si querés enforcement duro, usá Claude Code. Si aceptás disciplina a nivel agente, los demás corren el mismo workflow guiado. Corré `/nano-doctor` después de instalar para ver el estado real de tu install.
 
 ## Problemas comunes
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Works with Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity,
 
 Your agent is already capable of writing code. What it lacks is structure. Nanostack is seven specialists the agent invokes in order, each one reading what came before. Scope gets challenged before planning. The plan gets named files and risks before building. The build gets reviewed, audited, and tested before shipping. Ship creates the PR, verifies CI, and writes the sprint journal.
 
-Every step is enforced. You cannot `/ship` without `/review`, `/security`, and `/qa`. Nothing falls through the cracks because every step reads the artifact of the previous one.
+Every step reads the artifact the previous step wrote, so nothing falls through the cracks. On Claude Code the pipeline is enforced via PreToolUse hooks: `git commit` is blocked until `/review`, `/security`, and `/qa` produce fresh artifacts. On other agents the same workflow runs as guided instructions; see [What enforces on which agent](#what-enforces-on-which-agent) for the per-host capability table.
 
 |        | Step              | What the specialist does                                                |
 | ------ | ----------------- | ----------------------------------------------------------------------- |
@@ -183,7 +183,7 @@ Nanostack is a process, not a collection of tools. The skills run in the order a
 /think → /nano → build → /review → /qa → /security → /ship
 ```
 
-Each skill feeds into the next. `/nano` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. The phase gate enforces the pipeline: `git commit` is blocked until review, security and qa are done. Nothing falls through the cracks because every step knows what came before it, and skipping steps is not an option.
+Each skill feeds into the next. `/nano` writes an artifact that `/review` reads for scope drift detection. `/review` catches conflicts with `/security` findings. `/ship` verifies everything is clean before creating the PR. On Claude Code the phase gate enforces the pipeline at the hook layer: `git commit` is blocked until review, security, and qa have fresh artifacts. On agents without hook support the same gate runs as guided instructions, so the safety depends on the agent following them; see [What enforces on which agent](#what-enforces-on-which-agent).
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
@@ -346,7 +346,7 @@ Discuss the idea, approve the brief, walk away. The agent runs the full sprint:
 /nano → build → /review → /security → /qa → /ship
 ```
 
-The phase gate enforces the pipeline. Even if the agent judges a task as "simple" and tries to skip review or security, `git commit` is blocked until all phases have fresh artifacts. No instructions to follow. The hook stops the commit.
+On Claude Code the phase gate enforces the pipeline at the hook layer: even if the agent judges a task as "simple" and tries to skip review or security, `git commit` is blocked until all phases have fresh artifacts. The hook stops the commit, no instructions involved. On agents that do not support pre-action hooks the same gate runs as a rule the agent reads; the gate is honest about the difference and `/nano-doctor` reports the actual level for your install.
 
 Autopilot only stops if:
 - `/review` finds blocking issues that need your decision
@@ -461,19 +461,19 @@ All rules live in [`guard/rules.json`](guard/rules.json). Each rule has an ID, r
 
 ### What enforces on which agent
 
-Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today.
+Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today. The capability that ships for each host lives in [`adapters/`](adapters/) as a small JSON file; setup, doctor, and this table all read from those files. Levels follow the L0-L3 vocabulary documented in [`reference/host-adapter-schema.md`](reference/host-adapter-schema.md).
 
-| Agent | Skills | Hook enforcement | What this means |
-|---|---|---|---|
-| Claude Code | yes | yes (Bash, Write, Edit, MultiEdit) | Block rules and the Write/Edit denylist run before every tool call. The user does not have to read the rules; the hook does. |
-| Cursor | yes | no | Skills are exposed as rules text. The agent reads the rules and is expected to follow them. There is no pre-tool-use hook on Cursor today. |
-| OpenAI Codex | yes | no | Same as Cursor: instructions only. |
-| OpenCode | yes | no | Same. |
-| Gemini CLI / Antigravity / Amp / Cline | yes | no | Same. |
+| Agent | Bash guard | Write/Edit guard | Phase gate | What this means |
+|---|---|---|---|---|
+| Claude Code | enforced (L3) | enforced (L3) | enforced (L3) | Block rules and the Write/Edit denylist run before every tool call. The user does not have to read the rules; the hook does. CI continuously verifies the hook still blocks. |
+| Cursor | guided (L0) | guided (L0) | guided (L0) | Skills are exposed as rules text. The agent reads the rules and is expected to follow them. No pre-tool-use hook on Cursor today. |
+| OpenAI Codex | guided (L0) | guided (L0) | guided (L0) | Skill folder under `~/.codex/skills/`; no hook integration today. |
+| OpenCode | guided (L0) | guided (L0) | guided (L0) | Native skill folder; no hook integration today. |
+| Gemini CLI | guided (L0) | guided (L0) | guided (L0) | Installed as a Gemini extension; no hook integration today. |
 
-When hooks are not available, the protection downgrades from "blocked at the system call" to "agent should know better." Run `/nano-doctor` after install on any agent to see the actual state. If you want hard enforcement, use Claude Code; if you accept agent-level discipline, the rest still ship the same workflow.
+When hooks are not available, the protection downgrades from "blocked at the system call" to "agent should know better." Run `/nano-doctor` after install on any agent to see the actual state, including any drift between what the adapter declares and what your install really wires. If you want hard enforcement, use Claude Code; if you accept agent-level discipline, the rest still ship the same workflow.
 
-This gap is the single biggest known caveat in the framework. The roadmap is to add the same enforcement layer per agent as their tooling exposes the right hooks.
+This gap is the single biggest known caveat in the framework. The roadmap is to add the same enforcement layer per agent as their tooling exposes the right hooks. Each adapter file carries a `last_verified` date and a verification source so users can tell which guarantees are CI-asserted today and which are manual.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Last sprint of v0.8. The schema landed in #147; doctor consumed it in #148; setup in #149. README is the last reader. The blanket "every step is enforced" claim is gone: enforcement is named where it applies (Claude Code via PreToolUse hooks), and the guided fallback is honest where hooks do not exist. Spanish README catches up to the English version with the same matrix.

## Changes

### Three over-claims softened

| Location | Before | After |
|---|---|---|
| README §"What is Nanostack" | "Every step is enforced. You cannot `/ship` without `/review`, `/security`, `/qa`." | "...nothing falls through the cracks. On Claude Code the pipeline is enforced via PreToolUse hooks: `git commit` is blocked... On other agents the same workflow runs as guided instructions; see the per-host capability table." |
| README §"The sprint" | "The phase gate enforces the pipeline...skipping steps is not an option." | "On Claude Code the phase gate enforces at the hook layer... On agents without hook support the same gate runs as guided instructions." |
| README §"Autopilot" | "The phase gate enforces the pipeline...The hook stops the commit." | "On Claude Code the phase gate enforces at the hook layer... On agents that do not support pre-action hooks the same gate runs as a rule the agent reads; the gate is honest about the difference and `/nano-doctor` reports the actual level." |

### Cross-agent table now reads from adapters

The "What enforces on which agent" matrix is rewritten to use the L0-L3 vocabulary per bash_guard / write_guard / phase_gate, with links to `adapters/` and `reference/host-adapter-schema.md`.

### README.es synced

Spanish README's Guard section updated:

- New tier order (block first, matching PR #139).
- New "Qué se aplica en cada agente" subsection with the same per-host capability table as the English README.
- Brief callout that Write/Edit run through their own hook (`check-write.sh`) with symlink resolution.

## Reading flow

After this PR, setup output, `nano-doctor`, README, and adapter files all share the same vocabulary (Guided / Checked / Guarded / Blocked when unsafe). Future host upgrades update one adapter file; every surface reflects the new state without separate edits.

## Test plan

- [x] `bash tests/run.sh`: 44/44 pass.
- [x] Em-dash lint clean on both READMEs.
- [x] Manual diff review: three over-claims gone; capability matrix cross-references adapter files; Spanish doc internally consistent with the English matrix.

## What this enables

v0.8.0 release tag after merge. The four-sprint plan from `reference/agent-agnostic-delivery-spec.md` is now complete:

1. Schema and adapter files (#147)
2. Doctor consumes them (#148)
3. Setup consumes them (#149)
4. READMEs consume them (this PR)

## Related

`reference/agent-agnostic-delivery-spec.md` "Implementation Plan / Phase 1 (Truthful Guarantees)" and "Phase 2 / Sprint 4".