### PR TITLE
v1.0 Sprint 3: skills consume session state

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -747,3 +747,76 @@ jobs:
             fail=1
           fi
           exit $fail
+
+  skills-consume-session-state:
+    name: Skills consume session state
+    runs-on: ubuntu-latest
+    # Sprint 3 contract: review/security/qa/ship/doctor must read profile,
+    # run_mode, autopilot, and plan_approval from session.json (via the
+    # shared contract reference) and must not encode their own next-step
+    # prose. This job greps for the wiring so a future edit cannot
+    # silently regress one skill.
+    steps:
+      - uses: actions/checkout@v4
+      - name: SKILL.md files reference the shared session-state contract
+        run: |
+          set -e
+          fail=0
+
+          # The shared contract document must exist; skills point at it.
+          if [ ! -f reference/session-state-contract.md ]; then
+            echo "FAIL: reference/session-state-contract.md is missing"
+            exit 1
+          fi
+
+          # review/security/qa each read session state and use --json for
+          # next-step prose. Ship reads profile to branch close; doctor
+          # branches by session_profile from JSON.
+          for skill in review/SKILL.md security/SKILL.md qa/SKILL.md; do
+            if ! grep -q "reference/session-state-contract.md" "$skill"; then
+              echo "FAIL: $skill must reference reference/session-state-contract.md"
+              fail=1
+            fi
+            if ! grep -qE "next-step\.sh --json" "$skill"; then
+              echo "FAIL: $skill must call bin/next-step.sh --json"
+              fail=1
+            fi
+            if ! grep -qE "run_mode" "$skill"; then
+              echo "FAIL: $skill must read run_mode (report_only must not edit files)"
+              fail=1
+            fi
+          done
+
+          if ! grep -qE "session-state-contract\.md|session_profile|profile == \"guided\"" ship/SKILL.md; then
+            echo "FAIL: ship/SKILL.md must branch by session profile"
+            fail=1
+          fi
+
+          if ! grep -q "fix_available" doctor/SKILL.md; then
+            echo "FAIL: doctor/SKILL.md must document the fix_available JSON field"
+            fail=1
+          fi
+          if ! grep -q "session_profile" doctor/SKILL.md; then
+            echo "FAIL: doctor/SKILL.md must document the session_profile JSON field"
+            fail=1
+          fi
+
+          exit $fail
+
+      - name: nano-doctor.sh --json exposes fix_available + fix_command + session_profile
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d)
+          cd "$tmp"
+          mkdir -p .nanostack
+          # Synthetic session so session_profile resolves on JSON output.
+          cat > .nanostack/session.json <<EOF
+          {"schema_version":"2","session_id":"ci","workspace":"$tmp","profile":"guided","autopilot":false}
+          EOF
+          out=$($GITHUB_WORKSPACE/bin/nano-doctor.sh --json --offline 2>/dev/null) || true
+          echo "$out" | jq -e 'has("fix_available")'   >/dev/null || { echo "FAIL: doctor JSON missing fix_available"; fail=1; }
+          echo "$out" | jq -e 'has("fix_command")'     >/dev/null || { echo "FAIL: doctor JSON missing fix_command"; fail=1; }
+          echo "$out" | jq -e 'has("session_profile")' >/dev/null || { echo "FAIL: doctor JSON missing session_profile"; fail=1; }
+          echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
+          exit $fail

--- a/bin/nano-doctor.sh
+++ b/bin/nano-doctor.sh
@@ -542,16 +542,59 @@ if $JSON_OUTPUT; then
   if [ "$FAIL" -gt 0 ]; then _overall="fail"
   elif [ "$WARN" -gt 0 ]; then _overall="warn"
   fi
+
+  # fix_available is true when at least one warn/fail row sits in a
+  # category --fix can repair (home permissions, sender_executable,
+  # bash_guard, write_guard). The user-facing skill needs a single
+  # bit to decide whether to even mention --fix.
+  _fix_available="false"
+  _fix_targets="permissions:bash_guard permissions:write_guard install:sender_executable home:permissions"
+  while IFS=$'\t' read -r _s _c _n _d; do
+    [ -z "$_s" ] && continue
+    [ "$_s" = "pass" ] && continue
+    for _t in $_fix_targets; do
+      if [ "${_c}:${_n}" = "$_t" ]; then
+        _fix_available="true"
+        break
+      fi
+    done
+    [ "$_fix_available" = "true" ] && break
+  done <<EOF
+$CHECK_LINES
+EOF
+
+  # Pick up the project session profile if one exists in CWD. The
+  # session snippet lives in NANOSTACK_STORE; tolerate its absence.
+  _session_profile="null"
+  for _sf in ".nanostack/session.json" "$HOME/.nanostack/session.json"; do
+    if [ -f "$_sf" ]; then
+      _sp=$(jq -r '.profile // empty' "$_sf" 2>/dev/null)
+      if [ -n "$_sp" ]; then
+        _session_profile="\"$_sp\""
+        break
+      fi
+    fi
+  done
+
   printf '%s' "$CHECK_LINES" | jq -R -s \
     --arg overall "$_overall" \
     --argjson pass "$PASS" \
     --argjson warn "$WARN" \
