### PR TITLE
Examples Library PR 4: static-landing example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ The goal is not perfect apps. It is showing the full workflow end to end: idea, 
 | [starter-todo](starter-todo/) | New users, non-technical | One HTML file, zero dependencies | 5 to 10 minutes | `/nano-run` then `/think` |
 | [cli-notes](cli-notes/) | Technical users learning the CLI archetype | Bash script, plain text storage | 5 to 15 minutes | `/feature` or `/think` |
 | [api-healthcheck](api-healthcheck/) | Backend developers | Node stdlib HTTP server, zero dependencies | 10 to 15 minutes | `/feature` or `/think` |
-| static-landing (coming) | Founders and designers validating a visual demo | Static HTML | 5 to 15 minutes | `/think` |
+| [static-landing](static-landing/) | Founders and designers validating a visual demo | Static HTML, plain CSS, no framework | 10 to 15 minutes | `/feature` or `/think` |
 
 If you are new and unsure, start with `starter-todo`. It is intentionally the smallest case: a TODO app that fits in one HTML file with three feature ideas already written for you.
 

--- a/examples/static-landing/README.md
+++ b/examples/static-landing/README.md
@@ -1,0 +1,128 @@
+# Static Landing
+
+A one-page landing for a fictional product called Crumb. One file (`index.html`), zero dependencies, no build step. The point is not the product. It is having a real visual surface to run a full nanostack sprint on without touching any landing that matters.
+
+## Who this is for
+
+A founder validating an idea, or a designer iterating on copy and layout, who wants to feel how nanostack handles taste and persuasion work, not just code.
+
+## What you start with
+
+A working single-page landing for "Crumb, quick notes for people who think out loud":
+
+- A hero with a headline, lede, and a CTA button.
+- A "Why Crumb" section with three feature bullets.
+- A waitlist section pointing at a `mailto:` link.
+- A small footer.
+
+Plain CSS, no framework, no analytics, no images. Renders the same in every modern browser. About 80 lines.
+
+What it does NOT do yet (these are the seeds for your first sprint):
+
+- No social proof: no testimonials, no customer logos, no founder quote.
+- No second-look conversion: only one CTA, repeated. No reason to scroll a second time.
+- No comparison or pricing: no answer to "how is this different from Notes / Apple Reminders / Notion".
+
+## First sprint
+
+```bash
+git clone https://github.com/garagon/nanostack
+cd nanostack/examples/static-landing
+```
+
+Open `index.html` in your browser to see what you are starting with.
+
+If you have not installed nanostack yet:
+
+```bash
+npx create-nanostack
+```
+
+Then, inside this directory, in your agent (Claude Code, Cursor, Codex, OpenCode, or Gemini):
+
+```
+/nano-run
+```
+
+Pick one of the three feature prompts below.
+
+## Prompt to try
+
+Each fits one sprint of about 10 to 15 minutes. Use `/feature` for autopilot or `/think` if you want the agent to challenge scope first.
+
+**Easiest. Sharper hero copy.**
+
+```
+/feature Rewrite the hero headline and lede so a stranger lands on this page and understands in five seconds what Crumb is for and why it is different from the notes app on their phone. Keep the layout. One line for the headline, two lines max for the lede.
+```
+
+**Medium. Add a testimonials section.**
+
+```
+/feature Add a testimonials section between "Why Crumb" and the waitlist. Three short quotes with a name and role. Keep the visual style consistent with the existing feature cards. Do not add images or an external font.
+```
+
+**Higher pushback. Pricing.**
+
+```
+/think I want to add a pricing section so visitors know what this will cost. Push back if you think a pricing table is wrong for a pre-launch waitlist landing. If you do push back, suggest the smallest version that still answers "is this free, paid, or freemium" without committing to numbers.
+```
+
+The third prompt is the interesting one for a founder. There is a real argument that pricing on a pre-launch waitlist hurts conversion more than it helps, and a good `/think` should surface that before `/nano` writes a price table.
+
+## Expected Nanostack flow
+
+In about 10 to 15 minutes you should see:
+
+1. `/think` (or `/feature`'s implicit think) names the smallest version. For copy work it should ask who the visitor is and what they would compare Crumb to.
+2. `/nano` writes a plan that lists every file it will touch. For all three feature ideas this should be exactly one file (`index.html`).
+3. The agent edits `index.html`. No new files, no `package.json`, no asset folder.
+4. `/review` reports on the diff. Look for a one-line summary plus auto-fixes (semantic HTML, missing `alt` attributes if you add images, contrast issues).
+5. `/security` rates the change. With no scripts and no form submissions it should land at A.
+6. `/qa` opens the page and checks the new section renders correctly across viewport widths.
+7. `/ship` closes the sprint.
+
+The exact level of automatic blocking depends on your agent. On Claude Code, hooks can stop unsafe actions before they execute. On Cursor, Codex, OpenCode, and Gemini, nanostack runs as guided instructions the agent reads and follows.
+
+## Success criteria
+
+You succeeded if all of these are true after the sprint:
+
+- The new section renders correctly when you open `index.html` in a browser.
+- The page still works on mobile (the `viewport` meta tag is intact and the layout does not break).
+- All existing sections (hero, Why Crumb, waitlist, footer) still render and the CTA still goes to the waitlist anchor.
+- The plan named every file it touched. There is exactly one (`index.html`).
+- No external scripts, no tracking pixels, no `<script>` tag pulling from a CDN snuck in.
+- Nothing outside `examples/static-landing/` was touched.
+- You can describe the change to a teammate using the agent's review summary, without rereading the diff.
+
+If any of these is false, the example or the install needs attention. Run `/nano-doctor` and check TROUBLESHOOTING.
+
+## What this teaches
+
+- How `/think` reframes a vague visual ask ("make the headline better") into questions about audience, comparison set, and the one thing the visitor must learn first.
+- How `/nano` constrains scope to one file and refuses to silently introduce a build step or a font CDN.
+- How `/review` catches taste-side regressions: heading hierarchy, contrast, alt text, semantic landmarks, behavior on narrow viewports.
+- How `/security` treats a static landing as a real surface (no inline scripts, no third-party trackers) instead of waving it through as "just HTML".
+- How `/qa` actually opens the page and confirms the new section renders, not just that the markup is well-formed.
+- How nanostack stays inside this directory and never silently rewrites your design system, your tokens file, or any sibling project.
+
+## Reset
+
+To go back to the starting state without any sprint records:
+
+```bash
+rm -rf .nanostack/
+git checkout -- index.html
+```
+
+Each command is scoped to this directory:
+
+- `rm -rf .nanostack/` removes only the sprint records this example produced.
+- `git checkout -- index.html` restores the page to the version in this repo.
+
+There is nothing destructive to your wider machine in either step.
+
+If you want to fully forget this example, delete `examples/static-landing/`. It is not a dependency of nanostack itself.
+
+For setup or environment trouble, see [`../../TROUBLESHOOTING.md`](../../TROUBLESHOOTING.md).

--- a/examples/static-landing/index.html
+++ b/examples/static-landing/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Crumb: quick notes for people who think out loud</title>
+  <style>
+    :root {
+      --ink: #1a1a1a;
+      --muted: #555;
+      --bg: #fafafa;
+      --accent: #2c5fff;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.5;
+    }
+    main { max-width: 720px; margin: 0 auto; padding: 64px 24px; }
+    h1 { font-size: 2.4rem; line-height: 1.15; margin: 0 0 16px; }
+    .lede { font-size: 1.15rem; color: var(--muted); margin: 0 0 32px; }
+    .cta {
+      display: inline-block;
+      padding: 12px 20px;
+      background: var(--accent);
+      color: #fff;
+      text-decoration: none;
+      border-radius: 6px;
+      font-weight: 600;
+    }
+    .cta:hover { filter: brightness(0.95); }
+    section { margin-top: 56px; }
+    h2 { font-size: 1.4rem; margin: 0 0 16px; }
+    .features { display: grid; gap: 16px; padding: 0; list-style: none; }
+    .features li {
+      padding: 16px;
+      background: #fff;
+      border: 1px solid #e8e8e8;
+      border-radius: 8px;
+    }
+    .features strong { display: block; margin-bottom: 4px; }
+    footer {
+      margin-top: 80px;
+      padding-top: 24px;
+      border-top: 1px solid #e8e8e8;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Quick notes for people who think out loud.</h1>
+    <p class="lede">Crumb saves what you mumble while you work, then surfaces it back to you the next morning. No syncing, no folders, no projects.</p>
+    <a class="cta" href="#waitlist">Join the waitlist</a>
+
+    <section>
+      <h2>Why Crumb</h2>
+      <ul class="features">
+        <li><strong>One keystroke.</strong> Hit your hotkey, talk for ten seconds, get back to what you were doing.</li>
+        <li><strong>Quiet capture.</strong> Nothing pops up. Nothing pings. The note is there when you ask for it.</li>
+        <li><strong>Morning replay.</strong> Yesterday's crumbs show up at 8am as a single email you can scan in 30 seconds.</li>
+      </ul>
+    </section>
+
+    <section id="waitlist">
+      <h2>Join the waitlist</h2>
+      <p>We're picking the first 50 testers from the waitlist. No payment yet, we want to know if it works for you before we ask for anything.</p>
+      <a class="cta" href="mailto:hello@example.com?subject=Crumb%20waitlist">Send me an invite</a>
+    </section>
+
+    <footer>
+      <p>© 2026 Crumb. Built as a nanostack examples sandbox.</p>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

PR 4 of the Examples Library spec. Adds the founder/designer archetype: a single-page landing for a fictional product called Crumb.

## Files

`examples/static-landing/index.html` (81 lines):

- Hero with headline, lede, CTA.
- "Why Crumb" section with three feature cards.
- Waitlist section with `mailto:` CTA.
- Small footer.

Plain CSS, no framework, no analytics, no images, no JS. The CI contract requires `<title>` and viewport meta — both present.

Three intentional gaps that map to three feature prompts in the README, ordered by difficulty:

1. **Easiest:** sharper hero copy (taste/persuasion work, `/think` reframes by audience).
2. **Medium:** testimonials section (visual extension, `/review` checks layout consistency).
3. **Higher pushback:** pricing section. The interesting case for a founder — there is a real argument that pricing on a pre-launch waitlist hurts conversion more than it helps. A good `/think` should surface "do you want a pricing table or a freemium indicator" before `/nano` writes a price grid.

`examples/static-landing/README.md` follows the eight-section contract. Reset is safe: `rm -rf .nanostack/` + `git checkout -- index.html`.

`examples/README.md` index amended: `static-landing` promoted from "(coming)" to a real link.

## Em-dash discipline

`index.html` had two em-dashes in display copy (title + waitlist paragraph). Replaced defensively even though the existing `No em-dashes in public copy` CI lint only scans `*.md` and `examples/**/README.md`. The spirit of the rule covers public-facing copy regardless of format; PR 5's `check-examples.sh` may broaden the scan.

## Test plan

- [x] 81-line HTML with `<title>` and `viewport`.
- [x] All eight required H2 sections present in README.
- [x] 12 prompt mentions (`/feature`, `/think`, `/nano`).
- [x] Zero em-dashes in any file touched.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 matrix, 32/32 think E2E.
- [ ] CI lint matrix green on push.

## All four archetypes now present

| Example | Archetype |
|---|---|
| starter-todo | New / non-technical |
| cli-notes | Technical CLI |
| api-healthcheck | Backend developer |
| static-landing | Founder / designer |

## Order ahead

PR 5 (`ci/check-examples.sh` lint contract that locks the eight-section structure across every example and prevents drift), PR 6 (optional manual E2E).