### PR TITLE
/ship respects run_mode=report_only (P1 retest follow-up)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,50 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  ship-report-only:
+    name: /ship respects run_mode=report_only
+    runs-on: ubuntu-latest
+    # Retest follow-up P1. Every other phase already routes through the
+    # session-state contract; ship/SKILL.md must declare the same
+    # contract before the pipeline section so a future edit cannot
+    # silently bypass report-only and start mutating state.
+    steps:
+      - uses: actions/checkout@v4
+      - name: ship/SKILL.md reads run_mode
+        run: |
+          set -e
+          fail=0
+          if ! grep -qE 'run_mode|RUN_MODE' ship/SKILL.md; then
+            echo "FAIL: ship/SKILL.md must read run_mode from session"
+            fail=1
+          fi
+          if ! grep -qE 'report_only' ship/SKILL.md; then
+            echo "FAIL: ship/SKILL.md must reference report_only mode"
+            fail=1
+          fi
+          if ! grep -q 'reference/session-state-contract.md' ship/SKILL.md; then
+            echo "FAIL: ship/SKILL.md must point at the session-state contract"
+            fail=1
+          fi
+          # Forbidden mutations must be explicitly named as forbidden in
+          # the report-only section. The grep is loose by design — any
+          # phrasing is fine as long as the words appear.
+          for term in 'git commit' 'gh pr create' 'deploy' 'rollback'; do
+            if ! grep -q "$term" ship/SKILL.md; then
+              echo "FAIL: ship/SKILL.md must name '$term' as forbidden in report-only"
+              fail=1
+            fi
+          done
+          # The Report-only section must come before the Process section
+          # (early-exit before any mutation).
+          ro_line=$(grep -n '^## Report-only mode' ship/SKILL.md | head -1 | cut -d: -f1)
+          proc_line=$(grep -n '^## Process' ship/SKILL.md | head -1 | cut -d: -f1)
+          if [ -z "$ro_line" ] || [ -z "$proc_line" ] || [ "$ro_line" -ge "$proc_line" ]; then
+            echo "FAIL: '## Report-only mode' must appear before '## Process' (early exit)"
+            fail=1
+          fi
+          exit $fail
+
   v1-release-framing:
     name: v1.0 release framing (Guided/Professional in READMEs)
     runs-on: ubuntu-latest

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -25,6 +25,41 @@ _P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
 unset _P
 ```
 
+## Session state
+
+Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/session-state-contract.md` BEFORE doing any pre-flight or pipeline work. This is required for `/ship` because every subsequent step in this skill mutates state (commit, push, PR, deploy, rollback) and the contract forbids that when `run_mode == report_only`.
+
+```bash
+SESSION=$NANOSTACK_STORE/session.json
+[ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
+PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION" 2>/dev/null || echo "professional")
+RUN_MODE=$(jq -r '.run_mode // "normal"' "$SESSION" 2>/dev/null || echo "normal")
+AUTOPILOT=$(jq -r '.autopilot // false' "$SESSION" 2>/dev/null || echo "false")
+PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' "$SESSION" 2>/dev/null || echo "manual")
+```
+
+## Report-only mode
+
+When `RUN_MODE == "report_only"`, `/ship` enters **Shipping report** mode and MUST NOT mutate anything. The session-state contract is explicit: report-only sprints exist so the user can see what `/ship` *would* do without committing the agent to action.
+
+**Allowed in report-only:**
+
+- Read session state, artifacts, git status, branch info.
+- Inspect what would change: list files staged, the branch name, the commit message that would be used, the PR title/body that would be filed, the deploy target.
+- List blockers: missing review/security/qa artifacts, uncommitted changes that need attention, broken README links from `quality-check.sh`.
+- Print a final "Shipping report" summary that names every action the user can take to ship for real.
+
+**Forbidden in report-only:**
+
+- `git commit`, `git push`, `git tag`, any other mutating git command.
+- `gh pr create`, `gh pr merge`, any other GitHub mutation.
+- Deploy commands (`fly deploy`, `vercel deploy`, `wrangler deploy`, etc.).
+- Rollback commands.
+- `bin/init-project.sh --fix`, `bin/nano-doctor.sh --fix`, any other repair flag.
+- File writes outside `.nanostack/` (read-only inspection only). `save-artifact.sh ship` is skipped by default; treat artifact persistence as a future opt-in (`--save-report`).
+
+If `RUN_MODE == "report_only"`, jump straight from this section to the **Report output** section at the end of this skill, then stop. Do not run pre-flight, do not run quality-check (it reads only and is fine), do not enter the PR / CI / deploy flow below.
+
 ## Local Mode
 
 Run `source bin/lib/git-context.sh && detect_git_mode`.
