### PR TITLE
README wording update + fix silently-broken lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,32 @@ on:
     branches: [main]
 
 jobs:
+  workflow-yaml-parses:
+    name: Workflow YAML parses
+    runs-on: ubuntu-latest
+    # Defensive lint added 2026-04-26 after a stretch where lint.yml
+    # itself failed to parse and every downstream job skipped silently.
+    # An unquoted colon in a step name and an unindented heredoc body
+    # both produce GitHub-tolerant but spec-invalid YAML; this job
+    # asserts the file actually parses with strict YAML so a future
+    # broken edit fails loudly on PR instead of silently after merge.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Strict YAML parse on every workflow file
+        run: |
+          set -e
+          fail=0
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -f "$f" ] || continue
+            if ! python3 -c "import sys, yaml; yaml.safe_load(open('$f'))" 2>err.log; then
+              echo "FAIL: $f does not parse as YAML"
+              cat err.log
+              fail=1
+            fi
+          done
+          rm -f err.log
+          exit $fail
+
   shell-syntax:
     name: Shell syntax (bash -n)
     runs-on: ubuntu-latest
@@ -1018,7 +1044,7 @@ jobs:
           fi
           exit $fail
 
-      - name: profile resolution: Codex+git is guided
+      - name: "profile resolution: Codex+git is guided"
         run: |
           set -e
           tmp=$(mktemp -d /tmp/think-profile.XXXXXX)
@@ -1221,6 +1247,74 @@ jobs:
           fi
           exit $fail
 
+  readme-public-copy:
+    name: README public-copy regression lock
+    runs-on: ubuntu-latest
+    # Spec public-copy-regression-locks-2026-04-26. Stale claims have
+    # bitten this repo before (telemetry endpoint "lands in a later
+    # PR" stayed in the README months after the Worker shipped). This
+    # job asserts the stale strings the spec called out are gone and
+    # the required v1.0/Examples-Library/telemetry framing is present.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stale strings must NOT appear in README.md or README.es.md
+        run: |
+          set -e
+          fail=0
+          # Each stale string is one quoted argument so spaces inside
+          # do not split. Order intentional: most-cited spec entries
+          # first.
+          for stale in \
+            'Under 15 minutes' \
+            'Four tiers' \
+            'endpoint lands in a later PR' \
+            'Claude does the rest' \
+            'se ships' \
+            'Ship el puntito'; do
+            if grep -nF "$stale" README.md README.es.md 2>/dev/null; then
+              echo "FAIL: stale string present: $stale"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Required strings MUST appear in README.md
+        run: |
+          set -e
+          fail=0
+          for required in \
+            '13 skills total' \
+            'default sprint uses seven' \
+            'Examples Library' \
+            'starter-todo' \
+            'cli-notes' \
+            'api-healthcheck' \
+            'static-landing'; do
+            if ! grep -qF "$required" README.md; then
+              echo "FAIL: required string missing in README.md: $required"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Required strings MUST appear in README.es.md
+        run: |
+          set -e
+          fail=0
+          for required in \
+            'starter-todo' \
+            'cli-notes' \
+            'api-healthcheck' \
+            'static-landing' \
+            'telemetría' \
+            'Privacidad'; do
+            if ! grep -qF "$required" README.es.md; then
+              echo "FAIL: required string missing in README.es.md: $required"
+              fail=1
+            fi
+          done
+          exit $fail
+
   examples-library:
     name: Examples library contract
     runs-on: ubuntu-latest
@@ -1345,23 +1439,15 @@ jobs:
         run: |
           set -e
           fail=0
-          # Heading patterns the Spanish README must include. Each line
-          # is one full H2 heading; iterate with newline IFS so spaces
-          # inside the heading do not get split by the shell.
-          while IFS= read -r h; do
-            [ -z "$h" ] && continue
+          # Iterate with literal-quoted args so multi-word headings stay
+          # one item each. The heredoc form was correct shell but
+          # interacted badly with YAML block-scalar indentation rules.
+          for h in '## Instalación' '## Ejemplo' '## El sprint' '## Autopilot' '## Guard' '## Problemas comunes'; do
             if ! grep -qE "^$h" README.es.md; then
               echo "FAIL: README.es.md missing required section: $h"
               fail=1
             fi
