### PR TITLE
Unify Guided output contract — single source of truth (P2 retest follow-up)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,69 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  guided-skeleton-single-source:
+    name: Guided skeleton has a single source of truth
+    runs-on: ubuntu-latest
+    # Retest follow-up P2. Two divergent four-block lists existed: the
+    # plain-language contract (Result/How to try/What was checked/
+    # What remains) and the session-state contract (What was checked/
+    # Safe to try/One next action/What remains). Skills could "comply"
+    # with one and violate the other. This job pins
+    # plain-language-contract.md as canonical and refuses any reintro
+    # of a numbered skeleton in session-state-contract.md.
+    steps:
+      - uses: actions/checkout@v4
+      - name: plain-language-contract.md owns the four-block list
+        run: |
+          set -e
+          # Canonical list must define the four blocks in this exact
+          # order (the skill greps and the plain-language CI lock onto
+          # these names).
+          fail=0
+          for block in 'Result' 'How to try' 'What was checked' 'What remains'; do
+            if ! grep -qE "\*\*${block}\*\*|\*\*${block}\.\*\*" reference/plain-language-contract.md; then
+              echo "FAIL: plain-language-contract.md missing canonical block: $block"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: session-state-contract.md does not redefine the skeleton
+        run: |
+          set -e
+          fail=0
+          # Must reference the plain-language contract for the skeleton.
+          if ! grep -q 'reference/plain-language-contract.md' reference/session-state-contract.md; then
+            echo "FAIL: session-state-contract.md must point at plain-language-contract.md for the Guided skeleton"
+            fail=1
+          fi
+          # Must NOT contain a numbered list of four bold-headed blocks
+          # in the Guided section. We scan the "Guided final-output"
+          # block specifically, between its heading and the next H2.
+          guided=$(awk '/^## Guided final-output/{flag=1; next} /^## /{flag=0} flag' reference/session-state-contract.md)
+          numbered_bold=$(echo "$guided" | grep -cE '^[1-4]\. \*\*' || true)
+          if [ "$numbered_bold" -ge 4 ]; then
+            echo "FAIL: session-state-contract.md redefines a four-block skeleton (must reference plain-language-contract.md instead)"
+            echo "$guided"
+            fail=1
+          fi
+          exit $fail
+
+      - name: SKILL.md files reference the canonical skeleton (not the old session-state list)
+        run: |
+          set -e
+          fail=0
+          # If a skill mentions "four blocks from reference/session-state-contract.md"
+          # that points at the old (now removed) list and is a regression.
+          # The canonical pointer phrase is "four-block skeleton in reference/plain-language-contract.md".
+          for skill in review/SKILL.md security/SKILL.md qa/SKILL.md; do
+            if grep -q "four blocks from .reference/session-state-contract.md" "$skill"; then
+              echo "FAIL: $skill points at the removed four-block list in session-state-contract.md"
+              fail=1
+            fi
+          done
+          exit $fail
+
   ship-report-only:
     name: /ship respects run_mode=report_only
     runs-on: ubuntu-latest

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -224,7 +224,7 @@ After QA is complete and the artifact is saved:
 
 Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh qa`) is still supported.
 
-When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output. Use the wording rules in `reference/plain-language-contract.md` (no "QA", no "security audit", no "phase"; use "test pass", "safety check", "step"). Example:
+When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result. Use the wording rules in the same contract (no "QA", no "security audit", no "phase"; use "test pass", "safety check", "step"). Example:
 
 <!-- guided-output:start -->
 ```

--- a/reference/plain-language-contract.md
+++ b/reference/plain-language-contract.md
@@ -27,9 +27,11 @@ The list is intentionally short. Anything not on the list is allowed; the goal i
 
 ## Guided output skeleton
 
-Every Guided phase output (think, plan, qa, ship, doctor) must include these four blocks in order, before any optional technical detail:
+This file is the **single source of truth** for Guided output structure. `reference/session-state-contract.md` references this skeleton; if you find a second numbered list of Guided blocks anywhere else in the repo, that is a regression.
 
-1. **Result.** One sentence: what the skill found or did.
+Every Guided phase output (think, plan, qa, ship, doctor, review, security) must include these four blocks in order, before any optional technical detail:
+
+1. **Result.** One sentence: what the skill found or did, and whether it is safe to try. (When safety needs more than one sentence — e.g. "safe to try with these caveats" — split it onto a second short line, but keep it inside the Result block.)
 2. **How to try.** The exact command or URL to see the result. One action.
 3. **What was checked.** Two or three short bullets. Use plain verbs ("I tested", "I reviewed").
 4. **What remains.** What this skill could not check. Use a plain bullet list. Examples: "I did not deploy this to the internet", "No probé el flujo de pago real".