@@ -260,6 +295,29 @@ Pendiente:
 Detect project type, recommend ONE provider (Next.js→Vercel, Node→Railway, Static→Cloudflare Pages, Python→Railway, Go→Fly.io). Walk through: account, connect repo, env vars, push. Mention domain (~$10/yr), SSL (automatic), monitoring (Sentry free + UptimeRobot free). Show monthly cost.
 
 **If Done (option 3):** Skip to next features.
+
+## Report output (report-only mode only)
+
+When `RUN_MODE == "report_only"`, this is the only section that runs. It produces a summary the user can read and act on; the agent itself does not commit to any action.
+
+The report has four blocks:
+
+1. **What would ship.** Branch name (or "no git remote"), staged files, commit message that would be used, PR title and body that would be filed.
+2. **What is verified.** Read fresh artifacts from `.nanostack/`. List which of review / security / qa are present and pass. Use `bin/find-artifact.sh <phase> 1` to confirm freshness. If any are missing or stale, name them.
+3. **What is not verified.** Anything the report could not check: deploy target, post-deploy canary, dependencies, integration with downstream services. State this honestly; do not hide gaps.
+4. **What the user can do next.** Exactly the commands needed to ship for real, in order. Example:
+   ```
+   To ship for real:
+     /review     # missing
+     /security   # missing
+     /qa         # missing
+     session.sh init development --run-mode normal
+     /ship
+   ```
+
+Use the wording in `reference/plain-language-contract.md` when `PROFILE == "guided"` (Resultado / Como verlo / Que revise / Pendiente). Professional output may keep technical terms (PR, CI, branch).
+
+Stop after printing the report. Do not call telemetry-finalize with `success`; pass `report_only` so the event reflects what actually happened.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

P1 from the v1.0 retest follow-up. `reference/session-state-contract.md` says `run_mode == report_only` forbids mutating file system, git, GitHub, deploy targets, or running `--fix`. `/review`, `/security`, and `/qa` already route through that contract. `/ship` did not — it went straight from the local-mode check into pre-flight → PR preview → `gh pr create` → CI → deploy without reading `run_mode` at all.

## Change

`ship/SKILL.md` gains two sections, both above any mutating step:

1. **Session state** — reads `profile`, `run_mode`, `autopilot`, `plan_approval` via the canonical jq snippet from `reference/session-state-contract.md`. v1 sessions still read.
2. **Report-only mode** — explicit allow / forbid list:
   - **Allowed:** read state, inspect what would change, list blockers, print the shipping report.
   - **Forbidden:** `git commit`, `git push`, `git tag`, `gh pr create`, `gh pr merge`, deploy, rollback, `--fix`, file writes outside `.nanostack/`. `save-artifact.sh ship` is skipped by default; opt-in `--save-report` is named as future work.

When `RUN_MODE == "report_only"`, the skill jumps from the report-only section straight to the new **Report output** section at the end (four blocks: what would ship, what is verified, what is not verified, what the user can do next). Plain-language contract applies in `profile == "guided"`.

## CI lock

New `ship-report-only` lint job asserts:
- `ship/SKILL.md` reads `run_mode` and references the contract.
- The four forbidden phrases (`git commit`, `gh pr create`, `deploy`, `rollback`) appear by name (cannot be silently dropped).
- `## Report-only mode` appears before `## Process` so the early exit cannot drift below mutation steps in a future edit.

## Test plan

- [x] 44/44 unit tests pass.
- [x] `ci/e2e-user-flows.sh`: 57/57.
- [x] Local lint of all five new ship-report-only checks pass.
- [ ] CI lint matrix green on push.

## Next in this series

- **PR B:** unify the two divergent Guided skeletons (P2).
- **PR D:** `ci/e2e-delivery-matrix.sh` 9-cell coverage including report-only.