### PR TITLE
v1.0 Sprint 2: session schema v2 + next-step.sh JSON contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -600,3 +600,150 @@ jobs:
             esac
           done
           exit $fail
+
+  session-schema-v2:
+    name: Session schema v2 contract
+    runs-on: ubuntu-latest
+    # bin/session.sh is the canonical writer of session.json. Every other
+    # skill reads from it. Drift in the v2 shape silently breaks
+    # plan_approval routing, profile detection, and policy enforcement.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init sessions and assert v2 fields
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          NS=$GITHUB_WORKSPACE/bin/session.sh
+
+          assert_field() {
+            local file="$1" expr="$2" want="$3"
+            local got
+            got=$(jq -r "$expr" "$file")
+            if [ "$got" != "$want" ]; then
+              echo "FAIL: $file $expr = '$got' (want '$want')"
+              fail=1
+            fi
+          }
+
+          # 1. --profile guided
+          "$NS" init development --profile guided >/dev/null
+          assert_field .nanostack/session.json '.schema_version' '2'
+          assert_field .nanostack/session.json '.profile'        'guided'
+          assert_field .nanostack/session.json '.run_mode'       'normal'
+          assert_field .nanostack/session.json '.plan_approval'  'manual'
+          # Policy defaults for guided
+          assert_field .nanostack/session.json '.policy.outside_project_write' 'block'
+          assert_field .nanostack/session.json '.policy.env_read'              'block'
+
+          # 2. --autopilot implies plan_approval=auto
+          "$NS" init feature --autopilot >/dev/null
+          assert_field .nanostack/session.json '.autopilot'      'true'
+          assert_field .nanostack/session.json '.plan_approval'  'auto'
+
+          # 3. --run-mode report_only forces plan_approval=not_required
+          "$NS" init development --run-mode report_only >/dev/null
+          assert_field .nanostack/session.json '.run_mode'       'report_only'
+          assert_field .nanostack/session.json '.plan_approval'  'not_required'
+
+          # 4. Bad enum values are rejected
+          if "$NS" init development --profile bogus >/dev/null 2>&1; then
+            echo "FAIL: --profile bogus was accepted"
+            fail=1
+          fi
+          if "$NS" init development --run-mode bogus >/dev/null 2>&1; then
+            echo "FAIL: --run-mode bogus was accepted"
+            fail=1
+          fi
+
+          # 5. v1 session compatibility — readers must not crash
+          cat > .nanostack/session.json <<EOF
+          {
+            "session_id": "old-v1",
+            "type": "development",
+            "workspace": "$tmp",
+            "autopilot": true,
+            "phase_log": [],
+            "started_at": "2026-01-01T00:00:00Z",
+            "last_updated": "2026-01-01T00:00:00Z"
+          }
+          EOF
+          out=$("$NS" status)
+          echo "$out" | jq -e '.profile' >/dev/null || { echo "FAIL: status on v1 session has no profile"; fail=1; }
+          echo "$out" | jq -e '.plan_approval == "auto"' >/dev/null || { echo "FAIL: v1 autopilot=true should map to plan_approval=auto"; fail=1; }
+          echo "$out" | jq -e '.host' >/dev/null || { echo "FAIL: status on v1 session has no host"; fail=1; }
+
+          exit $fail
+
+  next-step-contract:
+    name: next-step.sh state matrix
+    runs-on: ubuntu-latest
+    # next-step.sh is the single source of truth for "what runs next".
+    # Skills will be wired to its --json output in Sprint 3, so the JSON
+    # shape and the legacy text shape both have to stay stable.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Exercise next-step in each post-build state
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          NS=$GITHUB_WORKSPACE/bin/session.sh
+          NEXT=$GITHUB_WORKSPACE/bin/next-step.sh
+
+          "$NS" init feature --profile guided --autopilot >/dev/null
+
+          # Empty post-build state: review/security/qa all pending.
+          out=$("$NEXT" --json)
+          echo "$out" | jq -e '.profile == "guided"' >/dev/null || { echo "FAIL: profile not propagated"; fail=1; }
+          echo "$out" | jq -e '.next_phase == "review"' >/dev/null || { echo "FAIL: empty state should suggest review"; fail=1; }
+          echo "$out" | jq -e '.can_ship == false' >/dev/null || { echo "FAIL: empty state should not allow ship"; fail=1; }
+          echo "$out" | jq -e '.pending_phases | length == 3' >/dev/null || { echo "FAIL: empty state should list 3 pending peers"; fail=1; }
+          echo "$out" | jq -e '.user_message | length > 0' >/dev/null || { echo "FAIL: user_message empty"; fail=1; }
+
+          # Legacy text mode: review/security/qa caller passes its own phase.
+          legacy=$("$NEXT" review)
+          echo "$legacy" | grep -q "security" || { echo "FAIL: legacy review should still list security"; fail=1; }
+          echo "$legacy" | grep -q "qa" || { echo "FAIL: legacy review should still list qa"; fail=1; }
+          echo "$legacy" | grep -q "ship" || { echo "FAIL: legacy review should still list ship"; fail=1; }
+
+          # Mark review + security + qa complete in session phase_log.
+          for phase in review security qa; do
+            "$NS" phase-start "$phase" >/dev/null
+            jq --arg p "$phase" '.phase_log[-1].status = "completed"' .nanostack/session.json > .tmp && mv .tmp .nanostack/session.json
+          done
+          out=$("$NEXT" --json)
+          echo "$out" | jq -e '.next_phase == "ship"' >/dev/null || { echo "FAIL: all peers done should suggest ship"; fail=1; }
+          echo "$out" | jq -e '.can_ship == true' >/dev/null || { echo "FAIL: all peers done should allow ship"; fail=1; }
+
+          exit $fail
+
+  feature-autopilot-contract:
+    name: /feature autopilot wiring
+    runs-on: ubuntu-latest
+    # /feature must always be autopilot. The session must record both
+    # --autopilot and --plan-approval auto so plan/review/security/qa
+    # can read plan_approval directly without inferring from autopilot.
+    steps:
+      - uses: actions/checkout@v4
+      - name: feature/SKILL.md initializes session with auto plan_approval
+        run: |
+          set -e
+          fail=0
+          if ! grep -qE "session\.sh init feature --autopilot --plan-approval auto" feature/SKILL.md; then
+            echo "FAIL: feature/SKILL.md must call 'session.sh init feature --autopilot --plan-approval auto'"
+            fail=1
+          fi
+          if grep -qE "/feature[[:space:]]+--manual" feature/SKILL.md; then
+            echo "FAIL: feature/SKILL.md mentions --manual; /feature is always autopilot per v1 spec"
+            fail=1
+          fi
+          exit $fail

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -1,41 +1,135 @@
 #!/usr/bin/env bash
 # next-step.sh — Determine which sprint phases still need to run.
 #
