### PR TITLE
README definitive product wording (Codex audit, 2026-04-26)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1263,14 +1263,20 @@ jobs:
           fail=0
           # Each stale string is one quoted argument so spaces inside
           # do not split. Order intentional: most-cited spec entries
-          # first.
+          # first. The set grows with each public-wording spec round
+          # so a regression hits the lint job, not the readers.
           for stale in \
             'Under 15 minutes' \
             'Four tiers' \
             'endpoint lands in a later PR' \
             'Claude does the rest' \
             'se ships' \
-            'Ship el puntito'; do
+            'Ship el puntito' \
+            'Nothing leaves unless you opt in' \
+            'post-deploy canary' \
+            'Four commands' \
+            'That is not a copilot' \
+            'Zero dependencies. Zero build step'; do
             if grep -nF "$stale" README.md README.es.md 2>/dev/null; then
               echo "FAIL: stale string present: $stale"
               fail=1
@@ -1289,7 +1295,11 @@ jobs:
             'starter-todo' \
             'cli-notes' \
             'api-healthcheck' \
-            'static-landing'; do
+            'static-landing' \
+            'delivery workflow' \
+            'What changes after installing Nanostack' \
+            'No Nanostack cloud' \
+            'Production deployment stays explicit'; do
             if ! grep -qF "$required" README.md; then
               echo "FAIL: required string missing in README.md: $required"
               fail=1

--- a/README.es.md
+++ b/README.es.md
@@ -1,6 +1,6 @@
 <h1 align="center">Nanostack</h1>
 <p align="center">
-  Convertí a tu agente de código con IA en un equipo de delivery: definí alcance, planificá, construí, revisá, probá, auditá y publicá en lenguaje que cualquiera puede leer.<br>
+  Nanostack convierte tu agente de AI coding en un flujo de delivery: clarifica alcance, planifica el cambio, construye, revisa, prueba, audita y deja registro de lo ocurrido.<br>
   <strong>Sprints en sandbox que corren en minutos. Los proyectos reales mantienen el mismo workflow profesional.</strong>
 </p>
 
@@ -78,14 +78,14 @@ Cada ejemplo trae prompt para pegar, flujo esperado, criterios de éxito y pasos
 
 ## Dos perfiles, mismo rigor
 
-Nanostack adapta lo que te muestra según tu contexto. El workflow no cambia; las palabras sí.
+Guided cambia el lenguaje, no baja el estándar.
 
-| Perfil | Cuándo lo recibís | Cómo se ve la salida |
-|---|---|---|
-| **Guiado** | Modo local (sin repositorio git), o cuando lo elegís explícitamente. | Lenguaje claro. Sin jerga de proceso. Cada paso te dice el resultado, cómo verlo, qué se revisó y qué queda sin verificar. |
-| **Profesional** | Repositorio git con herramientas de developer estándar, o cuando lo elegís. | Hallazgos, evidencia, rutas de archivos, estado de chequeos automáticos. Próximo paso consciente de la fase. |
+| Perfil | Qué cambia |
+|---------|------------|
+| **Guiado** | Lenguaje claro, una sola próxima acción, defaults más seguros, sin jerga oculta. |
+| **Profesional** | Salida más densa, tradeoffs explícitos, archivos, comandos y riesgos nombrados. |
 
-En ambos casos: el alcance se cuestiona antes de planificar, el plan nombra cada archivo, las revisiones (review, seguridad, qa) corren antes de publicar, y el agente reporta con honestidad qué chequeó y qué no. Nanostack no solo protege el workflow; ahora guía el delivery como un equipo profesional, entendible para usuarios técnicos y no técnicos.
+El modo local usa Guiado por defecto. Un proyecto con git también puede usar Guiado si querés explicaciones más simples.
 
 Las reglas de lenguaje viven en [`reference/plain-language-contract.md`](reference/plain-language-contract.md). Los campos de sesión que seleccionan el perfil viven en [`reference/session-state-contract.md`](reference/session-state-contract.md).
 