-    --argjson fail "$FAIL" '
+    --argjson fail "$FAIL" \
+    --argjson fix_available "$_fix_available" \
+    --argjson session_profile "$_session_profile" '
       split("\n")
       | map(select(length > 0))
       | map(split("\t"))
       | map({status:.[0], category:.[1], name:.[2], detail:.[3]}) as $checks
-      | {overall:$overall, pass:$pass, warn:$warn, fail:$fail, checks:$checks}
+      | {
+          overall: $overall,
+          pass: $pass, warn: $warn, fail: $fail,
+          checks: $checks,
+          fix_available: $fix_available,
+          fix_command: (if $fix_available then "nano-doctor.sh --fix" else null end),
+          session_profile: $session_profile
+        }
     '
 else
   # Human-readable report.

--- a/doctor/SKILL.md
+++ b/doctor/SKILL.md
@@ -33,7 +33,7 @@ Run the health check script, then summarize what the user actually needs to do:
 
 Optional flags:
 
-- `--json` — machine-readable output. Use when invoked by another tool or when piping to `jq`.
+- `--json` — machine-readable output. Use when invoked by another tool or when piping to `jq`. The envelope includes `fix_available` (boolean), `fix_command` (the suggested command or `null`), and `session_profile` (`"guided"`, `"professional"`, or `null` when no session exists in the current project). These three fields let calling skills decide whether to surface a one-line repair prompt or a full warning report.
 - `--offline` — skip Worker reachability. Use in air-gapped environments or during CI.
 - `--fix` — repair mechanical issues. Currently covers: `chmod 700` on `~/.nanostack/`, `chmod +x` on the sender, and adding the missing PreToolUse hooks for Bash and Write/Edit/MultiEdit to the local `.claude/settings.json`. Always backs up the file first as `.claude/settings.json.YYYYMMDD-HHMMSS.bak`. Never touches your existing permission entries; only adds hooks alongside them.
 
@@ -69,15 +69,19 @@ npx create-nanostack
 
 That reinstalls and preserves the existing `~/.nanostack/` (telemetry config, installation-id, past opt-in choice).
 
-## Local mode
+## Profile-aware output
 
-If the user is non-technical (detected via `bin/lib/git-context.sh` `local` mode), do not dump the raw report. Translate the outcome into one sentence:
+Read `session_profile` from the JSON envelope (or default to `professional` if no session exists). Branch the user-facing summary by profile:
+
+**Guided profile (also: local mode, no git, non-technical user).** Do not dump the raw report and do not lead with "hooks/settings JSON". Translate the outcome into one sentence:
 
 - All ok: "Nanostack está sano, todo en orden."
-- Warnings: "Hay algunos avisos menores. ¿Querés que los repare?" then offer to run with `--fix`.
+- Warnings: "Hay algunos avisos menores. ¿Querés que los repare?" then offer to run with `--fix` if `fix_available` is true.
 - Failures: "Hay un problema con la instalación. Lo más probable es que necesites reinstalar con `npx create-nanostack`. ¿Querés que te guíe?"
 
-Never read the internal category names ("install", "detection") to a non-technical user. Those are for the report, not for the conversation.
+Never read the internal category names ("install", "detection") to a Guided user. Those are for the report, not for the conversation.
+
+**Professional profile.** Print the full report. Lead with the failed/warned rows, name the missing hook or permission directly, and surface `fix_command` verbatim when `fix_available` is true. Example: `write_guard: warn — check-write.sh missing from .claude/settings.json. Fix: nano-doctor.sh --fix`.
 
 ## Telemetry finalize
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -204,25 +204,27 @@ Or pass full JSON for richer detail:
 | Regression tests | Skip | If fixing a bug | Full regression suite |
 | WTF threshold | 20% | 20% | 20% |
 
