### PR TITLE
/nano-run vNext PR 1: setup artifact schema + onboarding contract

### DIFF
--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -206,6 +206,98 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
 }
 ```
 
+### /nano-run (setup)
+
+`/nano-run` writes a setup artifact after the onboarding flow detects, configures, and recommends. The artifact lives at `.nanostack/setup/<timestamp>.json` with a copy at `.nanostack/setup/latest.json` (no symlink, for portability). Support, doctor, and future skills read it to know what onboarding decided.
+
+```json
+{
+  "schema_version": "1",
+  "phase": "setup",
+  "timestamp": "2026-04-26T12:00:00Z",
+  "project": "/absolute/path",
+  "branch": "main|null",
+  "summary": {
+    "status": "ready|needs_repair|report_only|blocked|partial",
+    "profile": "guided|professional",
+    "host": "claude|codex|cursor|opencode|gemini|unknown",
+    "run_mode": "normal|report_only",
+    "project_mode": "git|local",
+    "detected_stack": {
+      "node": true,
+      "go": false,
+      "python": false,
+      "docker": false,
+      "framework": "Next.js|null",
+      "package_manager": "npm|pnpm|yarn|bun|null"
+    },
+    "capabilities": {
+      "bash_guard":  "enforced|reported|instructions_only|unsupported|unknown",
+      "write_guard": "enforced|reported|instructions_only|unsupported|unknown",
+      "phase_gate":  "enforced|reported|instructions_only|unsupported|unknown"
+    },
+    "configuration": {
+      "config_json":      "created|updated|exists|skipped_report_only|error",
+      "stack_json":       "created|updated|exists|skipped_report_only|error",
+      "project_settings": "created|updated|exists|needs_repair|skipped_report_only|not_applicable|error",
+      "gitignore":        "created|updated|exists|skipped_report_only|not_applicable|error"
+    },
+    "legacy": {
+      "detected": false,
+      "missing_hooks": [],
+      "broad_permissions": [],
+      "repair_available": false,
+      "migration_requires_confirmation": false
+    },
+    "recommended_first_run": {
+      "kind": "sandbox|existing_project|repair|report_only",
+      "command": "/think \"add due dates to tasks\"",
+      "path": "examples/starter-todo",
+      "reason": "Safe first run before touching a real product."
+    }
+  },
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
+  }
+}
+```
+
+**Required fields** (the setup artifact writer rejects payloads without these):
+
+- `summary.status`
+- `summary.profile`
+- `summary.host`
+- `summary.run_mode`
+- `summary.project_mode`
+- `summary.capabilities` (all three sub-fields)
+- `summary.configuration` (all four sub-fields)
+- `summary.recommended_first_run.kind`
+- `summary.recommended_first_run.command`
+- `context_checkpoint.summary`
+
+**Optional but recommended:** `summary.detected_stack.framework`, `summary.detected_stack.package_manager`, `summary.legacy`.
+
+**Capability values** must come from `adapters/<host>.json`, not from prose. The five valid values map to L0-L3 honesty rule:
+
+| Value | Meaning | L-level |
+|---|---|---|
+| `enforced` | Blocked at host/tool layer. | L3 |
+| `reported` | Detected and reported, not blocked. | L2 |
+| `instructions_only` | Guides the agent, cannot hard-block. | L1 |
+| `unsupported` | Capability not provided on this host. | L0 |
+| `unknown` | Host not detected, or no adapter available. | (probe with `/nano-doctor`) |
+
+**Status values** (`summary.status`):
+
+- `ready`: onboarding succeeded, normal run. Setup artifact reflects fresh state.
+- `needs_repair`: host config (e.g. `.claude/settings.json`) is missing hooks or has legacy broad permissions. The artifact records what to repair; no silent narrowing.
+- `report_only`: onboarding ran in `run_mode == report_only`. No mutation. Artifact reflects what would change in normal mode.
+- `partial`: mutation started but failed midway. Artifact may be missing some `summary.configuration` fields; do not pretend setup completed.
+- `blocked`: onboarding could not run (missing dependency, no project root, etc.).
+
 ## Conflicts schema
 
 Present in review, security, and qa:

--- a/start/references/onboarding-contract.md
+++ b/start/references/onboarding-contract.md
@@ -1,0 +1,179 @@
+# /nano-run onboarding contract
+
+`/nano-run` is the first product surface a user sees after installing nanostack. This file is the contract the skill follows so a non-technical founder, an experienced engineer, and a legacy-install maintainer all land on a useful screen within one conversation.
+
+This document is paired with three references the skill also reads:
+
+- [`reference/session-state-contract.md`](../../reference/session-state-contract.md): the v2 session fields (`profile`, `run_mode`, `autopilot`, `plan_approval`, `host`).
+- [`reference/plain-language-contract.md`](../../reference/plain-language-contract.md): banned terms and the four-block Guided skeleton.
+- [`reference/artifact-schema.md`](../../reference/artifact-schema.md): the `setup` phase schema saved at the end of a successful run.
+
+## What `/nano-run` must do
+
+1. Read session state. Default to `profile=guided` when no session exists. Onboarding is the first screen; when in doubt, explain simply.
+2. Detect host, project root, and stack files. Only ask what cannot be detected.
+3. Read host capabilities from `adapters/<host>.json`. Do not infer from host name; do not hardcode promises.
+4. If `run_mode == report_only`, do not mutate. Print what would change and stop.
+5. Otherwise: run setup scripts, write a setup artifact (see schema), end with one next action.
+6. If a legacy `.claude/settings.json` is detected, recommend `bin/init-project.sh --repair`. Never run `--migrate-permissions` silently.
+
+## Profile behavior
+
+### Guided
+
+Output follows the four-block skeleton (`Result` / `How to try` / `What was checked` / `What remains`) per `reference/plain-language-contract.md`. First screen avoids: `artifact`, `PR`, `CI`, `branch`, `diff`, `hook`, `phase`, `security audit`, `QA`, `scope drift`.
+
+Default for `/nano-run`: when there is no project stack and `profile == guided`, the recommended first run is the sandbox at `examples/starter-todo`. Do not force; offer.
+
+### Professional
+
+Output names exact files, commands, host, adapter capability levels, repair status, next command. Reads like a setup report a senior engineer can paste into an issue.
+
+## Output examples
+
+### Guided success (no project)
+
+```
+Ready to try safely.
+
+How to try:
+1. Open examples/starter-todo and run /think "add due dates to tasks".
+
+What was checked:
+- I found your agent and checked which safety checks it supports.
+- I checked whether this folder already looks like an app.
+- I set the first run to plain-language guidance.
+
+What remains:
+- I did not change a real product yet.
+- Some safety checks depend on your agent. I will say when something is guided instead of blocked.
+```
+
+### Guided existing project
+
+```
+Ready to use in this project.
+
+How to try:
+1. Tell me the smallest change you want and start with /think.
+
+What was checked:
+- I found this project and its main tools.
+- I checked which safety checks your agent supports.
+- I saved the setup record locally.
+
+What remains:
+- I did not build or change the app yet.
+- If you want a safer first run, use the starter example before touching this project.
+```
+
+### Guided needs repair
+
+```
+Setup needs one repair.
+
+How to try:
+1. Let me update the safety checks and keep a backup.
+
+What was checked:
+- I found an older Nanostack setup.
+- Some safety checks are missing.
+- Your current settings will be backed up before changes.
+
+What remains:
+- I will not remove broad permissions unless you explicitly approve that migration.
+```
+
+### Professional success
+
+```
+Nanostack setup complete.
+
+Host: codex
+Profile: professional
+Project mode: git
+Project root: /path/to/repo
+Capabilities:
+- Bash guard: instructions_only
+- Write/Edit guard: instructions_only
+- Phase gate: instructions_only
+
+Files:
+- .nanostack/config.json: exists
+- .nanostack/stack.json: created
+- .nanostack/setup/latest.json: created
+
+Next:
+Run /think "describe the change" or try examples/starter-todo first.
+```
+
+### Report-only
+
+```
+Report-only setup preview.
+
+I did not change files.
+
+Would configure:
+- .nanostack/config.json
+- .nanostack/stack.json
+- project safety settings where supported
+
+Next:
+Run /nano-run in normal mode when you want me to apply this.
+```
+
+## Behavioral rules
+
+1. **Detect before asking.** Inspect `git rev-parse`, `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `Dockerfile`, `.nanostack/config.json`, `.nanostack/stack.json`, `.claude/settings.json`. Only ask what cannot be detected.
+2. **One decision per prompt.** Multi-question forms and "pick from this list of slash commands" prompts are not allowed. Ask "Sandbox first or this project?", "Plain language or technical?", "Repair the older setup with a backup?" one at a time.
+3. **Sandbox first for Guided + no project.** Default recommendation is `examples/starter-todo`. When a project exists, offer the sandbox but do not force.
+4. **No hidden mutation in report_only.** No `bin/init-stack.sh`, no `bin/init-project.sh`, no `.gitignore` write, no `.claude/settings.json` change, no setup-artifact write.
+5. **Legacy repair is explicit.** May recommend `bin/init-project.sh --repair`. Must NOT silently run `--migrate-permissions`.
+6. **Setup artifact is written after successful mutation.** If the run partially fails, write status `partial` (not `ready`) so doctor and support know.
+7. **End with one next action.** No long menus. Pick exactly one based on state:
+   - guided + no project → "Try examples/starter-todo."
+   - guided + project → "Start /think with the smallest change."
+   - professional + project → `/think "<change>"` or `/feature "<change>"`.
+   - needs_repair → "Run repair first."
+   - report_only → "Re-run in normal mode when ready."
+
+## Capability honesty
+
+`/nano-run` must read the five capability fields per host from `adapters/<host>.json`:
+
+- `bash_guard`
+- `write_guard`
+- `phase_gate`
+- `skill_discovery`
+- `verification.method`
+
+For Guided output, the only thing that goes on the first screen is whether something is `enforced` or `instructions_only`. Concrete level values (L0-L3) live in Professional output and `/nano-doctor`.
+
+If `host == "unknown"` or the adapter file is missing:
+
+- All capability fields → `unknown`.
+- First screen says: "I can still guide the workflow, but I could not verify hard safety checks for this agent."
+- Recommend `/nano-doctor` for a deeper check.
+- Use Guided language unless user explicitly chose Professional.
+
+## Forbidden claims
+
+The following phrases must never appear in `/nano-run` output, in any profile, regardless of host:
+
+- "always blocks"
+- "guaranteed blocks"
+- "all agents enforce"
+- "hard-blocks on every agent"
+
+CI greps for these in `start/SKILL.md`.
+
+## Where this lives in the lifecycle
+
+`/nano-run` is the only skill that:
+
+- Runs before any session exists.
+- May write `.nanostack/config.json` and `.nanostack/stack.json`.
+- May call `bin/init-project.sh` (with or without `--repair`).
+
+After `/nano-run` completes, the user enters the canonical sprint loop: `/think → /nano → build → /review → /security → /qa → /ship`. Subsequent runs of `/nano-run` on the same project either confirm that everything is set, or recommend a repair.