@@ -229,9 +229,9 @@ Para la guía completa de problemas en español (slash commands, jq, phase gate,
 
 ## Privacidad
 
-Los datos del sprint (briefs, planes, artifacts, journals) quedan en tu máquina en `.nanostack/`.
+Nanostack no tiene un servicio cloud propio. Guarda planes, artefactos, journals y know-how localmente en `.nanostack/`. No envía tu código, prompts, nombres de proyecto ni rutas de archivo a servidores de Nanostack. Tu proveedor de agente de IA puede procesar el contexto que le des; usá las opciones de privacidad de tu proveedor y tus propias políticas de datos para trabajo sensible.
 
-La telemetría es opt-in y por defecto está apagada. El cliente siempre escribe eventos locales bajo `~/.nanostack/` para que puedas inspeccionar tu propia actividad. Si activás el upload, los eventos se envían al Cloudflare Worker documentado en [`TELEMETRY.md`](TELEMETRY.md). El código del Worker, su schema, las invariantes de privacidad y los smoke tests adversarios viven en este repo.
+La telemetría es opt-in y se limita a eventos de uso agregados. No es necesaria para el workflow. Si la activás, los eventos van al Cloudflare Worker documentado en [`TELEMETRY.md`](TELEMETRY.md). El código del Worker, su schema, las invariantes de privacidad y los smoke tests adversarios viven en este repo.
 
 Niveles: `off` (default), `anonymous`, `community`. Las instalaciones desde v0.4 y anteriores quedan en `off` y no ven prompt. Las instalaciones nuevas reciben un prompt una sola vez en el primer skill run.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 <br>
 
 <p align="center">
-  Turns your AI coding agent into a delivery team: scope, plan, build, review, test, audit, and ship in language anyone can read.
+  Turn your AI coding agent into a delivery workflow.
 </p>
 
-<p align="center"><strong>Small sandbox sprints run in minutes. Real projects keep the same professional workflow.</strong></p>
+<p align="center">
+  Nanostack helps an agent challenge scope, plan the change, build, review, test, audit, and ship with a record of what happened.
+</p>
+
+<p align="center"><strong>Plain text skills. No build step. No Nanostack cloud.</strong></p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -30,7 +34,7 @@
 <br>
 
 
-Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). 13 skills total. The default sprint uses seven core specialists. Zero dependencies. Zero build step.
+Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). 13 skills total. The default sprint uses seven core specialists. No build step. No Nanostack cloud.
 
 Works with Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, and Cline.
 
@@ -50,67 +54,45 @@ Every step reads the artifact the previous step wrote, so nothing falls through 
 | **04** | `/review`         | Two-pass code review. Scope drift detection. Auto-fixes the mechanical. |
 | **05** | `/security`       | OWASP A01-A10 audit + STRIDE threat modeling. Graded A-F.               |
 | **06** | `/qa`             | Tests the thing. Browser, API, CLI, or root-cause debug.                |
-| **07** | `/ship`           | PR creation, CI verification, post-deploy canary, sprint journal.       |
+| **07** | `/ship`           | PR creation, CI verification, release notes, sprint journal. Production deployment stays explicit and user-controlled. |
 
 ## Two profiles, same rigor
 
-Nanostack adapts what it shows you based on your context. The workflow does not change; the wording does.
+Nanostack adapts the explanation, not the standard.
 
-| Profile | When you get it | What output looks like |
-|---|---|---|
-| **Guided** | Local mode (no git repo), or when you choose it explicitly. | Plain language. No PR/CI/branch/diff jargon. Each phase tells you the result, how to try it, what was checked, and what remains unverified. |
-| **Professional** | Git repository with the standard developer toolchain, or when you choose it. | Findings, evidence, file paths, PR/CI status preserved. Phase-aware next-step prose. |
+| Profile | What changes |
+|---------|--------------|
+| **Guided** | Plain language, one next action, safer defaults, no hidden jargon. |
+| **Professional** | Denser output, deeper tradeoffs, explicit files, commands, and risks. |
 
