### PR TITLE
v1.0 Sprint 4: plain-language contract for Guided output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -820,3 +820,71 @@ jobs:
           echo "$out" | jq -e 'has("session_profile")' >/dev/null || { echo "FAIL: doctor JSON missing session_profile"; fail=1; }
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
+
+  plain-language-contract:
+    name: Plain-language contract (Guided output)
+    runs-on: ubuntu-latest
+    # Sprint 4 contract. The wording rule applies to user-facing Guided
+    # output, not to skill instructions. To avoid false positives on
+    # prose like "scope drift is informational", only the fenced blocks
+    # marked with <!-- guided-output:start --> ... <!-- guided-output:end -->
+    # are scanned. Outside the fence, banned terms are allowed.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Contract document exists and is referenced
+        run: |
+          set -e
+          fail=0
+          if [ ! -f reference/plain-language-contract.md ]; then
+            echo "FAIL: reference/plain-language-contract.md is missing"
+            exit 1
+          fi
+          # Each user-facing skill must point at the contract so wording
+          # changes don't drift away from the canonical list.
+          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md; do
+            if ! grep -q "reference/plain-language-contract.md" "$skill"; then
+              echo "FAIL: $skill must reference reference/plain-language-contract.md"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Guided fenced blocks pass the banned-term grep
+        run: |
+          set -e
+          fail=0
+          # Banned terms (case-insensitive whole-word). Order matches
+          # the contract's term table. Patterns use word boundaries so
+          # "diff" doesn't match "different".
+          patterns='\bartifact\b|\bartifacts\b|\bPR\b|\bPRs\b|\bCI\b|\bbranch\b|\bbranches\b|\bdiff\b|\bdiffs\b|\bhook\b|\bhooks\b|\bphase\b|\bphases\b|\bsecurity audit\b|\bQA\b|\bscope drift\b'
+          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md reference/plain-language-contract.md; do
+            # Extract fenced blocks. awk emits one line per block,
+            # joined with " || " so grep -E -i sees the full block.
+            blocks=$(awk '
+              /<!-- guided-output:start -->/ { capture=1; buf=""; next }
+              /<!-- guided-output:end -->/   { if (capture) { print buf; buf="" } capture=0; next }
+              capture { buf = buf " " $0 }
+            ' "$skill")
+            if [ -z "$blocks" ]; then
+              # Skills that print user-facing Guided output must include
+              # at least one example block. The contract reference itself
+              # has multiple examples and is allowed here too.
+              if [ "$skill" != "reference/plain-language-contract.md" ]; then
+                echo "FAIL: $skill has no <!-- guided-output --> example block"
+                fail=1
+              fi
+              continue
+            fi
+            while IFS= read -r block; do
+              [ -z "$block" ] && continue
+              hit=$(echo "$block" | grep -i -oE "$patterns" || true)
+              if [ -n "$hit" ]; then
+                echo "FAIL: $skill guided block contains banned term(s): $(echo "$hit" | sort -u | tr '\n' ' ')"
+                echo "      block: $block"
+                fail=1
+              fi
+            done <<EOF
+$blocks
+EOF
+          done
+          exit $fail

--- a/doctor/SKILL.md
+++ b/doctor/SKILL.md
@@ -73,11 +73,26 @@ That reinstalls and preserves the existing `~/.nanostack/` (telemetry config, in
 
 Read `session_profile` from the JSON envelope (or default to `professional` if no session exists). Branch the user-facing summary by profile:
 
-**Guided profile (also: local mode, no git, non-technical user).** Do not dump the raw report and do not lead with "hooks/settings JSON". Translate the outcome into one sentence:
+**Guided profile (also: local mode, no git, non-technical user).** Do not dump the raw report and do not lead with "hooks/settings JSON". Follow `reference/plain-language-contract.md`. Translate the outcome into the four-block skeleton:
 
-- All ok: "Nanostack está sano, todo en orden."
-- Warnings: "Hay algunos avisos menores. ¿Querés que los repare?" then offer to run with `--fix` if `fix_available` is true.
-- Failures: "Hay un problema con la instalación. Lo más probable es que necesites reinstalar con `npx create-nanostack`. ¿Querés que te guíe?"
+<!-- guided-output:start -->
+```
+Resultado: Nanostack esta sano y listo para acompañarte.
+
+Como verlo:
+1. No hace falta hacer nada. Cuando empieces tu proximo trabajo, te aviso si algo necesita atencion.
+
+Que revise:
+- Las herramientas que necesita estan instaladas.
+- Los permisos del directorio personal son correctos.
+- Las protecciones automaticas estan activas.
+
+Pendiente:
+- No revise si hay actualizaciones nuevas (corre /nano-update si queres).
+```
+<!-- guided-output:end -->
+
+When the report has warnings, replace the result line with: "Encontre algunos avisos menores. ¿Queres que los repare?" and offer `--fix` only if `fix_available` is true. When it has failures: "Hay un problema con la instalacion. Lo mas probable es que necesites reinstalar con `npx create-nanostack`. ¿Queres que te guie?"
 
 Never read the internal category names ("install", "detection") to a Guided user. Those are for the report, not for the conversation.
 

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -53,6 +53,25 @@ If the file is missing entirely, treat as `manual`.
 
 **Local mode:** Run `source bin/lib/git-context.sh && detect_git_mode`. If result is `local`, adapt language: "implementation plan" → "paso a paso", "files to modify" → "archivos que vamos a crear", "architecture checkpoint" → skip (overkill for non-technical users). Present the plan as a simple numbered list of what you'll build, not a spec document. Same rigor, accessible words. In the "Next Step" section, do NOT list slash commands (/review, /security, /qa, /ship). Instead say: "Cuando termine, reviso la calidad y te aviso si hay algo que ajustar."
 
+**Plain-language contract.** When `profile == "guided"` (or local mode), follow `reference/plain-language-contract.md`. The plan summary uses the four-block skeleton:
+
+<!-- guided-output:start -->
+```
+Resultado: Voy a armar la herramienta en 3 archivos chicos.
+
+Como verlo:
+1. Cuando termine cada paso, te muestro lo que cambio.
+
+Que revise:
+- La forma mas simple de cumplir lo que pediste.
+- Que cada cambio se pueda probar por separado.
+- Que no rompa nada que ya estaba funcionando.
+
+Pendiente:
+- No probe en una computadora distinta a la tuya.
+```
+<!-- guided-output:end -->
+
 ## Process
 
 ### 1. Understand the Request

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -224,7 +224,25 @@ After QA is complete and the artifact is saved:
 
 Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh qa`) is still supported.
 
-When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
+When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output. Use the wording rules in `reference/plain-language-contract.md` (no "QA", no "security audit", no "phase"; use "test pass", "safety check", "step"). Example:
+
+<!-- guided-output:start -->
+```
+Resultado: Funciona como esperabamos.
+
+Como verlo:
+1. Corre el comando que te indique mas arriba y segui las instrucciones.
+
+Que revise:
+- El flujo principal termina sin errores.
+- Los mensajes se entienden cuando algo falla.
+- Lo que se guarda queda en el lugar correcto.
+
+Pendiente:
+- No probe con muchos usuarios al mismo tiempo.
+- No probe en Windows.
+```
+<!-- guided-output:end -->
 
 ## Final Headline
 

--- a/reference/plain-language-contract.md
+++ b/reference/plain-language-contract.md
@@ -1,0 +1,137 @@
+# Plain-language contract for Guided profile
+
+This is the wording contract for skills running in `profile == "guided"`. The purpose is to keep the same rigor a Professional sprint has while removing process jargon from the first screen the user sees.
+
+The contract applies to **user-facing output**, not to skill instructions, internal logs, or artifact JSON. A SKILL.md may still say "save the artifact" in its instructions; the user must not see the word "artifact" in the message the skill prints.
+
+## Hard rule
+
+When `profile == "guided"`, the first screen the user sees may not contain any banned term from the table below. Use the translation. If a term has no good translation in the current context, omit it.
+
+## Term table
+
+| Internal term | Guided replacement |
+|---|---|
+| artifact | saved note, record, or omit |
+| PR | "publish request" only if the user already has GitHub context; else omit |
+| CI | automatic checks |
+| branch | version |
+| diff | changes |
+| hook | safety check |
+| phase | step |
+| security audit | safety check |
+| QA | test pass |
+| scope drift | extra changes |
+
+The list is intentionally short. Anything not on the list is allowed; the goal is to remove process language, not to dumb down rigor.
+
+## Guided output skeleton
+
+Every Guided phase output (think, plan, qa, ship, doctor) must include these four blocks in order, before any optional technical detail:
+
+1. **Result.** One sentence: what the skill found or did.
+2. **How to try.** The exact command or URL to see the result. One action.
+3. **What was checked.** Two or three short bullets. Use plain verbs ("I tested", "I reviewed").
+4. **What remains.** What this skill could not check. Use a plain bullet list. Examples: "I did not deploy this to the internet", "No probé el flujo de pago real".
+
+Skills MAY include a short technical detail block AFTER the four blocks for users who want it, but the four blocks come first and they pass the banned-term grep.
+
+## Spanish parity
+
+When the project is local mode or the user is interacting in Spanish, the four blocks have a direct Spanish version:
+
+1. **Resultado.**
+2. **Como verlo.**
+3. **Que revise.**
+4. **Pendiente.**
+
+Sprint 5 promotes this to a first-class surface across every skill output. Sprint 4 only requires that Spanish blocks, when present, follow the same banned-term rule (no "artifact", no "branch", etc.).
+
+## Marking blocks for the CI grep
+
+So the CI lint can verify the rule without false positives on prose ("scope drift is informational"), every Guided output block in a SKILL.md is fenced with a marker:
+
+````markdown
+<!-- guided-output:start -->
+```
+Resultado: ...
+Como verlo: ...
+Que revise: ...
+Pendiente: ...
+```
+<!-- guided-output:end -->
+````
+
+The CI lint scans only inside `<!-- guided-output:start -->` ... `<!-- guided-output:end -->` blocks for banned terms. Outside the fence, banned terms are allowed (they are agent instructions, not user output).
+
+## Examples
+
+### /ship — guided close (English)
+
+<!-- guided-output:start -->
+```
+Ready to try.
+
+How to try:
+1. Open index.html in your browser.
+
+What was checked:
+- The page loads.
+- The main button responds.
+- I did not find secrets in visible files.
+
+What remains:
+- I did not publish this to the internet.
+- I did not check security on the dependencies.
+```
+<!-- guided-output:end -->
+
+### /ship — guided close (Spanish)
+
+<!-- guided-output:start -->
+```
+Listo para probar.
+
+Como verlo:
+1. Abri index.html en el navegador.
+
+Que revise:
+- La pantalla carga.
+- El boton principal responde.
+- No encontre secretos en archivos visibles.
+
+Pendiente:
+- No esta publicado en internet todavia.
+- No revise la seguridad de las dependencias.
+```
+<!-- guided-output:end -->
+
+### /qa — guided close
+
+<!-- guided-output:start -->
+```
+The feature works.
+
+How to try:
+1. Run the command shown above and follow the prompts.
+
+What was checked:
+- The happy path completes.
+- Error messages are readable.
+- The output saves to the expected location.
+
+What remains:
+- I did not load-test it.
+- I did not test on Windows.
+```
+<!-- guided-output:end -->
+
+## What this contract does NOT do
+
+- It does not change Professional output. Professional sprints keep findings, evidence, file paths, and exact commands.
+- It does not block technical detail. Skills MAY include a fenced "Technical detail" block after the four Guided blocks for users who ask. The contract scans only the marked Guided block.
+- It does not police skill instructions or comments. The grep target is the Guided fenced output, not the rest of the file.
+
+## Where the contract lives
+
+This file is the source of truth. Skills link to it. Tests link to it. If the term table changes, change it here first; do not duplicate the list across skills.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -222,7 +222,25 @@ If a phase says `no`, list it under "Not verified" so the user sees what was ski
 
 Read `profile` from session per `reference/session-state-contract.md`. The branch differs by profile:
 
-**If `profile == "guided"` (or no git remote, even when professional):** Skip the deployment menu and focus on how to try the result locally. Tell the user where the entry point is and the exact command to run, then list anything that is not yet verified (e.g. "I did not deploy this to the internet"). One next action only.
+**If `profile == "guided"` (or no git remote, even when professional):** Skip the deployment menu and focus on how to try the result locally. Tell the user where the entry point is and the exact command to run, then list anything that is not yet verified (e.g. "I did not deploy this to the internet"). One next action only. Follow `reference/plain-language-contract.md` for wording. Example:
+
+<!-- guided-output:start -->
+```
+Resultado: Listo para probar.
+
+Como verlo:
+1. Abri index.html en el navegador.
+
+Que revise:
+- La pantalla carga.
+- El boton principal responde.
+- No encontre secretos en archivos visibles.
+
+Pendiente:
+- No esta publicado en internet todavia.
+- No revise la seguridad de las dependencias.
+```
+<!-- guided-output:end -->
 
 **If `profile == "professional"` and `autopilot == true`:** Skip this question. Go directly to Next Step (compound + sprint summary). The user will decide how to run it after the sprint closes.
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -259,6 +259,26 @@ Determine the mode from the user's description:
 
 **Local mode language:** Run `source bin/lib/git-context.sh && detect_git_mode`. If the result is `local` (no git repo), the user is likely non-technical. Adapt your language throughout the entire sprint: replace jargon with plain language. "Starting point" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs. Do NOT expose internal labels like "Phase 1", "Phase 1.5", "Startup mode", or "Builder mode" — these are your internal process, not something the user needs to see. Just do the work naturally.
 
+**Plain-language contract.** When `profile == "guided"` (or local mode, which implies guided), the user-facing summary at the end of `/think` follows `reference/plain-language-contract.md`. Use the four-block skeleton (Result / How to try / What was checked / What remains) and avoid the banned terms in the contract's table. Example:
+
+<!-- guided-output:start -->
+```
+Resultado: La idea tiene sentido y vale la pena intentar la version mas chica primero.
+
+Como verlo:
+1. Cuando me digas "dale", arranco con el plan.
+
+Que revise:
+- Tenes un caso real propio que resuelve esto.
+- La version mas chica se puede probar en una tarde.
+- No hay otra solucion existente que ya cubra el caso.
+
+Pendiente:
+- No medi cuanta gente mas tiene este problema.
+- No estime cuanto va a salir mantenerlo a futuro.
+```
+<!-- guided-output:end -->
+
 ### Phase 1.5: Search Before Building
 
 Read `think/references/search-before-building.md` and follow the instructions before running the diagnostic.


### PR DESCRIPTION
## Summary

Sprint 4 of the v1.0 Delivery Experience track. Same rigor; no process jargon in the first screen the user sees. Sprint 3 wired profile-aware branches; Sprint 4 fills the wording.

- `reference/plain-language-contract.md` (new): banned-term table (artifact, PR, CI, branch, diff, hook, phase, security audit, QA, scope drift) + four-block Guided skeleton (Result / How to try / What was checked / What remains) + Spanish parity (Resultado / Como verlo / Que revise / Pendiente). Marker convention `<!-- guided-output:start --> ... <!-- guided-output:end -->` fences user-facing output so the CI grep scans only inside the fence.
- `think/SKILL.md`, `plan/SKILL.md`, `qa/SKILL.md`, `ship/SKILL.md`, `doctor/SKILL.md`: each now points at the contract and includes a fenced Guided example in Spanish (local mode implies guided). Professional output is unchanged.
- CI `plain-language-contract` job: asserts every user-facing skill references the contract document and includes at least one fenced block; runs the banned-term grep against every fenced block across all five skills + the contract reference.

## Why now

Sprint 3 (#158) gave skills a Guided branch and a four-block skeleton. Without Sprint 4 the wording inside the skeleton would drift skill-by-skill. Landing the contract before Sprint 5 (Spanish first-class) keeps the Spanish promotion mechanical instead of editorial.

## Test plan

- [x] 44/44 local tests pass
- [x] Local grep of every fenced block passes (5/5 skills clean, contract reference 4/4 examples clean)
- [ ] CI `plain-language-contract` job green on push

## Hard order ahead

Sprint 5 promotes Spanish to first-class across every surface (README.es first-class, Spanish troubleshooting, capability matrix). Sprint 6 cuts v1.0.