-          done <<'EOF'
-## Instalación
-## Ejemplo
-## El sprint
-## Autopilot
-## Guard
-## Problemas comunes
-EOF
+          done
           exit $fail
 
       - name: TROUBLESHOOTING.es covers most-encountered entries
@@ -1371,20 +1457,12 @@ EOF
           # Spanish entries that map to the high-traffic English ones.
           # Advanced topics (corporate proxy, telemetry, autopilot
           # double-run) are allowed to live only in canonical English.
-          while IFS= read -r h; do
-            [ -z "$h" ] && continue
+          for h in 'Los comandos slash no aparecen' 'Command not found: jq' 'phase gate' 'Estoy en Windows' 'sprint' 'Conflicto de nombres'; do
             if ! grep -qiE "$h" TROUBLESHOOTING.es.md; then
               echo "FAIL: TROUBLESHOOTING.es.md missing high-traffic entry: $h"
               fail=1
             fi
-          done <<'EOF'
-Los comandos slash no aparecen
-Command not found: jq
-phase gate
-Estoy en Windows
-sprint
-Conflicto de nombres
-EOF
+          done
           exit $fail
 
   plain-language-contract:
@@ -1441,6 +1519,8 @@ EOF
               fi
               continue
             fi
+            # Process substitution keeps $fail in the parent shell scope
+            # (a piped while runs in a subshell, which would lose the flag).
             while IFS= read -r block; do
               [ -z "$block" ] && continue
               hit=$(echo "$block" | grep -i -oE "$patterns" || true)
@@ -1449,8 +1529,6 @@ EOF
                 echo "      block: $block"
                 fail=1
               fi
-            done <<EOF
-$blocks
-EOF
+            done < <(printf '%s\n' "$blocks")
           done
           exit $fail

--- a/README.es.md
+++ b/README.es.md
@@ -1,7 +1,7 @@
 <h1 align="center">Nanostack</h1>
 <p align="center">
   Convertí a tu agente de código con IA en un equipo de delivery: definí alcance, planificá, construí, revisá, probá, auditá y publicá en lenguaje que cualquiera puede leer.<br>
-  <strong>Un workflow. Modo guiado o profesional. Honesto sobre lo que cada agente puede bloquear.</strong>
+  <strong>Sprints en sandbox que corren en minutos. Los proyectos reales mantienen el mismo workflow profesional.</strong>
 </p>
 
 <br>

--- a/README.es.md
+++ b/README.es.md
@@ -1,7 +1,7 @@
 <h1 align="center">Nanostack</h1>
 <p align="center">
-  Convertí a tu agente de IA en un equipo profesional de delivery. Cuestiona el alcance, planifica, revisa, prueba, audita y publica — en lenguaje que cualquiera puede leer.<br>
-  <strong>Un sprint. Minutos, no semanas. Para usuarios técnicos y no técnicos.</strong>
+  Convertí a tu agente de código con IA en un equipo de delivery: definí alcance, planificá, construí, revisá, probá, auditá y publicá en lenguaje que cualquiera puede leer.<br>
+  <strong>Un workflow. Modo guiado o profesional. Honesto sobre lo que cada agente puede bloquear.</strong>
 </p>
 
 <br>
@@ -28,7 +28,7 @@
 
 > **Nota:** la versión en inglés ([README.md](README.md)) es la canónica. Si encontrás divergencias o algo desactualizado en este documento, por favor abrí un issue.
 
