### PR TITLE
/think vNext PR 3: autopilot Minimum Viable Brief Gate (P2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,65 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-autopilot-brief-gate:
+    name: /think autopilot brief gate
+    runs-on: ubuntu-latest
+    # /think vNext PR 3. Autopilot's promise is "discuss the idea,
+    # approve the brief, walk away". That is only honest when there
+    # is actually a brief to walk away from. /think must validate
+    # the structured artifact's required fields before advancing,
+    # and stop with one focused question when any field is missing
+    # or empty.
+    steps:
+      - uses: actions/checkout@v4
+      - name: think/SKILL.md declares the Brief Gate before Next Step
+        run: |
+          set -e
+          fail=0
+          if ! grep -qE '^### Phase 6\.6: Minimum Viable Brief Gate' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must define the Phase 6.6 Brief Gate"
+            fail=1
+          fi
+          # Phase 6.6 must come before Phase 7 (Next Step) so the gate
+          # runs before the autopilot continuation.
+          gate_line=$(grep -n '^### Phase 6\.6: Minimum Viable Brief Gate' think/SKILL.md | head -1 | cut -d: -f1)
+          next_line=$(grep -n '^### Phase 7: Next Step' think/SKILL.md | head -1 | cut -d: -f1)
+          if [ -z "$gate_line" ] || [ -z "$next_line" ] || [ "$gate_line" -ge "$next_line" ]; then
+            echo "FAIL: Phase 6.6 Brief Gate must appear before Phase 7 Next Step"
+            fail=1
+          fi
+          # Gate must check every required field by name.
+          for field in value_proposition target_user narrowest_wedge key_risk premise_validated; do
+            if ! grep -qE "summary\.$field" think/SKILL.md; then
+              echo "FAIL: Brief Gate must check .summary.$field"
+              fail=1
+            fi
+          done
+          # Phase 7 must explicitly handle the gate-failed branch
+          # (not advance to /nano).
+          if ! grep -qE 'Brief Gate (failed|passed)' think/SKILL.md; then
+            echo "FAIL: Phase 7 must reference Brief Gate passed/failed branches"
+            fail=1
+          fi
+          exit $fail
+
+      - name: README and README.es ship the autopilot wording
+        run: |
+          set -e
+          fail=0
+          # English: spec asks for the literal "autopilot continues
+          # after a complete brief, not after blind guessing".
+          if ! grep -q 'complete brief, not after blind guessing' README.md; then
+            echo "FAIL: README.md must include 'complete brief, not after blind guessing'"
+            fail=1
+          fi
+          # Spanish: parity wording naming the gate behavior.
+          if ! grep -qiE 'brief completo|adivinando' README.es.md; then
+            echo "FAIL: README.es.md must mirror the autopilot brief-gate wording"
+            fail=1
+          fi
+          exit $fail
+
   think-session-first:
     name: /think reads session state (profile/run_mode/autopilot)
     runs-on: ubuntu-latest

--- a/README.es.md
+++ b/README.es.md
@@ -163,7 +163,10 @@ Discutí la idea, aprobá el brief, alejate. El agente corre el sprint completo:
 /nano → build → /review → /security → /qa → /ship
 ```
 
+**Autopilot avanza con un brief completo, no adivinando.** `/think --autopilot` siempre arma un brief primero. Si el brief tiene los campos requeridos (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continúa a `/nano` sin pausar. Si falta alguno, `/think` para una vez y hace una sola pregunta enfocada — no inventa campos para seguir.
+
 Autopilot solo para si:
+- `/think` no puede armar el brief desde el contexto (hace una pregunta y sigue)
 - `/review` encuentra issues bloqueantes que necesitan tu decisión
 - `/security` encuentra vulnerabilidades críticas o altas
 - `/qa` falla los tests

--- a/README.md
+++ b/README.md
@@ -360,7 +360,10 @@ Discuss the idea, approve the brief, walk away. The agent runs the full sprint:
 
 On Claude Code the phase gate enforces the pipeline at the hook layer: even if the agent judges a task as "simple" and tries to skip review or security, `git commit` is blocked until all phases have fresh artifacts. The hook stops the commit, no instructions involved. On agents that do not support pre-action hooks the same gate runs as a rule the agent reads; the gate is honest about the difference and `/nano-doctor` reports the actual level for your install.
 
+**Autopilot continues after a complete brief, not after blind guessing.** `/think --autopilot` always produces a brief first. If the brief has the required fields (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continues to `/nano` without pausing. If any required field is missing, `/think` stops once and asks one focused question — it does not invent fields to keep moving.
+
 Autopilot only stops if:
+- `/think` cannot fill the brief from context (asks one question, then continues)
 - `/review` finds blocking issues that need your decision
 - `/security` finds critical or high vulnerabilities
 - `/qa` tests fail

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -437,13 +437,44 @@ mkdir -p .nanostack/know-how/briefs
 
 Format and rules: see `think/references/brief-template.md`. Keep under 20 lines, skip sections that don't apply.
 
+### Phase 6.6: Minimum Viable Brief Gate
+
+Before continuing to `/nano` (whether under autopilot or as the final user-facing handoff), validate that the brief has the required fields per `reference/artifact-schema.md`. The autopilot promise is "discuss the idea, approve the brief, walk away" — that is only honest when there is actually a brief to walk away from.
+
+Read the artifact you just saved and check the required fields are populated and non-empty:
+
+```bash
+THINK_FILE=$("$REPO/bin/find-artifact.sh" think 1 2>/dev/null)
+GATE_OK=$(jq -r '
+  (.summary.value_proposition // "") != "" and
+  (.summary.target_user        // "") != "" and
+  (.summary.narrowest_wedge    // "") != "" and
+  (.summary.key_risk           // "") != "" and
+  (.summary.premise_validated // null) != null
+' "$THINK_FILE")
+```
+
+`GATE_OK == "true"`: the brief is complete. Continue.
+
+`GATE_OK == "false"`: stop and ask **exactly one** focused question. Do not invent fields, do not paper over with vague language. Pick the most load-bearing missing field and ask about it directly. Examples:
+
+- Missing `target_user` and `narrowest_wedge`: "No tengo suficiente para correr autopilot sin inventar. Necesito una sola cosa: ¿quién es el usuario específico y qué dolor querés resolver primero?"
+- Missing `key_risk`: "Antes de seguir, una sola cosa: ¿qué es lo más probable que haga fallar esto?"
+- Missing `premise_validated`: "Antes de avanzar: ¿la premisa de que esto es un problema real ya la validaste con alguien? Sí / no / no estoy seguro."
+
+After the user answers, re-save the artifact with the missing field populated, re-run the gate, and continue. The gate runs **once**: a second consecutive failure returns control to the user without trying a third question.
+
+When `RUN_MODE=report_only`, skip the gate entirely. The brief is saved as the report; do not pause and do not advance to `/nano`.
+
 ### Phase 7: Next Step
 
-**If `--autopilot` was used** (or the user said "autopilot", "run everything", "ship it end to end"):
+**If `--autopilot` was used** (or the user said "autopilot", "run everything", "ship it end to end") AND the Brief Gate passed:
 
 > Autopilot active. Proceeding with the full sprint: /nano, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
 
 Then proceed directly to `/nano` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
+
+**If `--autopilot` was used but the Brief Gate failed:** Stop. Ask the one question from Phase 6.6. Do not advance to `/nano`. Do not "decide for the user".
 
 **Otherwise, check if this is an early sprint** (first or second for this project):
 


### PR DESCRIPTION
## Summary

PR 3 of 6 in the `/think` vNext spec. Autopilot's README promise — "discuss the idea, approve the brief, walk away" — was only honest when there was actually a brief to walk away from. Today `/think --autopilot` silently advanced to `/nano` even when `value_proposition` or `narrowest_wedge` were never produced; `/nano` planned against air, `/review` reviewed air, the user got a sprint with no anchor.

## Change

`think/SKILL.md` adds **Phase 6.6: Minimum Viable Brief Gate** right before Phase 7 (Next Step). The gate reads the artifact PR 1 made structured and checks the required fields are populated and non-empty:

- `value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`

**Pass:** continue to `/nano` under autopilot exactly as before.
**Fail:** stop, ask ONE focused question targeting the most load-bearing missing field, do not invent values, do not advance. The gate runs **once** — a second consecutive failure returns control to the user.

`run_mode == report_only` skips the gate (the brief is the report).

Phase 7 now branches on the gate result instead of going straight to `/nano` whenever `AUTOPILOT=true`.

## README parity

The new framing lands in both READMEs (Sprint 5 / 6 contract: must match across English and Spanish):

- **EN:** *Autopilot continues after a complete brief, not after blind guessing.*
- **ES:** *Autopilot avanza con un brief completo, no adivinando.*

A new bullet on the "Autopilot stops if" list documents that `/think` itself can stop once and ask, then continue.

## CI lock

New `think-autopilot-brief-gate` job, two subchecks:

1. `think/SKILL.md` defines Phase 6.6 BEFORE Phase 7, names every required field by `.summary.<field>`, and Phase 7 references the passed/failed branches.
2. README.md ships the literal "complete brief, not after blind guessing" wording; README.es.md mirrors with "brief completo / adivinando".

## Test plan

- [x] Phase order check: 6.6 < 7.
- [x] Required field check on the gate.
- [x] README parity in EN + ES.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix.
- [ ] CI lint matrix green on push.

## Order ahead

PR 4 (preset no-dump), PR 5 (search privacy), PR 6 (E2E think flows).