### PR TITLE
/think vNext PR 1: structured think artifact (P1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,80 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-structured-artifact:
+    name: /think saves structured JSON artifact
+    runs-on: ubuntu-latest
+    # /think vNext PR 1. The artifact is the contract /nano,
+    # sprint-journal, and resolve.sh consume. Refusing to advance to
+    # /nano without a value_proposition / narrowest_wedge / key_risk
+    # is only honest when those fields actually live as named JSON
+    # keys, not as a prose blob inside summary.value.
+    steps:
+      - uses: actions/checkout@v4
+      - name: think/SKILL.md does not save via --from-session
+        run: |
+          set -e
+          fail=0
+          if grep -nE 'save-artifact\.sh[[:space:]]+--from-session[[:space:]]+think' think/SKILL.md; then
+            echo "FAIL: /think must save structured JSON, not the --from-session prose form"
+            fail=1
+          fi
+          # Must have the structured-save block: jq -n with the named
+          # fields the spec requires. Loose grep on the field names
+          # avoids brittleness to formatting changes.
+          for field in value_proposition scope_mode target_user narrowest_wedge key_risk premise_validated; do
+            if ! grep -q "$field" think/SKILL.md; then
+              echo "FAIL: think/SKILL.md must mention required field '$field'"
+              fail=1
+            fi
+          done
+          # Save call site must reference the canonical schema doc.
+          if ! grep -q 'reference/artifact-schema.md' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must point at reference/artifact-schema.md"
+            fail=1
+          fi
+          exit $fail
+
+      - name: artifact-schema.md declares the extended /think shape
+        run: |
+          set -e
+          fail=0
+          # The schema doc must include the new optional fields too,
+          # so future skills can rely on their names without each
+          # adding their own ad-hoc convention.
+          for field in out_of_scope manual_delivery_test search_summary context_checkpoint; do
+            if ! grep -q "$field" reference/artifact-schema.md; then
+              echo "FAIL: reference/artifact-schema.md missing field '$field' in /think schema"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: structured artifact roundtrip (jq queries from spec pass)
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d /tmp/think-ci.XXXXXX)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          $GITHUB_WORKSPACE/bin/session.sh init development >/dev/null
+          THINK_JSON=$(jq -n '{
+            phase:"think",
+            summary:{value_proposition:"VP", scope_mode:"reduce", target_user:"TU", narrowest_wedge:"NW", key_risk:"KR", premise_validated:true, out_of_scope:["x"]},
+            context_checkpoint:{summary:"x"}
+          }')
+          $GITHUB_WORKSPACE/bin/save-artifact.sh think "$THINK_JSON" >/dev/null
+          # The three jq queries the spec names as acceptance must succeed.
+          jq -e '.summary.value_proposition' .nanostack/think/*.json >/dev/null || { echo "FAIL: value_proposition not retrievable"; fail=1; }
+          jq -e '.summary.narrowest_wedge'   .nanostack/think/*.json >/dev/null || { echo "FAIL: narrowest_wedge not retrievable"; fail=1; }
+          jq -e '.summary.key_risk'          .nanostack/think/*.json >/dev/null || { echo "FAIL: key_risk not retrievable"; fail=1; }
+          # sprint-journal.sh consumes those exact fields; smoke-check it
+          # does not crash.
+          $GITHUB_WORKSPACE/bin/sprint-journal.sh >/dev/null 2>&1 || { echo "FAIL: sprint-journal crashed on structured think artifact"; fail=1; }
+          exit $fail
+
   guided-skeleton-single-source:
     name: Guided skeleton has a single source of truth
     runs-on: ubuntu-latest

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -59,10 +59,30 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
     "target_user": "string",
     "narrowest_wedge": "string",
     "key_risk": "string",
-    "premise_validated": true
+    "premise_validated": true,
+    "out_of_scope": ["string"],
+    "manual_delivery_test": {
+      "possible": true,
+      "steps": ["string"]
+    },
+    "search_summary": {
+      "mode": "local_only|private|public",
+      "result": "string",
+      "existing_solution": "none|partial|covers_80_percent"
+    }
+  },
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
   }
 }
 ```
+
+**Required vs optional in `summary`:**
+- Required: `value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. The autopilot brief gate (`/think --autopilot`) refuses to advance to `/nano` when any of these are missing or empty.
+- Optional: `out_of_scope`, `manual_delivery_test`, `search_summary`. Skills downstream of `/think` consume them when present, fall back to safe defaults when absent.
 
 ### /nano
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -353,13 +353,47 @@ Produce a clear brief for the next phase:
 - {{optional second, cap at three}}
 ```
 
-Immediately after writing the Think Summary — before anything else, before presenting next steps — save the artifact:
+Immediately after writing the Think Summary — before anything else, before presenting next steps — save the artifact as **structured JSON** that matches the canonical schema in `reference/artifact-schema.md`. Downstream skills (`/nano`, `bin/sprint-journal.sh`, `bin/resolve.sh`) read the named fields, so the prose-blob form (`--from-session`) is no longer acceptable for `/think`.
+
+Build the JSON inline and pass it to `save-artifact.sh`. Required fields (the autopilot brief gate refuses to advance without them): `value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. Optional but encouraged: `out_of_scope`, `manual_delivery_test`, `search_summary`, `context_checkpoint`.
+
+Use `jq -n` so the output is real JSON, not a string with embedded quotes:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: X. Scope: Y. Starting point: Z. Risk: W. Premise: validated/not.'
+THINK_JSON=$(jq -n \
+  --arg value_proposition "..."   \
+  --arg scope_mode        "..."   \
+  --arg target_user       "..."   \
+  --arg narrowest_wedge   "..."   \
+  --arg key_risk          "..."   \
+  --argjson premise_validated true \
+  --argjson out_of_scope          '[]' \
+  --argjson manual_delivery_test  '{"possible": false, "steps": []}' \
+  --argjson search_summary        '{"mode": "local_only", "result": "", "existing_solution": "none"}' \
+  --argjson context_checkpoint    '{"summary":"", "key_files":[], "decisions_made":[], "open_questions":[]}' \
+  '{
+     phase: "think",
+     summary: {
+       value_proposition: $value_proposition,
+       scope_mode:        $scope_mode,
+       target_user:       $target_user,
+       narrowest_wedge:   $narrowest_wedge,
+       key_risk:          $key_risk,
+       premise_validated: $premise_validated,
+       out_of_scope:      $out_of_scope,
+       manual_delivery_test: $manual_delivery_test,
+       search_summary:    $search_summary
+     },
+     context_checkpoint: $context_checkpoint
+   }')
+
+~/.claude/skills/nanostack/bin/save-artifact.sh think "$THINK_JSON"
 ```
 
-This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action.
+This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action. After this:
+
+- `bin/sprint-journal.sh` reads `.summary.value_proposition / .scope_mode / .narrowest_wedge / .key_risk` directly.
+- `bin/resolve.sh plan` returns the structured `summary` object so `/nano` can pre-populate its plan with `narrowest_wedge` as the scope constraint and `out_of_scope` as the do-not-touch list.
 
 ### Phase 6.5: Think Brief (shareable)
 


### PR DESCRIPTION
## Summary

PR 1 of the `/think` vNext spec. Replace the prose-blob save with a structured JSON artifact that matches the canonical schema. Required fields (`value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`) become real JSON keys instead of substrings inside a paragraph, so `/nano`, `bin/sprint-journal.sh`, and `bin/resolve.sh` can read them mechanically.

## The gap

`reference/artifact-schema.md` already declared the typed shape. `think/SKILL.md` was saving the prose form:

```bash
save-artifact.sh --from-session think 'Value prop: X. Scope: Y. ...'
```

`plan/SKILL.md` documents that it extracts `narrowest_wedge` for scope, `out_of_scope` to pre-populate the plan, `key_risk` to add to Risks. With the prose form those reads silently returned `null` — the contract was social, not mechanical.

## Change

- `think/SKILL.md`: build JSON inline with `jq -n` and save via the canonical `save-artifact.sh think <json>` mode. Heredoc-style example with every named field.
- `reference/artifact-schema.md`: extend the `/think` block with the new optional fields (`out_of_scope`, `manual_delivery_test`, `search_summary`, `context_checkpoint`). Add an explicit required/optional split so PR 3's autopilot brief gate has unambiguous rules.

## CI lock

New `think-structured-artifact` lint job, three subchecks:

1. `think/SKILL.md` does **not** use `--from-session` for `/think` (regression guard) and mentions every required field plus the schema link.
2. `reference/artifact-schema.md` declares the extended shape.
3. End-to-end roundtrip: init session → save structured think artifact → run the three spec acceptance jq queries (`value_proposition` / `narrowest_wedge` / `key_risk`) → smoke-check `sprint-journal.sh` doesn't crash.

## Test plan

- [x] Three spec jq queries pass on a saved artifact.
- [x] `resolve.sh plan` returns the artifact path; reading it surfaces every named field.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix all green.
- [ ] CI lint matrix green on push.

## Order ahead

This is PR 1 of 6:
- PR 2: session-first /think (read profile/run_mode/autopilot/plan_approval).
- PR 3: autopilot safe contract — Minimum Viable Brief Gate.
- PR 4: preset loading without output noise.
- PR 5: search mode and privacy.
- PR 6: ci/e2e-think-flows.sh.

PR 2 and PR 3 depend on this contract; the brief gate refuses to advance to `/nano` when any required field is missing or empty, which is only honest when those fields exist as named JSON keys.