### PR TITLE
/think vNext PR 2: session-first /think (P2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,63 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-session-first:
+    name: /think reads session state (profile/run_mode/autopilot)
+    runs-on: ubuntu-latest
+    # /think vNext PR 2. Every other Sprint phase routes through the
+    # session-state contract; /think used detect_git_mode as the only
+    # signal for "non-technical user". On Codex/Cursor/OpenCode the
+    # adapter declares instructions_only, so the user can be guided
+    # even with git. Trust profile from the session, not detect_git_mode
+    # alone.
+    steps:
+      - uses: actions/checkout@v4
+      - name: think/SKILL.md reads canonical session fields
+        run: |
+          set -e
+          fail=0
+          if ! grep -q 'reference/session-state-contract.md' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must reference reference/session-state-contract.md"
+            fail=1
+          fi
+          for var in PROFILE RUN_MODE AUTOPILOT PLAN_APPROVAL HOST; do
+            if ! grep -qE "$var=.*jq" think/SKILL.md; then
+              echo "FAIL: think/SKILL.md must read $var via jq from session.json"
+              fail=1
+            fi
+          done
+          # Profile selection must NOT be derived from detect_git_mode
+          # alone. The skill may still mention detect_git_mode as a
+          # secondary signal, but it must explicitly say so.
+          if grep -nE 'detect_git_mode.*(local).*(non-technical|guided)' think/SKILL.md \
+             | grep -v 'secondary signal'; then
+            echo "FAIL: think/SKILL.md couples guided/non-technical to detect_git_mode without naming it as secondary"
+            fail=1
+          fi
+          exit $fail
+
+      - name: profile resolution: Codex+git is guided
+        run: |
+          set -e
+          tmp=$(mktemp -d /tmp/think-profile.XXXXXX)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          ( export NANOSTACK_HOST=codex; $GITHUB_WORKSPACE/bin/session.sh init development >/dev/null )
+          profile=$(jq -r .profile .nanostack/session.json)
+          if [ "$profile" != "guided" ]; then
+            echo "FAIL: Codex+git resolved to '$profile' (expected 'guided' from instructions_only adapter)"
+            exit 1
+          fi
+          # And Claude+git stays professional.
+          ( export NANOSTACK_HOST=claude; $GITHUB_WORKSPACE/bin/session.sh init development >/dev/null )
+          profile=$(jq -r .profile .nanostack/session.json)
+          if [ "$profile" != "professional" ]; then
+            echo "FAIL: Claude+git resolved to '$profile' (expected 'professional')"
+            exit 1
+          fi
+
   think-structured-artifact:
     name: /think saves structured JSON artifact
     runs-on: ubuntu-latest

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -238,6 +238,34 @@ The goal propagates through the resolver to every phase. Use it to frame scope d
 
 Then run `session.sh phase-start think`.
 
+## Session state
+
+After `session.sh init`, read the canonical session fields per `reference/session-state-contract.md`. `/think` shapes its own UX from these fields the same way every other Sprint phase does — no skill should infer profile, autopilot, or run_mode from prose context alone.
+
+```bash
+SESSION=$NANOSTACK_STORE/session.json
+[ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
+
+PROFILE=$(jq -r '.profile // "professional"' "$SESSION" 2>/dev/null || echo "professional")
+RUN_MODE=$(jq -r '.run_mode // "normal"' "$SESSION" 2>/dev/null || echo "normal")
+AUTOPILOT=$(jq -r '.autopilot // false' "$SESSION" 2>/dev/null || echo "false")
+PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' "$SESSION" 2>/dev/null || echo "manual")
+HOST=$(jq -r '.host // "unknown"' "$SESSION" 2>/dev/null || echo "unknown")
+```
+
+How `/think` uses each field:
+
+| Field | Effect on `/think` |
+|---|---|
+| `PROFILE=guided` | Shorter conversation (max 3 opening questions). No internal labels (no "Founder mode", "Phase 1.5", "Startup mode"). Output follows `reference/plain-language-contract.md`. The Spanish four-block skeleton applies on local mode. |
+| `PROFILE=professional` | Keep the full Founder/Startup/Builder mode framework, the diagnostic, the staff-engineer scorecard. |
+| `RUN_MODE=report_only` | Brief produced and saved as artifact, but `/think` does NOT advance to `/nano` (no autopilot continuation, no plan_approval=auto). |
+| `AUTOPILOT=true` and brief is complete | Continue to `/nano` without pausing for approval (per session contract). The Minimum Viable Brief Gate decides "complete". |
+| `AUTOPILOT=true` and brief is incomplete | Pause once with a single focused question — see Phase 5 (Brief gate). Do not invent fields. |
+| `HOST=codex/cursor/opencode/gemini` | Even with a git repo, profile may already be `guided` because the host adapter declared `instructions_only`. Trust `PROFILE`, do not re-derive guided/professional from `detect_git_mode` alone. |
+
+`bin/lib/git-context.sh` `detect_git_mode` is still useful as a SECONDARY signal for downstream wording (e.g. "tu computadora" vs "este repo"), but it is not the source of truth for profile selection. The session is.
+
 ## Process
 
 ### Phase 1: Context Gathering
@@ -257,7 +285,11 @@ Determine the mode from the user's description:
 
 **How to detect the mode:** If the user describes a personal pain ("I have this problem," "I need to..."), default to Startup or Builder. If the user pitches an idea for others ("I want to build X for Y market"), default to Startup. Only use Founder mode when the user asks for it or the context is clearly a high-stakes venture decision.
 
-**Local mode language:** Run `source bin/lib/git-context.sh && detect_git_mode`. If the result is `local` (no git repo), the user is likely non-technical. Adapt your language throughout the entire sprint: replace jargon with plain language. "Starting point" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs. Do NOT expose internal labels like "Phase 1", "Phase 1.5", "Startup mode", or "Builder mode" — these are your internal process, not something the user needs to see. Just do the work naturally.
+**Guided UX rules (when `PROFILE=guided`):** The session decides this; do not re-derive from `detect_git_mode` alone. A Codex / Cursor / OpenCode / Gemini repo can be guided even with git, because the host adapter declared `instructions_only`.
+
+When `PROFILE=guided`, adapt your conversation throughout the entire sprint: replace jargon with plain language. "Starting point" → "¿Cuál es lo mínimo que necesitás que funcione?" / "Status quo" → "¿Cómo lo estás resolviendo ahora?" / "Premise validated" → "Tiene sentido, avancemos." Same rigor, simpler words. Never mention git, branches, PRs, or diffs. Do NOT expose internal labels like "Phase 1", "Phase 1.5", "Startup mode", or "Builder mode" — these are your internal process, not something the user needs to see. Just do the work naturally.
+
+`detect_git_mode` is still useful as a secondary signal: when it returns `local`, the user is on a non-git path and the local-mode wording (paths instead of branches, "tu carpeta" instead of "el repo") applies on top of guided.
 
 **Plain-language contract.** When `profile == "guided"` (or local mode, which implies guided), the user-facing summary at the end of `/think` follows `reference/plain-language-contract.md`. Use the four-block skeleton (Result / How to try / What was checked / What remains) and avoid the banned terms in the contract's table. Example:
 


### PR DESCRIPTION
## Summary

PR 2 of 6 in the `/think` vNext spec. Every other Sprint phase already routes through the session-state contract (`profile`, `run_mode`, `autopilot`, `plan_approval`). `/think` used `detect_git_mode` as the only signal for "non-technical user" — which fails on Codex/Cursor/OpenCode/Gemini repos: those hosts declare `instructions_only` in their adapter, so the user must be guided even with git, but `detect_git_mode` returned `full` and `/think` kept the Founder-mode framework.

## Change

`think/SKILL.md`:

1. New "Session state" section right after `## Session`. Reads the five canonical fields via `jq` and documents how each shapes `/think`:
   - `PROFILE=guided` → max 3 questions, no internal labels, plain-language contract.
   - `PROFILE=professional` → Founder/Startup/Builder framework intact.
   - `RUN_MODE=report_only` → brief saved as artifact, no `/nano` continuation.
   - `AUTOPILOT=true` → continue per PR 3's Minimum Viable Brief Gate.
   - `HOST=codex/cursor/...` → trust `PROFILE`, do not re-derive.
2. Phase 1 "Local mode language" subsection rewritten as "Guided UX rules" keyed on `PROFILE`. `detect_git_mode` named explicitly as a **secondary** signal (path wording on local-mode layered on top of guided), not the source of truth.

## CI lock

New `think-session-first` job, two subchecks:

1. `think/SKILL.md` references `reference/session-state-contract.md` AND reads each of `PROFILE` / `RUN_MODE` / `AUTOPILOT` / `PLAN_APPROVAL` / `HOST` via `jq` from `session.json`. Plus a regression check that the skill does not silently re-couple "guided/non-technical" to `detect_git_mode` without naming it secondary.
2. End-to-end profile resolution: **Codex+git** resolves to `guided` (instructions_only adapter), **Claude+git** resolves to `professional`. This is the contract `/think` now reads from.

## Test plan

- [x] 44/44 unit tests pass.
- [x] 57/57 user-flow E2E.
- [x] 17/17 delivery matrix.
- [x] Local: Codex+git → guided, Claude+git → professional.
- [ ] CI lint matrix green on push.

## Order ahead

PR 3 (autopilot Minimum Viable Brief Gate) depends on `PROFILE+AUTOPILOT` being read here, so the gate can decide to pause once or continue. PR 4 (preset no-dump) and PR 5 (search privacy) read `PROFILE` for wording defaults.