--- a/reference/session-state-contract.md
+++ b/reference/session-state-contract.md
@@ -29,21 +29,16 @@ If the session file does not exist, default to `professional` / `normal` / `fals
 
 | Field | Values | What the skill must do |
 |---|---|---|
-| `profile` | `guided` \| `professional` | Shapes the final output. Guided uses the four-block format below; Professional preserves findings/evidence style. |
+| `profile` | `guided` \| `professional` | Shapes the final output. Guided uses the four-block format defined in `reference/plain-language-contract.md`; Professional preserves findings/evidence style. |
 | `run_mode` | `normal` \| `report_only` | When `report_only`, the skill must NOT edit files, fix issues, commit, push, or call any `--fix` mode. It only reports. |
 | `autopilot` | `true` \| `false` | When `true`, do not pause between phases. Show one status line and continue. |
 | `plan_approval` | `manual` \| `auto` \| `not_required` | Used by `/nano` to decide whether to wait for plan approval. Other skills usually mirror autopilot. |
 
 ## Guided final-output blocks
 
-When `PROFILE == "guided"`, the final user-facing output of every Sprint phase (review, security, qa, ship, doctor) must include these four blocks in order:
+When `PROFILE == "guided"`, the final user-facing output of every Sprint phase (review, security, qa, ship, doctor) follows the four-block skeleton defined in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). The plain-language contract is authoritative; this file does not redefine the structure. "Whether it is safe to try" lives inside the Result block, not as a separate block.
 
-1. **What was checked** — one or two sentences naming what the skill actually inspected.
-2. **Whether it is safe to try** — yes / not yet, with a short reason.
-3. **One next action** — exactly one. Use `bin/next-step.sh --json | jq -r .user_message` for the wording.
-4. **What remains unverified** — list things the skill could not check (e.g. "No probé el flujo en producción", "No revisé seguridad de dependencias").
-
-Skills MAY include short technical details after these four blocks if useful, but the four blocks come first.
+The next-action prose comes from `bin/next-step.sh --json | jq -r .user_message`. The script reads `profile` from the session and shapes wording accordingly, so skills do not have to.
 
 ## Professional final-output
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -189,7 +189,7 @@ Use `.user_message` for the prose to show the user (it is profile-aware). Use `.
 
 The legacy positional form (`next-step.sh review`) still works and emits a space-separated list of pending phases for the autopilot logging line below; prefer `--json` for everything else.
 
-When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
+When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block.
 
 ## Final Headline
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -249,7 +249,7 @@ After the security audit is complete and the artifact is saved:
 
 Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh security`) is still supported.
 
-When `profile == "guided"`, also include the four blocks from `reference/session-state-contract.md` (what was checked, safe to try, one next action, what remains unverified) at the top of the user-facing output.
+When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block.
 
 ## Final Headline
 


### PR DESCRIPTION
## Summary

P2 from the v1.0 retest follow-up. Two divergent four-block skeletons existed and a skill could "comply" with one while violating the other:

| Doc | Block 1 | Block 2 | Block 3 | Block 4 |
|---|---|---|---|---|
| plain-language-contract.md | Result | How to try | What was checked | What remains |
| session-state-contract.md | What was checked | Whether safe to try | One next action | What remains |

For non-technical users this meant inconsistent output across phases.

## Decision

`reference/plain-language-contract.md` is the **single source of truth**. The session-state contract references it; it does not redefine the structure. "Whether it is safe to try" folds into the Result block per the spec recommendation.

## Changes

- `plain-language-contract.md` is now explicitly named the canonical source. The Result block grows one phrase ("and whether it is safe to try") so safety has a place inside Result.
- `session-state-contract.md` drops its own four-block list, points at `plain-language-contract.md`, keeps Professional and next-step sections (those are session-state mechanics, not output structure).
- `review/SKILL.md`, `security/SKILL.md`, `qa/SKILL.md` previously pointed at the now-removed list in `session-state-contract.md`. They now point at `plain-language-contract.md` and explicitly name the four blocks.

## CI lock

New `guided-skeleton-single-source` job, three subchecks:

1. `plain-language-contract.md` defines all four canonical block names in bold.
2. `session-state-contract.md` has a pointer to the canonical doc AND does not contain a numbered list of four bold-headed blocks in its Guided section (a regression check).
3. No `SKILL.md` references "four blocks from `reference/session-state-contract.md`" — that phrase pointed at the removed list.

## Test plan

- [x] 44/44 unit tests pass.
- [x] `ci/e2e-user-flows.sh`: 57/57 (no skips).
- [x] Local lint of all three subchecks pass.
- [ ] CI lint matrix green on push.

## Next in this series

- **PR D:** `ci/e2e-delivery-matrix.sh` 9-cell coverage.