### PR DESCRIPTION
## Summary

Adds a typed `setup` phase to the artifact schema and lands the per-skill contract `/nano-run` will follow. After this PR, downstream code has unambiguous answers to three questions that used to be implicit:

1. **What does a successful onboarding write to disk?** The new schema specifies the exact JSON shape, every required field, every enum value, and the file path (`.nanostack/setup/<timestamp>.json` + a `latest.json` copy).
2. **What is `/nano-run` allowed to claim about the host?** Capability values come from `adapters/<host>.json` and map cleanly to the L0-L3 honesty rule. Five values: `enforced`, `reported`, `instructions_only`, `unsupported`, `unknown`. No prose, no host-name hardcoding.
3. **What must `/nano-run` do in `report_only`?** The `configuration` enum distinguishes `skipped_report_only` from `error`, so a report-only run can write an artifact that is honest about not having mutated anything. The `legacy.migration_requires_confirmation` flag forbids silent `--migrate-permissions`.

## Files

**`reference/artifact-schema.md`** — appends the `/nano-run (setup)` section:

| Field | Why it exists |
|---|---|
| `summary.status` (`ready` / `needs_repair` / `report_only` / `partial` / `blocked`) | Distinguishes "setup completed" from "setup started but failed midway" so `/nano-doctor` and support do not over-trust a half-written artifact. |
| `summary.profile`, `.host`, `.run_mode`, `.project_mode` | Required. The skill writes them once and downstream readers stop guessing. |
| `summary.detected_stack` (node / go / python / docker booleans + optional framework + package_manager) | Lets `/think` and `/nano` skip "what stack is this?" and read the same answer onboarding already wrote. |
| `summary.capabilities` (`bash_guard`, `write_guard`, `phase_gate`) | Mirrors the L0-L3 table the README now publishes. Hard-blocking claims that do not match the adapter become a CI failure. |
| `summary.configuration` (`config_json`, `stack_json`, `project_settings`, `gitignore`) | Each tracks: `created` / `updated` / `exists` / `skipped_report_only` / `not_applicable` / `error`. The `skipped_report_only` value is what makes the report-only contract checkable. |
| `summary.legacy` (`detected`, `missing_hooks`, `broad_permissions`, `repair_available`, `migration_requires_confirmation`) | Encodes the legacy-Claude case so PR 4 can detect old installs and recommend `--repair` without silently running `--migrate-permissions`. |
| `summary.recommended_first_run` (`kind`, `command`, `path`, `reason`) | The single next action the skill ends with. CI in PR 5 will assert no menu of options replaces this. |

