### PR TITLE
v0.9 PR B: upgrade.sh suggests --repair for legacy projects

### DIFF
--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -7,6 +7,14 @@ set -e
 # Disable git pager globally for this script
 export GIT_PAGER=cat
 
+# Save the original working directory before we cd into the install dir.
+# The post-upgrade hint reads from this path to detect whether the user
+# is currently inside a nanostack-initialized project that predates the
+# hook era. Privacy: nanostack does not maintain a central registry of
+# projects (per agent-agnostic-delivery-spec.md). Only the current cwd
+# is inspected.
+ORIGINAL_PWD="$(pwd)"
+
 # Find nanostack directory
 if [ -f "$(dirname "$0")/../setup" ]; then
   SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -29,6 +37,55 @@ else
   STEP="==>"
 fi
 
+# Post-upgrade migration hint. Looks at ORIGINAL_PWD (the directory the
+# user was in when they ran upgrade.sh) and checks whether
+# .claude/settings.json exists but is missing the PreToolUse hooks. If
+# so, prints the exact command to repair. Silent in every other case
+# (not in a project, hooks already wired, no jq available, etc.).
+print_repair_hint() {
+  command -v jq >/dev/null 2>&1 || return 0
+  local proj_settings="$ORIGINAL_PWD/.claude/settings.json"
+  # If the user wasn't in a project root, walk up to a git root once;
+  # this matches how init-project.sh resolves PROJECT_ROOT.
+  if [ ! -f "$proj_settings" ]; then
+    local git_root
+    git_root=$(cd "$ORIGINAL_PWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || true
+    [ -n "$git_root" ] && proj_settings="$git_root/.claude/settings.json"
+  fi
+  [ -f "$proj_settings" ] || return 0
+
+  # Check whether the Bash and Write/Edit hooks are wired. Same jq
+  # filter as nano-doctor and init-project.sh use so the three tools
+  # stay in sync.
+  local has_bash=0 has_write=0
+  if jq -e '
+    (.hooks.PreToolUse // [])
+    | any(
+        (.matcher // "" | test("Bash"))
+        and ((.hooks // []) | any((.command // "") | contains("check-dangerous.sh")))
+      )
+  ' "$proj_settings" >/dev/null 2>&1; then
+    has_bash=1
+  fi
+  if jq -e '
+    (.hooks.PreToolUse // [])
+    | any(
+        (.matcher // "" | test("Write|Edit"))
+        and ((.hooks // []) | any((.command // "") | contains("check-write.sh")))
+      )
+  ' "$proj_settings" >/dev/null 2>&1; then
+    has_write=1
+  fi
+
+  if [ $has_bash -eq 1 ] && [ $has_write -eq 1 ]; then
+    return 0
+  fi
+
+  printf "\n%b This project's settings need a hook migration:\n" "$STEP"
+  printf "    %s\n" "$proj_settings"
+  printf "    Run: %s/bin/init-project.sh --repair\n" "$SCRIPT_DIR"
+}
+
 # Git clone installation: pull updates
 if [ -d .git ]; then
   BEFORE=$(git rev-parse HEAD)
@@ -44,6 +101,7 @@ if [ -d .git ]; then
 
   if [ "$BEFORE" = "$AFTER" ]; then
     printf "%b Already up to date.\n" "$STEP"
+    print_repair_hint
     exit 0
   fi
 
@@ -62,6 +120,7 @@ if [ -d .git ]; then
     printf "\n%b No setup changes needed.\n" "$STEP"
   fi
 
+  print_repair_hint
   printf "%b Done.\n" "$STEP"
 
 # npx/copy installation: re-install and re-run setup
@@ -71,6 +130,7 @@ else
     npx skills add garagon/nanostack -g --full-depth 2>&1
     printf "\n%b Re-running setup...\n" "$STEP"
     ./setup
+    print_repair_hint
     printf "%b Done.\n" "$STEP"
   else
     echo "Error: npx not found. Install manually:" >&2


### PR DESCRIPTION
## Summary

Sprint 2 of v0.9. After `upgrade.sh` finishes pulling the new nanostack version, it now checks whether the user's current project has `.claude/settings.json` but is missing the PreToolUse hooks for Bash and Write/Edit. If so, it prints the exact `init-project.sh --repair` command. This closes the migration UX from the user's side: the upgrade flow itself names the next step instead of leaving the user with warnings on the next `/nano-doctor` run.

## Sample output (legacy project)

```
==> Updated to abc1234 (4 new commits):
   ...

==> No setup changes needed.

==> This project's settings need a hook migration:
    /Users/dev/myproject/.claude/settings.json
    Run: /Users/dev/.claude/skills/nanostack/bin/init-project.sh --repair
==> Done.
```

Silent in every other case: not in a project, hooks already wired, `jq` unavailable.

## Privacy

Nanostack does not maintain a central project registry. The hint inspects only the current working directory (with a one-step walk to the git root if the cwd is a subdirectory). Matches the constraint in `reference/agent-agnostic-delivery-spec.md` "Upgrade".

## Implementation

- `ORIGINAL_PWD` captured at the very top, before any `cd`.
- New `print_repair_hint` helper uses the same `jq` filter as `nano-doctor` and `init-project.sh` to detect missing hooks, so the three tools stay in sync.
- Hook called at three exit points: git-clone success, git-clone "already up to date", and npx path.

## Test plan

- [x] Project with missing hooks: hint prints with actionable command.
- [x] Project with hooks already wired: silent.
- [x] Not in any project: silent.
- [x] `bash -n upgrade.sh`: passes.
- [x] `bash tests/run.sh`: 44/44 pass.
- [x] Em-dash lint clean.

## What this enables

v0.9.0 release tag. Sprint 1 (PR #152) added the migration flags; this sprint connects the upgrade flow to them. After merge, the v0.9 spec items are all complete:

- Symlink-safe Write/Edit guard (already shipped in v0.8 audit round 4)
- Secret disclosure variants (already shipped)
- CI matrix expanded (already shipped)
- `init-project.sh --repair` (PR #152)
- upgrade.sh post-flow (this PR)

## Related

`reference/agent-agnostic-delivery-spec.md` "Implementation Plan / Phase 3 / Upgrade".