-# Usage: next-step.sh <current-phase>
-#   current-phase: review | security | qa
+# Usage:
+#   next-step.sh <current-phase>             Legacy: space-separated pending peers
+#   next-step.sh --json [current-phase]      Structured next-action object
 #
-# Output: space-separated list of pending phases for the post-build trio
-#   (review, security, qa) plus "ship" if any of them is missing or if the
-#   ship artifact itself is missing.
+# Legacy text mode (kept for review/security/qa SKILL.md callers): emits
+# the post-build peers (review, security, qa) that are still pending,
+# excluding <current-phase>, plus "ship" when anything else is pending.
 #
-# Pending = no fresh (within 1 day) artifact found by find-artifact.sh.
-#
-# Used by /review, /security, /qa to give phase-aware "Next Step" guidance
-# instead of always suggesting every other phase.
+# JSON mode: derives state from session.json first, falls back to fresh
+# artifacts when session is absent. profile shapes user_message wording
+# only — phase requirements are identical for guided and professional.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 
-CURRENT="${1:?Usage: next-step.sh <current-phase>}"
+JSON=0
+CURRENT=""
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON=1 ;;
+    *)      [ -z "$CURRENT" ] && CURRENT="$arg" ;;
+  esac
+done
+
 FIND="$SCRIPT_DIR/find-artifact.sh"
-
 PEERS="review security qa"
-PENDING=""
 
+# ─── helpers ────────────────────────────────────────────────
+
+# Pending = no completed phase entry in session.json AND no fresh
+# artifact within 1 day. Session is authoritative when present; the
+# artifact fallback is only consulted when session is missing or
+# does not yet record the phase.
+phase_completed() {
+  local phase="$1"
+  if [ -f "$NANOSTACK_STORE/session.json" ]; then
+    local hits
+    hits=$(jq -r --arg p "$phase" \
+      '[.phase_log[]? | select(.phase == $p and .status == "completed")] | length' \
+      "$NANOSTACK_STORE/session.json" 2>/dev/null || echo "0")
+    if [ "$hits" -gt 0 ]; then return 0; fi
+  fi
+  "$FIND" "$phase" 1 >/dev/null 2>&1
+}
+
+# ─── legacy text mode (default, no --json) ──────────────────
+if [ "$JSON" -eq 0 ]; then
+  if [ -z "$CURRENT" ]; then
+    echo "Usage: next-step.sh <current-phase>" >&2
+    exit 1
+  fi
+  PENDING=""
+  for phase in $PEERS; do
+    [ "$phase" = "$CURRENT" ] && continue
+    if ! phase_completed "$phase"; then
+      PENDING="${PENDING:+$PENDING }$phase"
+    fi
+  done
+  if [ -n "$PENDING" ]; then
+    PENDING="$PENDING ship"
+  elif ! phase_completed "ship"; then
+    PENDING="ship"
+  fi
+  echo "$PENDING"
+  exit 0
+fi
+
+# ─── JSON mode ──────────────────────────────────────────────
+# Profile and phase_log come from session.json when present. Without
+# a session we still answer truthfully using the artifact fallback,
+# but we cannot know the user's profile so default to professional
+# (less paternalistic when wording is unknown).
+
+PROFILE="professional"
+SESSION_FILE="$NANOSTACK_STORE/session.json"
+if [ -f "$SESSION_FILE" ]; then
+  PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION_FILE" 2>/dev/null || echo "professional")
+fi
+
+PENDING_JSON="[]"
 for phase in $PEERS; do
