### PR TITLE
Brief gate: premise_validated=false is a complete answer (P1, Codex retest)

### DIFF
--- a/ci/e2e-think-flows.sh
+++ b/ci/e2e-think-flows.sh
@@ -145,7 +145,9 @@ build_think_json() {
 
 # Pure jq evaluation of the brief gate. Mirrors the snippet in
 # think/SKILL.md Phase 6.6 so a regression in the doc shows up as a
-# behavior change here.
+# behavior change here. premise_validated is checked by type so that
+# both true and false count as a complete answer; only null / missing
+# / wrong-type fails.
 brief_gate_pass() {
   local file="$1"
   jq -r '
@@ -153,7 +155,7 @@ brief_gate_pass() {
     (.summary.target_user        // "") != "" and
     (.summary.narrowest_wedge    // "") != "" and
     (.summary.key_risk           // "") != "" and
-    (.summary.premise_validated // null) != null
+    ((.summary.premise_validated | type) == "boolean")
   ' "$file"
 }
 
@@ -225,7 +227,8 @@ cell_claude_git_professional() {
 # ─── Cell 4: brief gate passes on a complete brief ────────────────────
 
 cell_brief_gate_complete() {
-  new_project "cell4"
+  # 4a: premise_validated=true. Standard "we validated it" flow.
+  new_project "cell4-true"
   git init -q
   "$REPO/bin/session.sh" init development --autopilot >/dev/null
   local think_json
@@ -235,7 +238,34 @@ cell_brief_gate_complete() {
   artifact=$(ls .nanostack/think/*.json | head -1)
   local result
   result=$(brief_gate_pass "$artifact")
-  assert_eq "complete brief: gate passes (true)" "true" "$result"
+  assert_eq "complete brief, premise_validated=true: gate passes" "true" "$result"
+
+  # 4b: premise_validated=false. Honest "no, premise not validated".
+  # This is the case Codex retest caught: the previous filter treated
+  # false identically to null because `false // null` evaluates to
+  # null in jq. The fix uses a type test so true and false both pass.
+  new_project "cell4-false"
+  git init -q
+  "$REPO/bin/session.sh" init development --autopilot >/dev/null
+  think_json=$(jq -n '{
+    phase:"think",
+    summary:{
+      value_proposition:"Test thing",
+      scope_mode:"reduce",
+      target_user:"Solo dev",
+      narrowest_wedge:"Smallest path",
+      key_risk:"Premise might be wrong",
+      premise_validated: false,
+      out_of_scope:[],
+      manual_delivery_test:{possible:false, steps:[]},
+      search_summary:{mode:"local_only", result:"", existing_solution:"none"}
+    },
+    context_checkpoint:{summary:""}
+  }')
+  "$REPO/bin/save-artifact.sh" think "$think_json" >/dev/null
+  artifact=$(ls .nanostack/think/*.json | head -1)
+  result=$(brief_gate_pass "$artifact")
+  assert_eq "complete brief, premise_validated=false: gate passes (regression)" "true" "$result"
 }
 
 # ─── Cell 5: brief gate fails on incomplete brief ─────────────────────

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -461,9 +461,13 @@ GATE_OK=$(jq -r '
   (.summary.target_user        // "") != "" and
   (.summary.narrowest_wedge    // "") != "" and
   (.summary.key_risk           // "") != "" and
-  (.summary.premise_validated // null) != null
+  ((.summary.premise_validated | type) == "boolean")
 ' "$THINK_FILE")
 ```
+
+`premise_validated` must be a real boolean — both `true` ("the premise is validated") and `false` ("we discussed it and the premise is NOT validated yet") count as a complete answer. The earlier filter `(.summary.premise_validated // null) != null` was a bug: in jq, `false // null` evaluates to `null`, so an honest "no, premise not validated" was treated identically to a missing field. The fix uses the type test so `true`, `false` both pass and only `null` / missing / wrong-type fails.
+
+When `premise_validated == false` and the gate passes, advancing to `/nano` is still a real product decision: the agent should call out "premise unvalidated" in the summary so the user can decide to ship a probe rather than a full sprint. The gate's job is to reject inventions, not to overrule the user's honest answer.
 
 `GATE_OK == "true"`: the brief is complete. Continue.
 


### PR DESCRIPTION
## Summary

P1 from a Codex retest of `/think` vNext. Phase 6.6's brief gate had a jq edge that punished the honest answer:

```
(.summary.premise_validated // null) != null
```

In jq, the alternative operator `//` treats `false` as falsy along with `null`, so `false // null` evaluates to `null`. That made an honest "no, premise not validated yet" indistinguishable from a missing field: the gate would refuse to advance to `/nano` on a brief that was actually complete by the spec definition (*"premise_validated: true|false explícito"*).

This is the worst kind of false negative — it punishes telling the truth and rewards skipping the question.

## Fix

Type test in jq:

```
((.summary.premise_validated | type) == "boolean")
```

Now `true` and `false` both pass; only `null` / missing / wrong-type fails. Applied in two places that must stay in sync:

- `think/SKILL.md` Phase 6.6 (the documented gate snippet).
- `ci/e2e-think-flows.sh` `brief_gate_pass()` (the harness mirror).

A short paragraph after the snippet in `think/SKILL.md` notes that when `premise_validated=false` the agent should call out "premise unvalidated" in the next-step framing — the gate's job is to reject inventions, not to overrule the user's honest answer.

## Regression coverage

`ci/e2e-think-flows.sh` cell 4 grows a 4b case that explicitly tests `premise_validated=false`. The cell now runs two save+gate roundtrips and asserts both pass. Cell 5 still covers the missing/null case → must fail.

## Why CI didn't catch it earlier

The lint matrix verifies structure ("file mentions field name"). The original cell 4 only exercised `premise_validated=true` and cell 5 only the null case. The `false` case fell in the gap between them. Cell 4b is the new backstop.

## Test plan

- [x] `tests/run.sh`: 44/44.
- [x] `ci/e2e-user-flows.sh`: 57/57.
- [x] `ci/e2e-delivery-matrix.sh`: 17/17.
- [x] `ci/e2e-think-flows.sh`: **32/32** (was 31/31; +1 from cell 4b).
- [ ] CI lint matrix green on push.

## Credit

Caught by a Codex retest of the just-merged `/think` vNext series. Useful pattern: the static lint owns "the thing exists"; a real-user retest owns "the thing works for the answers that matter".