### PR TITLE
/think vNext PR 4: preset loading without output noise (P2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -821,6 +821,44 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-preset-no-dump:
+    name: /think preset loading without output noise
+    runs-on: ubuntu-latest
+    # /think vNext PR 4. Preset markdown is internal voice instruction,
+    # not user-facing content. Dumping it via `cat "$PRESET_FILE"` puts
+    # 50+ lines of rules on the first screen the user sees, which is
+    # noise for technical users and overwhelm for non-technical ones.
+    # The skill must read the preset internally and print one short
+    # headline.
+    steps:
+      - uses: actions/checkout@v4
+      - name: think/SKILL.md does not dump preset files
+        run: |
+          set -e
+          fail=0
+          # Forbidden literal forms the spec called out:
+          if grep -nE 'cat[[:space:]]+"\$PRESET_FILE"' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must not 'cat \$PRESET_FILE' (regression: floods first screen with rules)"
+            fail=1
+          fi
+          if grep -nE 'cat[[:space:]]+"\$HOME/\.claude/skills/nanostack/think/presets/default\.md"' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must not cat default.md either"
+            fail=1
+          fi
+          # Profile-keyed headline: at least mention 'Preset:' (professional)
+          # AND 'guided' (so the doc covers both voices).
+          if ! grep -q 'Preset:' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must show a one-line 'Preset: <name>.' headline"
+            fail=1
+          fi
+          # Spec rule: skill must say it loads the preset internally,
+          # not dump it.
+          if ! grep -qE 'Load the preset internally|read the file' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must declare that it loads the preset internally"
+            fail=1
+          fi
+          exit $fail
+
   think-autopilot-brief-gate:
     name: /think autopilot brief gate
     runs-on: ubuntu-latest

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -102,19 +102,28 @@ Parsing rules:
 - `/think "idea"` (no flag) → preset is `default`.
 - Unknown value → tell the user `Unknown preset '<name>'. Valid: default, yc, garry, eng, design, devex. Running with default.` and proceed with `default`.
 
-Load and display the preset so the user sees which voice you are about to use:
+Load the preset internally and show the user only a short headline — the kind of message they actually need ("Preset: eng. I'll pressure-test architecture, failure modes, rollback and tests."). Do NOT dump the preset file to the conversation. The preset markdown is internal voice instruction, not user-facing content; printing it floods the first screen with rules the user did not ask for.
 
-```bash
-PRESET="${PRESET:-default}"
-PRESET_FILE="$HOME/.claude/skills/nanostack/think/presets/$PRESET.md"
-if [ -f "$PRESET_FILE" ]; then
-  echo "--- preset: $PRESET ---"
-  cat "$PRESET_FILE"
-else
-  echo "preset '$PRESET' not found, using default"
-  cat "$HOME/.claude/skills/nanostack/think/presets/default.md"
-fi
+Read the file with the `Read` tool against the absolute path:
+
+```text
+$HOME/.claude/skills/nanostack/think/presets/<PRESET>.md
 ```
+
+Once the contents are in your context, summarize the preset to the user in **one short sentence** keyed on the active profile:
+
+| Profile | Style of headline |
+|---|---|
+| `professional` | "Preset: eng. I'll pressure-test architecture, failure modes, rollback and tests." (one line, names the lens, no preset body) |
+| `guided` | "Voy a ayudarte a elegir la versión más chica que vale la pena construir." (one line, plain language, do not mention "preset" or "voice rules") |
+
+If the preset name is unknown: warn briefly and fall back to `default`. Do not dump `default.md` either.
+
+```text
+Unknown preset 'foo'. Falling back to default.
+```
+
+Then keep working. The user sees one line, not the rule book.
 
 Apply the preset's **Voice** rules to every subsequent message in this skill run: diagnostic questions, ambition check, premise challenge, brief, closing. Apply the **Diagnostic framing** notes during Phase 2. Apply the **Closing** style at Phase 7.
 


### PR DESCRIPTION
## Summary

PR 4 of 6 in the `/think` vNext spec. Preset markdown is internal voice instruction, not user-facing content. Dumping it via `cat "$PRESET_FILE"` put 50+ lines of voice rules on the first screen the user saw — noise for technical users and overwhelm for non-technical ones.

## Change

`think/SKILL.md`: load the preset internally with the Read tool against the absolute path, then show the user **one short headline** keyed on `PROFILE`:

| Profile | Headline |
|---|---|
| `professional` | "Preset: eng. I'll pressure-test architecture, failure modes, rollback and tests." |
| `guided` | "Voy a ayudarte a elegir la versión más chica que vale la pena construir." |

Unknown preset: short warning, fall back to `default`. **Default is NOT dumped either.**

## CI lock

New `think-preset-no-dump` job. Blocks regression to either form the spec called out:

```bash
cat "$PRESET_FILE"
cat "$HOME/.claude/skills/nanostack/think/presets/default.md"
```

Plus positive checks: skill must show the `Preset:` headline form and explicitly state it loads the preset internally.

## Test plan

- [x] No `cat "$PRESET_FILE"` in skill.
- [x] No `cat default.md` in skill.
- [x] `Preset:` headline form present.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix.
- [ ] CI lint matrix green on push.

## Order ahead

PR 5 (search mode and privacy), PR 6 (E2E think flows).