+## Session state
+
+Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/session-state-contract.md`. When `run_mode == report_only`, do not auto-fix bugs; only report what fails.
+
 ## Next Step
 
 After QA is complete and the artifact is saved:
 
-**If AUTOPILOT is active and tests pass:** Proceed to `/ship`. Show: `Autopilot: qa passed (X tests, 0 failed). Running /ship...`
+**If `autopilot == true` and tests pass:** Proceed to `/ship`. Show: `Autopilot: qa passed (X tests, 0 failed). Running /ship...`
 
-**If AUTOPILOT is active but tests fail:** Stop and ask the user. Show failures and wait.
+**If autopilot and tests fail:** Stop and ask the user. Show failures and wait.
 
-**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+**Otherwise:** Read the next action from session state:
 
 ```bash
-~/.claude/skills/nanostack/bin/next-step.sh qa
+~/.claude/skills/nanostack/bin/next-step.sh --json
 ```
 
-The script outputs a space-separated list of pending phases. Tell the user only what is pending. Examples:
-- Output `review security ship` → "QA complete. Next: `/review`, then `/security`, then `/ship`."
-- Output `security ship`        → "QA complete. Next: `/security`, then `/ship`."
-- Output `ship`                 → "QA complete. Ready for `/ship`."
-- Empty output                  → "QA complete. Sprint is fully verified."
+Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh qa`) is still supported.
+
+When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
 
 ## Final Headline
 

--- a/reference/session-state-contract.md
+++ b/reference/session-state-contract.md
@@ -1,0 +1,76 @@
+# Session-state contract for skills
+
+This is the read-side contract for `session.json` schema v2 (introduced in Sprint 2 of v1.0). Every skill that runs after `/nano` reads from this file to decide:
+
+- whether to pause for approval
+- whether to edit files at all
+- how to phrase its final output
+- which phase to suggest next
+
+Do not infer these answers from skill prose, command-line arguments, or conversation context. Read them from `session.json`.
+
+## Reading the four fields
+
+Use this snippet near the top of any skill that reads session state. It is safe on v1 sessions: the `// fallback` jq filters provide the spec compatibility defaults.
+
+```bash
+SESSION=$NANOSTACK_STORE/session.json
+[ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
+
+PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION" 2>/dev/null || echo "professional")
+RUN_MODE=$(jq -r '.run_mode // "normal"' "$SESSION" 2>/dev/null || echo "normal")
+AUTOPILOT=$(jq -r '.autopilot // false' "$SESSION" 2>/dev/null || echo "false")
+PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' "$SESSION" 2>/dev/null || echo "manual")
+```
+
+If the session file does not exist, default to `professional` / `normal` / `false` / `manual`.
+
+## What each field decides
+
+| Field | Values | What the skill must do |
+|---|---|---|
+| `profile` | `guided` \| `professional` | Shapes the final output. Guided uses the four-block format below; Professional preserves findings/evidence style. |
+| `run_mode` | `normal` \| `report_only` | When `report_only`, the skill must NOT edit files, fix issues, commit, push, or call any `--fix` mode. It only reports. |
+| `autopilot` | `true` \| `false` | When `true`, do not pause between phases. Show one status line and continue. |
+| `plan_approval` | `manual` \| `auto` \| `not_required` | Used by `/nano` to decide whether to wait for plan approval. Other skills usually mirror autopilot. |
+
+## Guided final-output blocks
+
+When `PROFILE == "guided"`, the final user-facing output of every Sprint phase (review, security, qa, ship, doctor) must include these four blocks in order:
+
+1. **What was checked** — one or two sentences naming what the skill actually inspected.
+2. **Whether it is safe to try** — yes / not yet, with a short reason.
+3. **One next action** — exactly one. Use `bin/next-step.sh --json | jq -r .user_message` for the wording.
+4. **What remains unverified** — list things the skill could not check (e.g. "No probé el flujo en producción", "No revisé seguridad de dependencias").
+
+Skills MAY include short technical details after these four blocks if useful, but the four blocks come first.
+
+## Professional final-output
+
+When `PROFILE == "professional"`, keep the existing findings/evidence format. Use `bin/next-step.sh --json | jq -r .user_message` for the next-step prose so the wording stays consistent across skills.
+
+## Next-step contract
+
+Stop encoding next-step prose in each skill. Call:
+
+```bash
+~/.claude/skills/nanostack/bin/next-step.sh --json
+```
+
+Read `.user_message` for the next action and `.next_phase` for the phase name. The script reads `session.json` first, falls back to fresh artifacts, and chooses wording based on `profile`. Skills must NOT print their own list of pending phases.
+
+## report_only guard
+
+Place this near the top of the skill's process section, before any edit/fix step:
+
+```bash
+if [ "$RUN_MODE" = "report_only" ]; then
+  # Do not edit files, do not run --fix, do not commit, do not push.
+  # Only describe what would change.
+  REPORT_ONLY=1
+else
+  REPORT_ONLY=0
+fi
+```
+
+Subsequent steps must check `$REPORT_ONLY` before mutating anything. A skill that ignores this flag is a regression: report-only sprints exist so a user can see what the skill would do without committing the agent to action.

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -167,25 +167,29 @@ Or pass full JSON for richer detail:
 | Conflict detection | Auto-resolve | Document inline | BLOCKING until resolved |
 | Output | Blocking issues only | All categories | All + rationale per finding |
 