-Either way: scope is challenged before planning, the plan names every file, review/security/qa run before ship, and the agent honestly reports what it could and could not check. Nanostack does not only protect the workflow; it guides delivery like a professional engineering team, understandable for technical and non-technical users.
+Local mode uses Guided language by default. A git project can still use Guided if the user wants simpler explanations.
 
 The wording rules live in [`reference/plain-language-contract.md`](reference/plain-language-contract.md). The session fields that select the profile live in [`reference/session-state-contract.md`](reference/session-state-contract.md).
 
-## Features
+## What is enforced depends on your agent
 
-<table>
-<tr>
-<td align="center" width="33%">
-<h3>🧠 Thinking partner</h3>
-Thinks with you, pushes back when needed. Asks the questions that take an idea from vague to concrete. You finish with clarity about what to build and why.
-</td>
-<td align="center" width="33%">
-<h3>📋 Real plans</h3>
-<code>/nano</code> lists every file the agent will touch and every risk before it writes a line. A plan you can read, argue with, and check off.
-</td>
-<td align="center" width="33%">
-<h3>🔍 Scope guard</h3>
-<code>/review</code> compares what got built with what you agreed to build. If the agent added extras, you see them before you merge.
-</td>
-</tr>
-<tr>
-<td align="center">
-<h3>🛡️ Security audit</h3>
-<code>/security</code> looks for password leaks, broken logins, and the kind of mistakes that make headlines. Every release, not once a quarter.
-</td>
-<td align="center">
-<h3>🧪 Real QA</h3>
-<code>/qa</code> opens your app like a real user. Clicks buttons, takes screenshots, and fixes the bugs it finds.
-</td>
-<td align="center">
-<h3>📦 Honest PRs</h3>
-<code>/ship</code> writes a PR description that explains <em>why</em> the change exists, not just which files moved.
-</td>
-</tr>
-<tr>
-<td align="center">
-<h3>🎯 Phase gate</h3>
-The sprint runs in order: think, plan, build, review, security, qa, ship. On hosts with hooks, skip attempts can be blocked. On other agents, the same order is guided and reported honestly.
-</td>
-<td align="center">
-<h3>🔐 Local first</h3>
-Nothing leaves unless you opt in. Your code, prompts, project names, and file paths stay on your computer.
-</td>
-<td align="center">
-<h3>⚡ No lock-in</h3>
-The skills are plain text files on your computer. Open any of them and read exactly what it does. No login, no SaaS, no cloud.
-</td>
-</tr>
-</table>
+Nanostack is agent-agnostic, but agent hosts do not expose the same control points. The adapter files in [`adapters/`](adapters/) are the source of truth for each host.
+
+| Level | Meaning |
+|-------|---------|
+| **L0 Unsupported** | Nanostack cannot provide this capability on that host. |
+| **L1 Instructions only** | The skill tells the agent what to do, but cannot block it. |
+| **L2 Reported** | Nanostack can detect and report the issue. |
+| **L3 Enforced** | Nanostack can block the action through host hooks or guard scripts. |
+
+A detailed per-host matrix (Bash guard, Write/Edit guard, phase gate) lives further down in [What enforces on which agent](#what-enforces-on-which-agent).
+
+## What changes after installing Nanostack
+
+| Before | With Nanostack |
+|--------|----------------|
+| A vague prompt turns into code immediately. | `/think` turns the idea into a brief, risk, and smallest useful starting point. |
+| The plan disappears in chat. | `/nano` saves a plan with files, risks, checks, and out-of-scope items. |
+| The agent can drift from the request. | `/review` compares what changed against what was agreed. |
+| QA and security happen only if someone remembers. | `/qa` and `/security` are first-class sprint phases. |
+| Shipping explains which files moved. | `/ship` explains why the change exists, how it was checked, and what remains. |
+| Every session starts from zero. | Sprint artifacts and journals preserve decisions in `.nanostack/`. |
+| Enforcement is unclear. | Adapter capabilities show what is blocked, guided, or unsupported for each agent. |
 
 ## Nanostack is right for you if
 
@@ -194,11 +176,19 @@ You:    [builds it]
 You:    /review
         Review: 2 findings (1 auto-fixed, 1 nit). 2 things done well.
 
+You:    /security
+        No secrets, auth changes, or unsafe data flows introduced. Grade A.
+
+You:    /qa
+        Opened the app, posted a reply, refreshed, confirmed the dot
+        appears and clears. 4 checks pass.
+
 You:    /ship
-        Ship: PR created. Tests pass. Done.
+        PR explains why the change exists, how it was checked, and what
+        remains. CI green. Sprint journal saved.
 ```
 
-You said "notifications." The agent said "your users have a freshness problem" and found a solution that ships in an afternoon instead of three weeks. Four commands. That is not a copilot. That is a thinking partner.
+That is the difference: not just code generation, but a delivery loop you can inspect.
 
 ## The sprint
 
@@ -568,14 +558,17 @@ This creates `.claude/settings.json` with permissions so Claude Code doesn't int
 
 Requires [Git for Windows](https://git-scm.com/downloads/win) which includes Git Bash. Claude Code uses Git Bash internally, so the setup script and all bin/ scripts work without changes. Alternatively use WSL or `npx skills add`.
 
-### Requirements
+## Requirements
 
-Nanostack works best with git but adapts automatically when there's no repo. With git, artifacts are stored relative to the git root, the phase gate verifies sprint compliance, scope drift compares planned files against `git diff`, and guard uses the repo boundary for in-project safety. Without git, nanostack detects local mode and adapts the sprint: review checks files from the plan instead of a diff, ship opens the result instead of creating a PR, and all skills use plain language without git terminology.
+- macOS or Linux shell environment (Windows works with Git Bash or WSL)
+- `bash`
+- [`git`](https://git-scm.com/)
+- [`jq`](https://jqlang.github.io/jq/) (`brew install jq`, `apt install jq`, or `choco install jq`)
+- One supported AI coding agent: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, or Cline
 
-- [Git](https://git-scm.com/)
-- [jq](https://jqlang.github.io/jq/) for artifact processing (`brew install jq`, `apt install jq`, or `choco install jq`)
-- macOS, Linux or Windows (Git Bash or WSL)
-- One of: Claude Code, Cursor, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Amp, Cline
+Nanostack has no app runtime dependency and no build step. The scripts use standard local tools.
+
+Nanostack works best with git but adapts automatically when there is no repo. With git, artifacts are stored relative to the git root, the phase gate verifies sprint compliance, scope drift compares planned files against `git diff`, and guard uses the repo boundary for in-project safety. Without git, Nanostack detects local mode and adapts the sprint: review checks files from the plan instead of a diff, ship opens the result instead of creating a PR, and all skills use plain language without git terminology.
 
 ## The Zen of Nanostack
 
@@ -792,9 +785,13 @@ Full guide: [`EXTENDING.md`](EXTENDING.md). Working starting point: [`examples/c
 
 ## Privacy
 
-Sprint data (briefs, plans, artifacts, journals) stays on your machine in `.nanostack/`.
+Nanostack itself has no cloud service.
 
-Telemetry is opt-in. Default is `off`. The client always writes local usage events to `~/.nanostack/` so you can inspect your own activity. If you opt into upload, events are sent to the Cloudflare Worker documented in [`TELEMETRY.md`](TELEMETRY.md). The Worker source, schema, privacy invariants, and adversarial smoke tests all live in this repo.
+By default, sprint artifacts, plans, journals, and know-how are written locally under `.nanostack/`.
+
+Nanostack itself stores sprint state, artifacts, and know-how locally. It does not send your code, prompts, project names, or file paths to a Nanostack server. Your AI agent provider may still process the context you give it. Use your agent provider's privacy settings and your own data policies for sensitive work.
+
+Telemetry is opt-in and limited to aggregate usage events. It is not required for the workflow. If you opt in, events go to the Cloudflare Worker documented in [`TELEMETRY.md`](TELEMETRY.md); the Worker source, schema, privacy invariants, and adversarial smoke tests all live in this repo.
 
 Tiers: `off` (default), `anonymous`, `community`. Installs from v0.4 and earlier default to `off` and see no prompt. New installs see a one-time prompt on first skill run.
 


### PR DESCRIPTION
## Summary

README-only PR per the Codex public-product-wording audit. Goal: a non-technical founder, a senior engineer, and an OSS evaluator all land within 30 seconds of arrival.

## Hero

> Turn your AI coding agent into a delivery workflow.
> Nanostack helps an agent challenge scope, plan the change, build, review, test, audit, and ship with a record of what happened.
> Plain text skills. No build step. No Nanostack cloud.

## What changes (the big ones)

| Area | Change |
|---|---|
| **Hero** | Rewritten per spec. Drops "delivery team" phrasing. |
| **`## Features` (3x3 grid)** | Replaced by **`## What changes after installing Nanostack`** before/after table. The grid forced readers to assemble the product themselves. |
| **`## Two profiles, same rigor`** | Tightened to spec wording: "Nanostack adapts the explanation, not the standard." |
| **`## What is enforced depends on your agent`** (new) | L0/L1/L2/L3 capability summary. Reader gets the honest enforcement story near the top, not buried in Guard. |
| **`## See it work` demo** | Extended to show `/review`, `/security`, `/qa` between `/nano` and `/ship`. The old version skipped them, which undersold the product. |
| **Sprint table `/ship` row** | "post-deploy canary" → "release notes, sprint journal. Production deployment stays explicit and user-controlled." |
| **Demo close** | "That is not a copilot. That is a thinking partner" → "That is the difference: not just code generation, but a delivery loop you can inspect." |
| **`## Privacy`** | Rewritten so the boundary is explicit: Nanostack has no cloud, but your AI agent provider may still process the context you give it. |
| **`## Requirements`** | Promoted to top-level. Names `bash` / `git` / `jq` / supported agent. Says "Nanostack has no app runtime dependency". Resolves the old "Zero dependencies" overclaim. |
| **README.es** | Hero, Privacidad, and Two profiles parity per the canonical Spanish positioning the spec called out. |

## CI regression lock extended

`readme-public-copy` job now forbids five new stale strings ("Nothing leaves unless you opt in", "post-deploy canary", "Four commands", "That is not a copilot", "Zero dependencies. Zero build step") and requires four new framing strings ("delivery workflow", "What changes after installing Nanostack", "No Nanostack cloud", "Production deployment stays explicit").

## Spec acceptance checks

- [x] Stale grep returns nothing.
- [x] Required grep matches all core concepts.
- [x] No quickstart shows `/ship` before `review`/`security`/`qa`.
- [x] README.es matches the canonical Spanish wording.
- [x] `git diff --check` clean.
- [x] All five suites green: 44/44 + 57/57 + 17/17 + 32/32 + 32/32.
- [x] Workflow YAML parses (27 jobs).
- [ ] CI lint matrix green on push.

## Out of scope

- No runtime script changes.
- No adapter changes.
- No examples code changes.
- No skill behavior changes.

This is a README-only PR.

## Honest changes that the spec asked for

The product was carrying three small overclaims:

1. **Privacy.** "Nothing leaves unless you opt in. Your code, prompts, project names, and file paths stay on your computer" reads as a provider-level guarantee. Nanostack itself does not phone home — but it cannot promise anything about what your agent provider does with the context you give it. The new wording draws that line.
2. **Dependencies.** "Zero dependencies" while the install needs `jq` was misleading. The Requirements section now names the local tools and says "no app runtime dependency".
3. **Deployment.** "post-deploy canary" implied Nanostack pushes production by default. It does not. The /ship row now says "Production deployment stays explicit and user-controlled."

Those three are the kind of small lies that erode trust over time. Better to fix them now while the README is being reread.