-Inspirado en [gstack](https://github.com/garrytan/gstack) de [Garry Tan](https://x.com/garrytan). 13 skills. Cero dependencias. Cero build step.
+Inspirado en [gstack](https://github.com/garrytan/gstack) de [Garry Tan](https://x.com/garrytan). 13 skills en total. El sprint principal usa siete especialistas. Cero dependencias. Cero paso de build.
 
 Funciona con Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp y Cline.
 
@@ -58,7 +58,16 @@ Después del install, según tu agente:
 
 ### Probar primero sin riesgo
 
-¿Querés probar antes de tocar tu proyecto real? `examples/starter-todo/` es una app TODO chica con tres ideas para arrancar. Ver [`examples/starter-todo/README.md`](examples/starter-todo/README.md).
+La forma más rápida de entender Nanostack es correrlo en un proyecto que no importa todavía. Elegí un sandbox de la Examples Library:
+
+| Ejemplo | Ideal para | Stack | Tiempo |
+|---|---|---|---|
+| [`starter-todo`](examples/starter-todo/) | usuarios nuevos o no técnicos | un HTML | 5-10 min |
+| [`cli-notes`](examples/cli-notes/) | workflows CLI | Bash | 5-15 min |
+| [`api-healthcheck`](examples/api-healthcheck/) | flujos backend | Node HTTP sin dependencias | 10-15 min |
+| [`static-landing`](examples/static-landing/) | founders y diseño | HTML/CSS estático | 10-15 min |
+
+Cada ejemplo trae prompt para pegar, flujo esperado, criterios de éxito y pasos de reset. Library completa: [`examples/`](examples/).
 
 ### Requisitos
 
@@ -101,9 +110,9 @@ Agente: Voy a empujar contra "notificaciones". Dijiste que abren la
 
         Un sistema de notificaciones (email, push, in-app, preferencias,
         digest, unsubscribe) es un proyecto de 3 semanas. Un puntito
-        rojo en el ícono que diga "hay algo nuevo" se ships esta tarde.
+        rojo en el ícono que diga "hay algo nuevo" sale esta tarde.
 
-        RECOMENDACIÓN: Reducir alcance. Ship el puntito. Ver si bajan
+        RECOMENDACIÓN: Reducir alcance. Publicá el puntito. Ver si bajan
         los reclamos. Si bajan, te ahorraste 3 semanas. Si no bajan,
         ahí construís push notifications, pero ya con datos.
 
@@ -163,7 +172,7 @@ Discutí la idea, aprobá el brief, alejate. El agente corre el sprint completo:
 /nano → build → /review → /security → /qa → /ship
 ```
 
-**Autopilot avanza con un brief completo, no adivinando.** `/think --autopilot` siempre arma un brief primero. Si el brief tiene los campos requeridos (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continúa a `/nano` sin pausar. Si falta alguno, `/think` para una vez y hace una sola pregunta enfocada — no inventa campos para seguir.
+**Autopilot avanza con un brief completo, no adivinando.** `/think --autopilot` siempre arma un brief primero. Si el brief tiene los campos requeridos (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continúa a `/nano` sin pausar. Si falta alguno, `/think` para una vez y hace una sola pregunta enfocada. No inventa campos para seguir.
 
 Autopilot solo para si:
 - `/think` no puede armar el brief desde el contexto (hace una pregunta y sigue)
@@ -217,6 +226,14 @@ Si querés enforcement duro, usá Claude Code. Si aceptás disciplina a nivel ag
 ¿Phase gate bloqueó tu commit? Completá `/review`, `/security`, `/qa` para el sprint activo. O si el commit no es del sprint: `NANOSTACK_SKIP_GATE=1 git commit ...`.
 
 Para la guía completa de problemas en español (slash commands, jq, phase gate, puerto en uso, Windows, sprints atascados, conflictos de nombres), ver [TROUBLESHOOTING.es.md](TROUBLESHOOTING.es.md). Para temas avanzados (proxy corporativo, doble ejecución en autopilot, telemetría) consultá la versión canónica en inglés: [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+## Privacidad
+
+Los datos del sprint (briefs, planes, artifacts, journals) quedan en tu máquina en `.nanostack/`.
+
+La telemetría es opt-in y por defecto está apagada. El cliente siempre escribe eventos locales bajo `~/.nanostack/` para que puedas inspeccionar tu propia actividad. Si activás el upload, los eventos se envían al Cloudflare Worker documentado en [`TELEMETRY.md`](TELEMETRY.md). El código del Worker, su schema, las invariantes de privacidad y los smoke tests adversarios viven en este repo.
+
+Niveles: `off` (default), `anonymous`, `community`. Las instalaciones desde v0.4 y anteriores quedan en `off` y no ven prompt. Las instalaciones nuevas reciben un prompt una sola vez en el primer skill run.
 
 ## Más documentación
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 <br>
 
 <p align="center">
-  Turns your AI agent into a professional delivery team. Challenges scope, plans, reviews, tests, audits, and ships — in language anyone can read.
+  Turns your AI coding agent into a delivery team: scope, plan, build, review, test, audit, and ship in language anyone can read.
 </p>
 
-<p align="center"><strong>One sprint. Minutes, not weeks. For technical and non-technical users.</strong></p>
+<p align="center"><strong>One workflow. Technical or guided. Honest about what each agent can enforce.</strong></p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -30,13 +30,15 @@
 <br>
 
 
-Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). 13 skills. Zero dependencies. Zero build step.
+Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). 13 skills total. The default sprint uses seven core specialists. Zero dependencies. Zero build step.
 
 Works with Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, and Cline.
 
 ## What is Nanostack?
 
-Your agent is already capable of writing code. What it lacks is structure. Nanostack is seven specialists the agent invokes in order, each one reading what came before. Scope gets challenged before planning. The plan gets named files and risks before building. The build gets reviewed, audited, and tested before shipping. Ship creates the PR, verifies CI, and writes the sprint journal.
+Your agent is already capable of writing code. What it lacks is delivery structure. Nanostack gives it a workflow: challenge the scope, plan the files, build the change, review the diff, test the behavior, audit security, and ship with a record of what happened.
+
+The default sprint uses seven core specialists. Each one reads the record the previous one wrote, so context does not vanish between steps.
 
 Every step reads the artifact the previous step wrote, so nothing falls through the cracks. On Claude Code the pipeline is enforced via PreToolUse hooks: `git commit` is blocked until `/review`, `/security`, and `/qa` produce fresh artifacts. On other agents the same workflow runs as guided instructions; see [What enforces on which agent](#what-enforces-on-which-agent) for the per-host capability table.
 
@@ -97,7 +99,7 @@ Thinks with you, pushes back when needed. Asks the questions that take an idea f
 <tr>
 <td align="center">
 <h3>🎯 Phase gate</h3>
-The sprint runs in order: think, plan, build, review, security, qa, ship. Trying to ship before reviewing is blocked.
+The sprint runs in order: think, plan, build, review, security, qa, ship. On hosts with hooks, skip attempts can be blocked. On other agents, the same order is guided and reported honestly.
 </td>
 <td align="center">
 <h3>🔐 Local first</h3>
@@ -140,7 +142,18 @@ One command. Detects your agents, installs everything, runs setup.
 
 Then run `/nano-run` in your agent to configure your project through a conversation. On your first sprint, `/think` shows the full pipeline so you know what comes next.
 
-Want to try it on a sandbox first? `examples/starter-todo/` is a tiny TODO app with three suggested features to learn the sprint flow without touching a real project. See [`examples/starter-todo/README.md`](examples/starter-todo/README.md).
+## Try it safely first
+
+The fastest way to understand Nanostack is to run it on a project that does not matter yet. Pick a sandbox from the Examples Library:
+
+| Example | Best for | Stack | Time |
+|---|---|---|---|
+| [`starter-todo`](examples/starter-todo/) | new and non-technical users | one HTML file | 5-10 min |
+| [`cli-notes`](examples/cli-notes/) | CLI workflows | Bash | 5-15 min |
+| [`api-healthcheck`](examples/api-healthcheck/) | backend flows | Node stdlib HTTP | 10-15 min |
+| [`static-landing`](examples/static-landing/) | founders and designers | static HTML/CSS | 10-15 min |
+
+Each example has a copy-paste prompt, expected sprint flow, success criteria, and reset steps. Full library: [`examples/`](examples/).
 
 ## See it work
 
@@ -360,7 +373,9 @@ Discuss the idea, approve the brief, walk away. The agent runs the full sprint:
 
 On Claude Code the phase gate enforces the pipeline at the hook layer: even if the agent judges a task as "simple" and tries to skip review or security, `git commit` is blocked until all phases have fresh artifacts. The hook stops the commit, no instructions involved. On agents that do not support pre-action hooks the same gate runs as a rule the agent reads; the gate is honest about the difference and `/nano-doctor` reports the actual level for your install.
 
-**Autopilot continues after a complete brief, not after blind guessing.** `/think --autopilot` always produces a brief first. If the brief has the required fields (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continues to `/nano` without pausing. If any required field is missing, `/think` stops once and asks one focused question — it does not invent fields to keep moving.
+**Autopilot continues after a complete brief, not after blind guessing.** `/think --autopilot` always produces a brief first. If the brief has the required fields (`value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`), `/think` continues to `/nano` without pausing. If any required field is missing, `/think` stops once and asks one focused question. It does not invent fields to keep moving.
+
+If the premise is not validated yet, that is allowed as long as the brief says so explicitly. Nanostack will steer the sprint toward a probe instead of pretending the idea is proven.
 
 Autopilot only stops if:
 - `/think` cannot fill the brief from context (asks one question, then continues)
@@ -777,9 +792,11 @@ Full guide: [`EXTENDING.md`](EXTENDING.md). Working starting point: [`examples/c
 
 ## Privacy
 
-Sprint data (briefs, plans, artifacts, journals) stays on your machine in `.nanostack/`. That has not changed.
+Sprint data (briefs, plans, artifacts, journals) stays on your machine in `.nanostack/`.
 
-v0.5 adds **opt-in telemetry** about skill usage. Three tiers: `off`, `anonymous`, `community`. Installs from v0.4 and earlier default to `off` and see no prompt. New installs see a one-time prompt on first skill run. Nothing is sent over the network in the initial v0.5 release; a remote endpoint lands in a later PR. Full disclosure of what is collected, what is never collected, and how to audit or opt out: [TELEMETRY.md](TELEMETRY.md).
+Telemetry is opt-in. Default is `off`. The client always writes local usage events to `~/.nanostack/` so you can inspect your own activity. If you opt into upload, events are sent to the Cloudflare Worker documented in [`TELEMETRY.md`](TELEMETRY.md). The Worker source, schema, privacy invariants, and adversarial smoke tests all live in this repo.
+
+Tiers: `off` (default), `anonymous`, `community`. Installs from v0.4 and earlier default to `off` and see no prompt. New installs see a one-time prompt on first skill run.
 
 Change your tier at any time:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   Turns your AI coding agent into a delivery team: scope, plan, build, review, test, audit, and ship in language anyone can read.
 </p>
 
-<p align="center"><strong>One workflow. Technical or guided. Honest about what each agent can enforce.</strong></p>
+<p align="center"><strong>Small sandbox sprints run in minutes. Real projects keep the same professional workflow.</strong></p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>

--- a/TROUBLESHOOTING.es.md
+++ b/TROUBLESHOOTING.es.md
@@ -148,7 +148,7 @@ Nanostack funciona en Windows con dos caminos soportados:
 - **Git Bash** (incluido con Git for Windows). Corré `setup` desde Git Bash, no desde PowerShell o CMD.
 - **WSL2** (recomendado para uso intenso). Funciona como Linux nativo.
 
-PowerShell y CMD no están soportados — los scripts de nanostack usan Bash.
+PowerShell y CMD no están soportados; los scripts de nanostack usan Bash.
 
 Si las skills no aparecen después del setup en Windows:
 


### PR DESCRIPTION
## Summary

Codex spec `public-wording-master-spec-2026-04-26` + companion `public-copy-regression-locks-2026-04-26`. Pure copy/docs work on both READMEs, plus a critical CI fix for a regression that had been hiding older em-dash failures.

## README.md

- **Hero rewritten:** *"Turns your AI coding agent into a delivery team: scope, plan, build, review, test, audit, and ship in language anyone can read."* Bumper: *"One workflow. Technical or guided. Honest about what each agent can enforce."*
- **13 skills / seven specialists reconciliation:** *"13 skills total. The default sprint uses seven core specialists."*
- **"What is Nanostack?" rewritten** around delivery structure rather than "is seven specialists".
- **Phase-gate feature card** softened to honest cross-agent claim.
- **"Try it safely first" section** replaces the single starter-todo mention with the full four-archetype Examples Library table.
- **Autopilot:** one-sentence addendum that `premise_validated=false` is allowed as long as the brief says so (matches PR #173's behavior).
- **Privacy/telemetry** rewritten to reflect the deployed Cloudflare Worker. Removed stale "endpoint lands in a later PR".

## README.es.md

- Hero parity, "13 skills en total / siete especialistas", four-archetype table.
- Spanglish cleanup: "se ships" → "sale", "Ship el puntito" → "Publicá el puntito".
- New `## Privacidad` section mirroring the English one.

## Critical CI fix

`.github/workflows/lint.yml` was **silently broken**. PR #160 introduced two heredocs whose bodies sat at column 0 (outside the `run: |` block scalar's required indent), and PR #168 introduced a step name with an unquoted colon. Both produced YAML that GitHub Actions treated as a hard parse failure, so every recent lint run showed "failure" but never actually ran the per-job script. The whole stack of `think-*` / `examples-library` / etc. shipped without validating in CI.

Three structural fixes:

1. Both heredoc-driven loops rewritten as `for h in '...' '...'` loops. No column-0 content, no YAML break.
2. Quoted the colon-in-name step.
3. Third heredoc (process substitution from a multi-line variable) rewritten as `done < <(printf '%s\n' "$blocks")` — keeps `$fail` in the parent shell, avoids column-0 body.

Plus two new defensive lint jobs:

- **`workflow-yaml-parses`** — strict YAML parse on every workflow file. A future broken edit fails loudly on PR instead of silently after merge.
- **`readme-public-copy`** — the spec-requested regression lock. Forbids the six stale strings (`Under 15 minutes`, `endpoint lands in a later PR`, `se ships`, etc.) and requires the seven English + six Spanish framing strings (archetype names, `13 skills total`, `Examples Library`, `Privacidad`, `telemetría`, etc.).

Pre-existing em-dashes in `README.md`, `README.es.md`, and `TROUBLESHOOTING.es.md` (which the broken YAML had hidden) are also fixed by rephrasing.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` clean on lint.yml + e2e.yml.
- [x] All 27 lint jobs visible after parse.
- [x] `tests/run.sh`: 44/44.
- [x] `ci/e2e-user-flows.sh`: 57/57.
- [x] `ci/e2e-delivery-matrix.sh`: 17/17.
- [x] `ci/e2e-think-flows.sh`: 32/32.
- [x] `ci/check-examples.sh`: 32/32.
- [x] Spec stale-grep returns nothing.
- [x] Spec required-grep returns matches in both README.md and README.es.md.
- [x] `git diff --check` clean.
- [ ] **CI lint matrix actually green on push** — first PR after the fix where this is meaningful.

## Honesty note

The earlier "44/44 + 57/57 + ..." claims in PRs #163-#178 were all from local runs only. CI was reporting failure on every run because the workflow file did not parse, so the per-job logic those PRs added never executed remotely. The new `workflow-yaml-parses` job is the structural fix that prevents this from recurring.