+## Session state
+
+Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/session-state-contract.md`. When `run_mode == report_only`, do not apply any fix or write any file as part of review; only report what would change.
+
 ## Next Step
 
 After the review is complete and the artifact is saved, proceed:
 
-**If AUTOPILOT is active and no blocking issues found:** Proceed directly to the next pending skill (`/security` or `/qa`). Show: `Autopilot: review complete (X findings, 0 blocking). Running /security...`
+**If `autopilot == true` (or `plan_approval == "auto"`) and no blocking issues found:** Proceed directly to the next pending skill. Show: `Autopilot: review complete (X findings, 0 blocking). Running /security...`
 
-**If AUTOPILOT is active but blocking issues found:** Stop and ask the user to resolve. Show the blocking issues and wait. After resolution, continue autopilot.
+**If autopilot and blocking issues found:** Stop and ask the user to resolve. Show the blocking issues and wait. After resolution, continue autopilot.
 
-**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+**Otherwise:** Read the next action from session state. Do not encode the wording here:
 
 ```bash
-~/.claude/skills/nanostack/bin/next-step.sh review
+~/.claude/skills/nanostack/bin/next-step.sh --json
 ```
 
-The script outputs a space-separated list of pending phases (e.g. `security qa ship`). Tell the user only what is pending. Examples:
-- Output `security qa ship` → "Review complete. Next: `/security`, then `/qa`, then `/ship`."
-- Output `qa ship`          → "Review complete. Next: `/qa`, then `/ship`."
-- Output `ship`             → "Review complete. Ready for `/ship`."
-- Empty output              → "Review complete. Sprint is fully verified."
+Use `.user_message` for the prose to show the user (it is profile-aware). Use `.next_phase` to know which phase comes next.
+
+The legacy positional form (`next-step.sh review`) still works and emits a space-separated list of pending phases for the autopilot logging line below; prefer `--json` for everything else.
+
+When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
 
 ## Final Headline
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -229,25 +229,27 @@ Or pass full JSON for richer detail:
 | Tentative findings | Skip | Skip | Report as TENTATIVE |
 | Confidence gate | 9/10 | 7/10 | 3/10 |
 
+## Session state
+
+Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/session-state-contract.md`. When `run_mode == report_only`, do not apply fixes; only report findings.
+
 ## Next Step
 
 After the security audit is complete and the artifact is saved:
 
-**If AUTOPILOT is active and no critical/high findings:** Proceed to next pending skill (`/qa` or `/ship`). Show: `Autopilot: security grade X (0 critical, 0 high). Running /qa...`
+**If `autopilot == true` and no critical/high findings:** Proceed to next pending skill. Show: `Autopilot: security grade X (0 critical, 0 high). Running /qa...`
 
-**If AUTOPILOT is active but critical or high findings found:** Stop and ask the user to review. Show the findings and wait. After resolution, continue autopilot.
+**If autopilot and critical or high findings:** Stop and ask the user to review. Show the findings and wait. After resolution, continue autopilot.
 
-**Otherwise:** Determine which phases still need to run (do not suggest skills the user already ran). Run:
+**Otherwise:** Read the next action from session state:
 
 ```bash
-~/.claude/skills/nanostack/bin/next-step.sh security
+~/.claude/skills/nanostack/bin/next-step.sh --json
 ```
 
-The script outputs a space-separated list of pending phases. Tell the user only what is pending. Examples:
-- Output `review qa ship` → "Security audit complete. Next: `/review`, then `/qa`, then `/ship`."
-- Output `qa ship`        → "Security audit complete. Next: `/qa`, then `/ship`."
-- Output `ship`           → "Security audit complete. Ready for `/ship`."
-- Empty output            → "Security audit complete. Sprint is fully verified."
+Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh security`) is still supported.
+
+When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
 
 ## Final Headline
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -201,11 +201,32 @@ Or pass full JSON for richer detail:
 ~/.claude/skills/nanostack/bin/sprint-journal.sh
 ```
 
