### PR TITLE
Resolve leaf symlinks in write guard fallback (closes macOS BSD bypass)

### DIFF
--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -268,14 +268,12 @@ flow_write_guard() {
     printf "    ${DIM}SKIP  write blocks: ~/.ssh/config (no ~/.ssh on this host)${NC}\n"
   fi
 
-  if realpath -m /tmp/foo/bar >/dev/null 2>&1; then
-    ln -sfn "/etc/passwd" "$proj/passwd-link"
-    assert_false "write blocks: leaf symlink to /etc/passwd (GNU realpath path)" \
-      "$guard" "$proj/passwd-link"
-  else
-    SKIP=$((SKIP+1))
-    printf "    ${DIM}SKIP  write blocks: leaf symlink (no GNU realpath; macOS BSD)${NC}\n"
-  fi
+  # Leaf-symlink case. After the macOS-fallback fix, this passes on
+  # both GNU realpath (-m) and BSD realpath (plain) and on the pure-bash
+  # readlink-based fallback when no realpath is usable.
+  ln -sfn "/etc/passwd" "$proj/passwd-link"
+  assert_false "write blocks: leaf symlink to /etc/passwd" \
+    "$guard" "$proj/passwd-link"
 
   # Allow list — paths the guard must NOT block.
   assert_true "write allows: .env.example" "$guard" "$proj/.env.example"

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -63,22 +63,55 @@ esac
 # target whose textual path does not match any denylist entry. The fix
 # is to evaluate the denylist against BOTH the original path and its
 # resolved form; if either matches, block. Falls back to a pure-bash
-# parent-realpath when the realpath binary is missing or refuses
-# missing leaves (Write to a not-yet-existing file).
+# resolver when the realpath binary is missing or refuses missing
+# leaves (Write to a not-yet-existing file).
+#
+# Three resolution paths:
+#   1. GNU realpath -m / --canonicalize-missing follows every symlink
+#      including the leaf. Best when available (Ubuntu, macOS+coreutils).
+#   2. macOS BSD realpath (no -m) accepts only existing paths. Try it
+#      anyway: leaf symlinks created in this test get resolved.
+#   3. Pure-bash fallback: resolve the parent via `cd && pwd -P`, then
+#      if the leaf itself is a symlink, follow it manually with
+#      readlink. Relative readlink targets resolve against the
+#      already-resolved parent. This closes the macOS-without-coreutils
+#      bypass where `ln -s /etc/passwd leaf-link` could reach the
+#      target unguarded.
 RESOLVED_PATH=""
 if command -v realpath >/dev/null 2>&1; then
   RESOLVED_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null) \
     || RESOLVED_PATH=$(realpath --canonicalize-missing "$FILE_PATH" 2>/dev/null) \
+    || RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null) \
     || RESOLVED_PATH=""
 fi
 if [ -z "$RESOLVED_PATH" ]; then
-  # Pure-bash fallback. cd into the parent (which IS a real dir even
-  # when the leaf is being created) and re-attach the basename. pwd -P
-  # follows symlinks at the parent level, which catches sshlink/...
   _parent=$(dirname "$FILE_PATH")
   _base=$(basename "$FILE_PATH")
   if RESOLVED_PARENT=$(cd "$_parent" 2>/dev/null && pwd -P); then
     RESOLVED_PATH="$RESOLVED_PARENT/$_base"
+    # If the leaf exists and is a symlink, follow it manually so the
+    # denylist sees the target. readlink without flags is portable
+    # across BSD and GNU; -f / -e are GNU-only.
+    if [ -L "$RESOLVED_PATH" ]; then
+      _target=$(readlink "$RESOLVED_PATH" 2>/dev/null)
+      if [ -n "$_target" ]; then
+        case "$_target" in
+          /*) RESOLVED_PATH="$_target" ;;
+          *)  RESOLVED_PATH="$RESOLVED_PARENT/$_target" ;;
+        esac
+        # Collapse a single layer of /a/../b that the manual splice
+        # may introduce. cd into the new parent and re-attach base if
+        # possible; if the directory does not exist (target points at
+        # a not-yet-created path) keep the textual form so the
+        # denylist still has something to match.
+        _new_parent=$(dirname "$RESOLVED_PATH")
+        _new_base=$(basename "$RESOLVED_PATH")
+        if _NEW_PARENT_REAL=$(cd "$_new_parent" 2>/dev/null && pwd -P); then
+          RESOLVED_PATH="$_NEW_PARENT_REAL/$_new_base"
+        fi
+        unset _target _new_parent _new_base _NEW_PARENT_REAL
+      fi
+    fi
   else
     RESOLVED_PATH="$FILE_PATH"
   fi


### PR DESCRIPTION
## Summary

`guard/bin/check-write.sh` had a portability gap caught by the v1.0 retest: on macOS without GNU coreutils, a leaf symlink to a protected file was not resolved, so a deliberate `ln -s /etc/passwd ./leaf-link` could reach the target unguarded.

```bash
tmp=$(mktemp -d /tmp/ns-write.XXXXXX)
ln -s /etc/passwd "$tmp/etc-passwd-leaf"
guard/bin/check-write.sh "$tmp/etc-passwd-leaf"
# before: exit 0 (BYPASS)
# after:  exit 1 (BLOCKED [W-001])
```

GNU realpath with `-m` / `--canonicalize-missing` follows every symlink including the leaf and was already wired in. BSD realpath (default macOS) lacks those flags, so the script fell through to a pure-bash fallback that resolved the parent (`cd && pwd -P`) but skipped the leaf.

## Fix

Two parts:

1. **Add a third realpath attempt: plain `realpath FILE_PATH`.** macOS BSD realpath accepts existing paths and *does* follow leaf symlinks. This covers the common case where the symlink is already on disk.

2. **Pure-bash fallback follows the leaf via `readlink`.** When the leaf exists and is itself a symlink, fetch the target with portable `readlink` (no `-f` / `-e` flags) and resolve relative targets against the already-resolved parent. Re-canonicalize with one more `cd && pwd -P` when the new parent dir exists.

The denylist still evaluates against both the original `FILE_PATH` and `RESOLVED_PATH`. Either match blocks.

## Acceptance (matches the spec)

| Case | Before | After |
|---|---|---|
| `ln -s /etc/passwd leaf-link` → check leaf | exit 0 (bypass) | exit 1 (W-001) |
| Not-yet-existing safe file | exit 0 | exit 0 (regression) |
| Parent-dir symlink to /etc → check parent/passwd | exit 1 | exit 1 (regression) |
| Relative leaf symlink within project | exit 0 | exit 0 (regression) |

## Test plan

- [x] All five repro cases pass locally on macOS (BSD realpath without coreutils).
- [x] `tests/run.sh`: 44/44 pass.
- [x] `ci/e2e-user-flows.sh` drops the `realpath -m` capability gate on the leaf-symlink test. Local: **57/57 pass** (was 56/57 with one skip on macOS BSD).
- [ ] CI lint matrix green on push.

## Out of scope

The other two retest findings (P1 `/ship` ignores `report_only`, P2 divergent Guided contracts) ship in separate PRs per the spec.