**`start/references/onboarding-contract.md`** (new, 178 lines) — the contract `start/SKILL.md` will read against:

- The 6 things `/nano-run` must do (read session, detect host + project, read adapter capabilities, honor `report_only`, recommend repair without silent migration, write a setup artifact).
- Profile behavior: Guided uses the four-block plain-language skeleton; Professional names exact files and capability levels.
- Five canonical output examples (Guided no-project, Guided existing project, Guided needs_repair, Professional success, report_only).
- Seven behavioral rules including "one decision per prompt", "sandbox first for Guided + no project", and "end with one next action".
- Four forbidden phrases (`always blocks`, `guaranteed blocks`, `all agents enforce`, `hard-blocks on every agent`) that PR 2's `nano-run-capability-honesty` lint job will block.
- Lifecycle note: `/nano-run` is the only skill that runs before a session exists and is allowed to write `.nanostack/config.json` / `.nanostack/stack.json` / call `bin/init-project.sh`.

## What downstream PRs gain

- **PR 2** (`start/SKILL.md` rewrite) cites the contract for its session-state read and copies the output examples verbatim. The `nano-run-*` lint jobs grep for the field names defined here.
- **PR 3** (`bin/save-setup-artifact.sh`) validates payloads against the required-fields list. Without the schema, the writer would either accept anything or hardcode rules.
- **PR 4** (legacy repair) reads `summary.legacy.migration_requires_confirmation` to refuse silent narrowing. The flag has to exist in the schema before the writer can refuse to omit it.
- **PR 5** (E2E onboarding matrix) compares actual artifact output to fixtures derived from this schema.

## What does NOT change

No runtime code, no skill logic, no adapter files, no scripts. Pure documentation. `start/SKILL.md` itself is untouched in this PR; PR 2 rewrites it.

## Acceptance from the spec

```bash
rg '"phase": "setup"|recommended_first_run|needs_repair|skipped_report_only' reference/artifact-schema.md
rg 'nano-run|setup artifact|first-run onboarding' \
   reference/session-state-contract.md \
   reference/plain-language-contract.md \
   start/references/onboarding-contract.md
```

Both grep targets match.

## Test plan

- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix, 32/32 think E2E, 32/32 examples contract.
- [x] Workflow YAML parses (27 jobs).
- [x] Zero em-dashes in new content (defensive, `reference/` not in lint scope but the spirit applies).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.