-**Step 2: How to see the result.**
+**Step 2: Proof block.** Before "How to see the result", emit a proof block summarizing what was verified during the sprint. Read it from session phase_log:
 
-**If AUTOPILOT is active:** Skip this question. Go directly to Next Step (compound + sprint summary). The user will decide how to run it after the sprint closes.
+```bash
+SESSION=$NANOSTACK_STORE/session.json
+[ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
+jq -r '
+  ([.phase_log[]? | select(.phase == "review"   and .status == "completed")] | length) as $rev   |
+  ([.phase_log[]? | select(.phase == "security" and .status == "completed")] | length) as $sec   |
+  ([.phase_log[]? | select(.phase == "qa"       and .status == "completed")] | length) as $qa    |
+  "Reviewed: \(if $rev   > 0 then "yes" else "no" end)\n" +
+  "Security checked: \(if $sec > 0 then "yes" else "no" end)\n" +
+  "QA checked: \(if $qa  > 0 then "yes" else "no" end)"
+' "$SESSION" 2>/dev/null
+```
 
-**Otherwise**, ask:
+If a phase says `no`, list it under "Not verified" so the user sees what was skipped instead of inferring it from absence.
+
+**Step 3: How to see the result.**
+
+Read `profile` from session per `reference/session-state-contract.md`. The branch differs by profile:
+
+**If `profile == "guided"` (or no git remote, even when professional):** Skip the deployment menu and focus on how to try the result locally. Tell the user where the entry point is and the exact command to run, then list anything that is not yet verified (e.g. "I did not deploy this to the internet"). One next action only.
+
+**If `profile == "professional"` and `autopilot == true`:** Skip this question. Go directly to Next Step (compound + sprint summary). The user will decide how to run it after the sprint closes.
+
+**Otherwise (professional, manual)**, ask:
 > How do you want to see it?
 > 1. Local — I'll start the server and show you how to open it
 > 2. Production — I'll guide you through deploying to the internet


### PR DESCRIPTION
## Summary

Sprint 3 of the v1.0 Delivery Experience track. Wires review/security/qa/ship/doctor to read the schema v2 fields landed in #156 (`profile`, `run_mode`, `autopilot`, `plan_approval`) instead of inferring them from skill prose or context.

- `reference/session-state-contract.md` (new): single source of truth for how skills read session state. Canonical jq snippet with v1-compat fallbacks. Decision table for each field. Guided four-block output skeleton. `report_only` guard. Next-step prose comes from `bin/next-step.sh --json`.
- `review/SKILL.md`, `security/SKILL.md`, `qa/SKILL.md`: new "Session state" section pointing at the contract; `run_mode == report_only` blocks edits/fixes; "Next Step" rewired to use `next-step.sh --json` for prose. Guided profile must add the four blocks at the top of output (Sprint 4 polishes wording).
- `ship/SKILL.md`: new proof block before "How to see the result" (review/security/qa yes/no from `session.phase_log`); Guided/no-git close skips deployment menu and focuses on how to try the result locally; professional autopilot still skips, professional manual still asks.
- `doctor/SKILL.md` and `bin/nano-doctor.sh`: JSON envelope now exposes `fix_available` (boolean), `fix_command` (string or null), and `session_profile` (guided/professional/null). doctor SKILL replaces ad-hoc "Local mode" branch with profile-aware output: Guided gets one Spanish sentence and an `--fix` offer when applicable; Professional gets the full report and the explicit fix command.

## Why now

Sprint 2 (#156) wrote the session schema; nothing was reading it yet. Sprint 4 will rewrite output prose against `reference/plain-language-contract.md`, which assumes skills already have profile-aware branches. Landing those branches now keeps Sprint 4's grep contract honest.

## Test plan

- [x] `bash -n` clean on `bin/nano-doctor.sh`
- [x] 44/44 local tests pass
- [x] `nano-doctor.sh --json --offline` against a synthetic guided session returns `fix_available`, `fix_command`, `session_profile=guided`
- [ ] CI lint matrix green on push (1 new job: `skills-consume-session-state` with two contract-grep + JSON-envelope subchecks)

## Hard order ahead

Sprint 4 (plain language) is now unblocked. Next: `reference/plain-language-contract.md` and the Guided wording rewrites in think/plan/qa/ship/doctor. Sprint 5 (Spanish first-class) and Sprint 6 (release) follow.