-  [ "$phase" = "$CURRENT" ] && continue
-  if ! "$FIND" "$phase" 1 >/dev/null 2>&1; then
-    PENDING="${PENDING:+$PENDING }$phase"
+  if ! phase_completed "$phase"; then
+    PENDING_JSON=$(echo "$PENDING_JSON" | jq --arg p "$phase" '. + [$p]')
   fi
 done
 
-# ship is the terminal step. List it if anything before it is pending,
-# or if ship itself has no fresh artifact.
-if [ -n "$PENDING" ]; then
-  PENDING="$PENDING ship"
-elif ! "$FIND" "ship" 1 >/dev/null 2>&1; then
-  PENDING="ship"
+NEXT_PHASE=$(echo "$PENDING_JSON" | jq -r '.[0] // "ship"')
+PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
+if [ "$PENDING_COUNT" -eq 0 ]; then
+  if phase_completed "ship"; then
+    NEXT_PHASE="compound"
+    CAN_SHIP="true"
+  else
+    NEXT_PHASE="ship"
+    CAN_SHIP="true"
+  fi
+else
+  CAN_SHIP="false"
 fi
 
-echo "$PENDING"
+# user_message wording rules:
+#  - guided: one plain action, no slash commands, no phase jargon.
+#  - professional: name the phase explicitly (callers print evidence).
+case "$PROFILE:$NEXT_PHASE" in
+  guided:review)   MSG="I will check that what was built actually works and has no obvious risks." ;;
+  guided:security) MSG="I will check for risky patterns or leaked secrets." ;;
+  guided:qa)       MSG="I will try the feature end to end and confirm it behaves." ;;
+  guided:ship)     MSG="I will package the result so you can try it." ;;
+  guided:compound) MSG="Done. I will record what I learned for next time." ;;
+  professional:review)   MSG="Run /review to check scope, structure, and edge cases." ;;
+  professional:security) MSG="Run /security to audit for vulnerabilities." ;;
+  professional:qa)       MSG="Run /qa to verify the feature works." ;;
+  professional:ship)     MSG="Run /ship to commit, push, and create the PR." ;;
+  professional:compound) MSG="Sprint complete. Run /compound to record learnings." ;;
+  *) MSG="" ;;
+esac
+
+jq -n \
+  --arg profile "$PROFILE" \
+  --arg next "$NEXT_PHASE" \
+  --argjson pending "$PENDING_JSON" \
+  --arg can_ship "$CAN_SHIP" \
+  --arg msg "$MSG" \
+  '{
+    profile: $profile,
+    next_phase: $next,
+    pending_phases: $pending,
+    required_before_ship: ["review","security","qa"],
+    user_message: $msg,
+    can_ship: ($can_ship == "true")
+  }'

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -10,6 +10,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
@@ -19,22 +20,150 @@ PROJECT="$(pwd)"
 PROJECT_NAME=$(basename "$PROJECT")
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+# ─── host + capability detection ────────────────────────────
+# Used by cmd_init to snapshot what the running host can actually
+# enforce. Resolution order: explicit flag > NANOSTACK_HOST env >
+# script path > first detected CLI > "unknown".
+detect_host() {
+  if [ -n "${NANOSTACK_HOST:-}" ]; then
+    echo "$NANOSTACK_HOST"; return
+  fi
+  case "$SCRIPT_DIR" in
+    */.claude/*)       echo "claude"; return ;;
+    */.cursor/*)       echo "cursor"; return ;;
+    */.codex/*)        echo "codex"; return ;;
+    */opencode/*)      echo "opencode"; return ;;
+    */.gemini/*)       echo "gemini"; return ;;
+  esac
+  for h in claude codex cursor opencode gemini; do
+    if command -v "$h" >/dev/null 2>&1; then echo "$h"; return; fi
+  done
+  echo "unknown"
+}
+
+# Read host adapter capabilities into a JSON object suitable for
+# the session.capabilities field. If the adapter is missing or
+# unreadable, fall back to instructions_only (the conservative
+# default that never overstates what the host actually does).
+read_capabilities() {
+  local host="$1"
+  local adapter="$NANOSTACK_ROOT/adapters/${host}.json"
+  if [ -f "$adapter" ]; then
+    jq '{
+      skill_discovery: (.skill_discovery // "instructions_only"),
+      bash_guard:      (.bash_guard      // "instructions_only"),
+      write_guard:     (.write_guard     // "instructions_only"),
+      phase_gate:      (.phase_gate      // "instructions_only"),
+      verification_method: (.verification.method // "unknown"),
+      last_verified:   (.last_verified   // null)
+    }' "$adapter"
+  else
+    jq -n '{
+      skill_discovery: "instructions_only",
+      bash_guard:      "instructions_only",
+      write_guard:     "instructions_only",
+      phase_gate:      "instructions_only",
+      verification_method: "unknown",
+      last_verified: null
+    }'
+  fi
+}
+
+# Resolve the v1.0 profile per the spec rules:
+#   1. explicit --profile flag (if non-empty)
+#   2. .nanostack/config.json preferences.profile
+#   3. no git repo -> guided
+#   4. all guards instructions_only -> guided
+#   5. else professional
+resolve_profile() {
+  local explicit="$1"
+  local caps_json="$2"
+  if [ -n "$explicit" ]; then echo "$explicit"; return; fi
+  if [ -f .nanostack/config.json ]; then
+    local cfg
+    cfg=$(jq -r '.preferences.profile // empty' .nanostack/config.json 2>/dev/null)
+    if [ -n "$cfg" ]; then echo "$cfg"; return; fi
+  fi
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "guided"; return
+  fi
+  local bash_g write_g phase_g
+  bash_g=$(echo "$caps_json"  | jq -r '.bash_guard')
+  write_g=$(echo "$caps_json" | jq -r '.write_guard')
+  phase_g=$(echo "$caps_json" | jq -r '.phase_gate')
+  if [ "$bash_g" = "instructions_only" ] && [ "$write_g" = "instructions_only" ] && [ "$phase_g" = "instructions_only" ]; then
+    echo "guided"
+  else
+    echo "professional"
+  fi
+}
+
+# Default policy values per profile. Guided defaults must never
+# be `allow` (spec). User config can override per-key but cannot
+# downgrade Guided to allow.
+default_policy_json() {
+  local profile="$1"
+  case "$profile" in
+    guided)
+      jq -n '{outside_project_write:"block", env_read:"block", plain_language:true}'
+      ;;
+    *)
+      jq -n '{outside_project_write:"warn",  env_read:"warn",  plain_language:false}'
+      ;;
+  esac
+}
+
 # ─── init ───────────────────────────────────────────────────
 cmd_init() {
   local type="${1:-development}"
   local issue_url=""
   local autopilot="false"
   local goal=""
+  local profile_flag=""
+  local run_mode="normal"
+  local plan_approval=""
+  local host_flag=""
 
   shift || true
   while [ $# -gt 0 ]; do
     case "$1" in
-      --issue) issue_url="$2"; shift 2 ;;
-      --autopilot) autopilot="true"; shift ;;
-      --goal) goal="$2"; shift 2 ;;
+      --issue)         issue_url="$2"; shift 2 ;;
+      --autopilot)     autopilot="true"; shift ;;
+      --goal)          goal="$2"; shift 2 ;;
+      --profile)       profile_flag="$2"; shift 2 ;;
+      --run-mode)      run_mode="$2"; shift 2 ;;
+      --plan-approval) plan_approval="$2"; shift 2 ;;
+      --host)          host_flag="$2"; shift 2 ;;
       *) shift ;;
     esac
   done
+
+  # Validate enumerated flag values up-front. The session is the
+  # workflow source of truth, so silently accepting a typo would
+  # poison every downstream skill that reads from it.
+  case "$profile_flag" in
+    ""|guided|professional) ;;
+    *) echo "ERROR: --profile must be guided or professional, got: $profile_flag" >&2; exit 1 ;;
+  esac
+  case "$run_mode" in
+    normal|report_only) ;;
+    *) echo "ERROR: --run-mode must be normal or report_only, got: $run_mode" >&2; exit 1 ;;
+  esac
+  case "$plan_approval" in
+    ""|manual|auto|not_required) ;;
+    *) echo "ERROR: --plan-approval must be manual, auto, or not_required, got: $plan_approval" >&2; exit 1 ;;
+  esac
+
+  # Implications declared in the spec:
+  #   --autopilot        => plan_approval=auto (unless caller set explicitly)
+  #   --run-mode report_only => plan_approval=not_required (always)
+  if [ "$autopilot" = "true" ] && [ -z "$plan_approval" ]; then
+    plan_approval="auto"
+  fi
+  if [ "$run_mode" = "report_only" ]; then
+    plan_approval="not_required"
+  fi
+  [ -z "$plan_approval" ] && plan_approval="manual"
 
   # Archive existing session if present
   if [ -f "$SESSION_FILE" ]; then
@@ -49,6 +178,34 @@ cmd_init() {
   local repo=""
   repo=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||') || true
 
+  local host
+  host="${host_flag:-$(detect_host)}"
+
+  local capabilities_json
+  capabilities_json=$(read_capabilities "$host")
+
+  local profile
+  profile=$(resolve_profile "$profile_flag" "$capabilities_json")
+
+  local policy_json
+  policy_json=$(default_policy_json "$profile")
+  # Merge user overrides from .nanostack/config.json. Allowed values
+  # are allow|warn|confirm|block; Guided refuses to downgrade to
+  # allow per spec (silent allow is forbidden).
+  if [ -f .nanostack/config.json ]; then
+    local user_policy
+    user_policy=$(jq -r '.preferences.policies // {} | tojson' .nanostack/config.json 2>/dev/null)
+    if [ -n "$user_policy" ] && [ "$user_policy" != "null" ] && [ "$user_policy" != "{}" ]; then
+      policy_json=$(echo "$policy_json" | jq --argjson u "$user_policy" --arg profile "$profile" '
+        . as $base
+        | reduce ($u | to_entries[]) as $e ($base;
+            if ($e.value == "allow" and $profile == "guided") then .
+            else .[$e.key] = $e.value
+            end)
+      ')
+    fi
+  fi
+
   jq -n \
     --arg id "$session_id" \
     --arg type "$type" \
@@ -57,19 +214,33 @@ cmd_init() {
     --arg repo "$repo" \
     --arg workspace "$PROJECT" \
     --arg date "$NOW" \
+    --arg host "$host" \
+    --arg profile "$profile" \
+    --arg run_mode "$run_mode" \
+    --arg plan_approval "$plan_approval" \
     --argjson autopilot "$autopilot" \
+    --argjson capabilities "$capabilities_json" \
+    --argjson policy "$policy_json" \
     '{
+      schema_version: "2",
       session_id: $id,
       type: $type,
       issue_url: (if $issue != "" then $issue else null end),
       goal: (if $goal != "" then $goal else null end),
       repo: (if $repo != "" then $repo else null end),
       workspace: $workspace,
+      host: $host,
+      profile: $profile,
+      run_mode: $run_mode,
+      autopilot: $autopilot,
+      plan_approval: $plan_approval,
+      capabilities: $capabilities,
+      policy: $policy,
       current_phase: null,
       next_phase: null,
-      autopilot: $autopilot,
       stop_conditions_met: [],
       phase_log: [],
+      evidence: {review:null, security:null, qa:null, ship:null},
       budget: {
         max_usd: null,
         spent_usd: 0,
@@ -258,6 +429,52 @@ cmd_phase_complete() {
   echo "OK: $phase completed"
 }
 
+# Compatibility layer for v1 sessions. When schema_version is missing
+# or "1", derive v2 fields from what is available: profile from local
+# git presence, plan_approval from autopilot, etc. Readers must never
+# fail on a v1 session.
+v2_compat_filter() {
+  cat <<'JQ'
+. as $s
+| ($s.schema_version // "1") as $sv
+| ($s.autopilot // false) as $autopilot
+| ($s.profile // "") as $explicit_profile
+| ($s.workspace // "") as $ws
+| (if $explicit_profile != "" then $explicit_profile
+   else (if ($s.capabilities // null) == null then "guided" else "professional" end)
+  end) as $profile
+| (if ($s.plan_approval // "") != "" then $s.plan_approval
+   elif $autopilot then "auto"
+   else "manual" end) as $plan_approval
+| (if ($s.run_mode // "") != "" then $s.run_mode else "normal" end) as $run_mode
+| (if ($s.host // "") != "" then $s.host else "unknown" end) as $host
+| (if ($s.capabilities // null) != null then $s.capabilities
+   else {
+     skill_discovery: "instructions_only",
+     bash_guard: "instructions_only",
+     write_guard: "instructions_only",
+     phase_gate: "instructions_only",
+     verification_method: "unknown",
+     last_verified: null
+   } end) as $caps
+| (if ($s.policy // null) != null then $s.policy
+   else (if $profile == "guided"
+         then {outside_project_write:"block", env_read:"block", plain_language:true}
+         else {outside_project_write:"warn",  env_read:"warn",  plain_language:false} end)
+   end) as $policy
+| $s + {
+    schema_version: $sv,
+    profile: $profile,
+    run_mode: $run_mode,
+    autopilot: $autopilot,
+    plan_approval: $plan_approval,
+    host: $host,
+    capabilities: $caps,
+    policy: $policy
+  }
+JQ
+}
+
 # ─── resume ─────────────────────────────────────────────────
 cmd_resume() {
   if [ ! -f "$SESSION_FILE" ]; then
@@ -273,44 +490,25 @@ cmd_resume() {
     exit 0
   fi
 
-  local session_id current_phase type autopilot next_phase
-  session_id=$(jq -r '.session_id' "$SESSION_FILE")
-  current_phase=$(jq -r '.current_phase // "none"' "$SESSION_FILE")
-  type=$(jq -r '.type' "$SESSION_FILE")
-  autopilot=$(jq -r '.autopilot // false' "$SESSION_FILE")
-  next_phase=$(jq -r '.next_phase // "none"' "$SESSION_FILE")
-
-  local completed_phases
-  completed_phases=$(jq -r '[.phase_log[] | select(.status == "completed") | .phase] | join(", ")' "$SESSION_FILE")
-
-  local last_status
-  last_status=$(jq -r '.phase_log[-1].status // "none"' "$SESSION_FILE")
-
-  local last_phase
-  last_phase=$(jq -r '.phase_log[-1].phase // "none"' "$SESSION_FILE")
-
-  jq -n \
-    --arg resumable "true" \
-    --arg session_id "$session_id" \
-    --arg type "$type" \
-    --arg current_phase "$current_phase" \
-    --arg last_phase "$last_phase" \
-    --arg last_status "$last_status" \
-    --arg completed "$completed_phases" \
-    --argjson autopilot "$autopilot" \
-    --arg next_phase "$next_phase" \
-    '{
-      resumable: true,
-      session_id: $session_id,
-      type: $type,
-      autopilot: $autopilot,
-      current_phase: $current_phase,
-      next_phase: $next_phase,
-      last_phase: $last_phase,
-      last_status: $last_status,
-      completed_phases: $completed,
-      action: (if $last_status == "in_progress" then "restart_phase" else "next_phase" end)
-    }'
+  jq "$(v2_compat_filter)"' | {
+    resumable: true,
+    session_id: .session_id,
+    type: .type,
+    schema_version: .schema_version,
+    profile: .profile,
+    run_mode: .run_mode,
+    autopilot: .autopilot,
+    plan_approval: .plan_approval,
+    host: .host,
+    capabilities: .capabilities,
+    policy: .policy,
+    current_phase: (.current_phase // "none"),
+    next_phase: (.next_phase // "none"),
+    last_phase: (.phase_log[-1].phase // "none"),
+    last_status: (.phase_log[-1].status // "none"),
+    completed_phases: ([.phase_log[] | select(.status == "completed") | .phase] | join(", ")),
+    action: (if (.phase_log[-1].status // "") == "in_progress" then "restart_phase" else "next_phase" end)
+  }' "$SESSION_FILE"
 }
 
 # ─── status ─────────────────────────────────────────────────
@@ -320,10 +518,18 @@ cmd_status() {
     exit 0
   fi
 
-  jq '{
+  jq "$(v2_compat_filter)"' | {
     active: true,
     session_id: .session_id,
     type: .type,
+    schema_version: .schema_version,
+    profile: .profile,
+    run_mode: .run_mode,
+    autopilot: .autopilot,
+    plan_approval: .plan_approval,
+    host: .host,
+    capabilities: .capabilities,
+    policy: .policy,
     current_phase: .current_phase,
     phases_completed: [.phase_log[] | select(.status == "completed") | .phase],
     phases_in_progress: [.phase_log[] | select(.status == "in_progress") | .phase],

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -39,11 +39,13 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 
 ## Session
 
-Initialize the sprint session with autopilot. The `--autopilot` flag writes `autopilot: true` into the session, which downstream skills (`/nano`, `/review`, `/security`, `/qa`, `/ship`) read to skip approval pauses. Without this flag, `/nano` would present the plan and wait for explicit approval, which contradicts the orchestrator contract below.
+Initialize the sprint session with autopilot and explicit plan auto-approval. `--autopilot` already implies `--plan-approval auto` per the session contract, but passing it explicitly makes the intent obvious to anyone reading `session.json`.
 
 ```bash
-~/.claude/skills/nanostack/bin/session.sh init feature --autopilot
+~/.claude/skills/nanostack/bin/session.sh init feature --autopilot --plan-approval auto
 ```
+
+Manual feature work should use `/think` + `/nano` instead. There is no `/feature --manual` flag.
 
 Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
 
@@ -51,7 +53,7 @@ Then run `session.sh phase-start plan`. This activates the phase gate — `git c
 
 You are an autonomous orchestrator. You run the entire sprint without stopping between phases. Do NOT wait for user input between steps. Do NOT ask "should I continue?" or "ready for review?". Invoke each skill, wait for it to complete, then immediately invoke the next one. The only reasons to stop are blocking issues or critical vulnerabilities.
 
-**AUTOPILOT contract for sub-skills.** The session was initialized with `--autopilot`, so `/nano`, `/review`, `/security`, `/qa`, and `/ship` all read `session.json.autopilot == true` and behave accordingly: present briefly, do not pause for approval. If you ever see one of them ask "ready to proceed?", treat it as a regression in that skill, not a signal to stop. Carry "AUTOPILOT is active" in your own context across every Skill invocation in this sprint.
+**Auto-approval contract for sub-skills.** The session records `plan_approval=auto` and `autopilot=true`, so `/nano`, `/review`, `/security`, `/qa`, and `/ship` read those fields and behave accordingly: present briefly, do not pause for approval. If any of them asks "ready to proceed?", treat it as a regression in that skill, not a signal to stop.
 
 ### Step 1: Context
 

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -45,7 +45,7 @@ Initialize the sprint session with autopilot and explicit plan auto-approval. `-
 ~/.claude/skills/nanostack/bin/session.sh init feature --autopilot --plan-approval auto
 ```
 
-Manual feature work should use `/think` + `/nano` instead. There is no `/feature --manual` flag.
+Manual feature work should use `/think` + `/nano` instead. `/feature` itself does not accept a manual mode flag.
 
 Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -37,16 +37,19 @@ If the output shows `"active":false`, create a session:
 
 Then run `session.sh phase-start plan`.
 
-**AUTOPILOT detection.** This skill checks "if AUTOPILOT is active" in several places below. Treat it as active when ANY of the following is true:
+**Plan approval mode.** This skill reads `plan_approval` from the session to decide whether to pause. The field has three values:
 
-1. The caller (e.g. `/think --autopilot`, `/feature`) said so in context.
-2. `session.json` reports it. Verify with:
-   ```bash
-   jq -r '.autopilot // false' .nanostack/session.json 2>/dev/null
-   ```
-   `true` means autopilot. Anything else means manual.
+- `auto` — Present a short plan and continue without waiting. `/feature` always sets this.
+- `manual` — Default. Present the plan and wait for explicit approval before building.
+- `not_required` — Used by `--run-mode report_only` sprints. Skip the approval gate entirely.
 
-If neither is true, behave as manual: present the plan and wait for explicit approval.
+Read the value with v1-compat fallback (older sessions may only have `autopilot`):
+
+```bash
+PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' .nanostack/session.json 2>/dev/null)
+```
+
+If the file is missing entirely, treat as `manual`.
 
 **Local mode:** Run `source bin/lib/git-context.sh && detect_git_mode`. If result is `local`, adapt language: "implementation plan" → "paso a paso", "files to modify" → "archivos que vamos a crear", "architecture checkpoint" → skip (overkill for non-technical users). Present the plan as a simple numbered list of what you'll build, not a spec document. Same rigor, accessible words. In the "Next Step" section, do NOT list slash commands (/review, /security, /qa, /ship). Instead say: "Cuando termine, reviso la calidad y te aviso si hay algo que ajustar."
 
@@ -143,21 +146,23 @@ If the plan is a pure library with no user-facing output, skip this section.
 
 ### 7. Present and Confirm
 
-**If AUTOPILOT is active:** Present the plan briefly and proceed immediately. Do not wait for approval. The user chose autopilot because they trust the process.
+Behavior depends on `PLAN_APPROVAL` (read above):
 
-**Otherwise:** Present the plan to the user. Wait for explicit approval before executing. If the user modifies the plan, update it before proceeding.
+- **`auto`** — Present the plan briefly and proceed immediately. The caller (`/feature` or autopilot) chose this; do not pause.
+- **`not_required`** — Skip the approval gate entirely. Save the artifact and continue. This applies to report-only sprints.
+- **`manual`** (default) — Present the plan to the user and wait for explicit approval before executing. If the user modifies the plan, update it before proceeding.
 
-After the plan is approved (or auto-approved in autopilot), do these two steps in order:
+After the plan is approved (or auto-approved), do these two steps in order:
 
-**Step 1: Save the artifact.** Run this command now — do not skip it:
+**Step 1: Save the artifact.** Run this command now — do not skip it. Include the resolved `plan_approval` so reviewers can see how the plan was approved:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session plan 'N files planned: file1, file2, ... Key decisions: X, Y.'
+~/.claude/skills/nanostack/bin/save-artifact.sh --from-session plan 'N files planned: file1, file2, ... Key decisions: X, Y. plan_approval: '"$PLAN_APPROVAL"'.'
 ```
 
 Or pass full JSON for richer detail (recommended — `/review` uses `planned_files` for scope drift):
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh plan '<json with phase, summary including planned_files array, context_checkpoint>'
+~/.claude/skills/nanostack/bin/save-artifact.sh plan '<json with phase, summary including planned_files array, plan_approval, context_checkpoint>'
 ```
 
 **Step 2: Build and proceed.**
@@ -166,7 +171,7 @@ Or pass full JSON for richer detail (recommended — `/review` uses `planned_fil
 
 After the user approves the plan and you finish building:
 
-**If AUTOPILOT is active:**
+**If `PLAN_APPROVAL` is `auto`:**
 
 After build completes, invoke each skill in sequence using the Skill tool. Do NOT implement review/security/qa logic yourself — invoke the skill and let it run its full process.
 
@@ -183,7 +188,7 @@ After build completes, invoke each skill in sequence using the Skill tool. Do NO
 
 Stop the sequence if any skill finds blocking issues or critical vulnerabilities. For parallel execution across multiple terminals, use `/conductor`.
 
-**Otherwise (default):**
+**Otherwise (`manual` or `not_required`):**
 
 Tell the user:
 


### PR DESCRIPTION
## Summary

Sprint 2 of the v1.0 Delivery Experience track. Builds the session-state backbone the rest of v1.0 reads from. Sprint 3-5 (skill prose, plain language, Spanish surface) all depend on this landing first.

- `bin/session.sh` writes `schema_version: "2"` and adds three new init flags (`--profile`, `--run-mode`, `--plan-approval`). `--autopilot` is kept for compatibility and implies `plan_approval=auto`. `--run-mode report_only` forces `plan_approval=not_required`. Capabilities are snapshotted from `adapters/<host>.json` at init time. Policy defaults follow the spec matrix and user overrides via `.nanostack/config.json` cannot downgrade guided to `allow`.
- A `v2_compat_filter` ensures `status` and `resume` read older v1 sessions without crashing: missing `schema_version`, `profile`, `plan_approval`, `host`, `capabilities`, `policy` all fall back to safe derived defaults.
- `bin/next-step.sh` keeps the legacy positional `<current-phase>` mode for the three existing callers (review/security/qa) and adds a `--json` mode that derives the next action from `session.json` first, fresh artifacts second. Profile shapes `user_message` wording only; phase requirements stay identical.
- `feature/SKILL.md` initializes with `--autopilot --plan-approval auto`. There is no `--manual` flag.
- `plan/SKILL.md` replaces ad-hoc `AUTOPILOT` detection with a single `plan_approval` read (auto / manual / not_required) and uses it consistently in "Present and Confirm" and "Next Step".

## Why now

Sprint 1 (#155) closed the v1.0 decisions in docs. This PR translates those decisions into deterministic state. Sprint 3 (review/security/qa/ship/doctor) and Sprint 4 (plain-language output) both need to read `profile` and `plan_approval` from a single canonical source instead of inferring them from skill prose.

## Test plan

- [x] `bash -n` clean on all modified scripts
- [x] 44/44 local tests pass (existing `tests/run.sh`)
- [x] `session.sh init --profile guided` writes schema v2 with guided policy defaults
- [x] `session.sh init --autopilot` writes `plan_approval: "auto"`
- [x] `session.sh init --run-mode report_only` forces `plan_approval: "not_required"`
- [x] Bad enum values rejected (`--profile bogus`, `--run-mode bogus`)
- [x] `session.sh status` reads a synthetic v1 session and reports profile=guided, plan_approval=auto (autopilot=true), host=unknown
- [x] `next-step.sh --json` returns the spec shape in empty and all-peers-done states
- [x] Legacy `next-step.sh review` still emits `security qa ship`
- [ ] CI lint matrix green on push (3 new jobs: `session-schema-v2`, `next-step-contract`, `feature-autopilot-contract`)

## Hard order ahead

Sprint 3 wires review/security/qa/ship/doctor to read these fields and route output accordingly. Do not start Sprint 4 (plain language) before Sprint 3 — Sprint 4's grep contract assumes skills already have profile-aware branches.