### PR TITLE
/nano-run vNext PR 2: session-first rewrite + four lint locks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,134 @@ on:
     branches: [main]
 
 jobs:
+  nano-run-session-first:
+    name: /nano-run reads session state
+    runs-on: ubuntu-latest
+    # /nano-run vNext PR 2. Onboarding has to follow the same
+    # session-first pattern every other Sprint phase already follows
+    # (PROFILE / RUN_MODE / AUTOPILOT / PLAN_APPROVAL / HOST). A
+    # silent regression to git-vs-no-git inference would re-introduce
+    # the bug where Codex+git users land in Professional even though
+    # the adapter is instructions_only.
+    steps:
+      - uses: actions/checkout@v4
+      - name: start/SKILL.md reads the five canonical session fields via jq
+        run: |
+          set -e
+          fail=0
+          for var in PROFILE RUN_MODE AUTOPILOT PLAN_APPROVAL HOST; do
+            if ! grep -qE "^${var}=.*jq" start/SKILL.md; then
+              echo "FAIL: start/SKILL.md must read $var via jq from session.json"
+              fail=1
+            fi
+          done
+          if ! grep -q 'reference/session-state-contract.md' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must reference reference/session-state-contract.md"
+            fail=1
+          fi
+          exit $fail
+
+  nano-run-report-only:
+    name: /nano-run respects run_mode=report_only
+    runs-on: ubuntu-latest
+    # The report-only guard must appear BEFORE any mutating instruction
+    # (init-stack.sh, init-project.sh, file writes). A future edit that
+    # moves a mutation above the guard reintroduces the silent-mutate
+    # bug; this job blocks that.
+    steps:
+      - uses: actions/checkout@v4
+      - name: REPORT_ONLY guard appears before the first mutation site
+        run: |
+          set -e
+          fail=0
+          if ! grep -qE 'REPORT_ONLY' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must define REPORT_ONLY from run_mode"
+            fail=1
+          fi
+          guard_line=$(grep -nE 'REPORT_ONLY' start/SKILL.md | head -1 | cut -d: -f1)
+          # First mutating call site (init-stack or init-project run).
+          mut_line=$(grep -nE 'init-stack\.sh|init-project\.sh' start/SKILL.md | head -1 | cut -d: -f1)
+          if [ -z "$guard_line" ] || [ -z "$mut_line" ]; then
+            echo "FAIL: could not locate guard or mutation site"
+            exit 1
+          fi
+          if [ "$guard_line" -ge "$mut_line" ]; then
+            echo "FAIL: REPORT_ONLY guard (line $guard_line) must come BEFORE mutation site (line $mut_line)"
+            fail=1
+          fi
+          # Skill must explicitly say report-only does not write the
+          # setup artifact and does not run mutating scripts.
+          if ! grep -qE 'report.?only|REPORT_ONLY=1' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must reference the report_only mode by name"
+            fail=1
+          fi
+          exit $fail
+
+  nano-run-guided-output:
+    name: /nano-run Guided output uses the four-block skeleton
+    runs-on: ubuntu-latest
+    # The onboarding contract doc carries the canonical Guided
+    # output examples. The four blocks (Result / How to try / What
+    # was checked / What remains, plus Spanish parity) must all be
+    # present so the skill cannot drift away from the
+    # plain-language contract.
+    steps:
+      - uses: actions/checkout@v4
+      - name: onboarding-contract.md declares the four Guided blocks
+        run: |
+          set -e
+          fail=0
+          contract=start/references/onboarding-contract.md
+          if [ ! -f "$contract" ]; then
+            echo "FAIL: $contract is missing"
+            exit 1
+          fi
+          for block in 'Result' 'How to try' 'What was checked' 'What remains'; do
+            if ! grep -q "$block" "$contract"; then
+              echo "FAIL: $contract missing canonical Guided block: $block"
+              fail=1
+            fi
+          done
+          # Spanish parity, since local mode implies guided.
+          for block in 'Resultado' 'Como verlo' 'Que revise' 'Pendiente'; do
+            if ! grep -q "$block" "$contract"; then
+              echo "FAIL: $contract missing Spanish Guided block: $block"
+              fail=1
+            fi
+          done
+          # start/SKILL.md must point at the contract for shapes.
+          if ! grep -q 'onboarding-contract.md' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must point at start/references/onboarding-contract.md"
+            fail=1
+          fi
+          exit $fail
+
+  nano-run-capability-honesty:
+    name: /nano-run does not overclaim host enforcement
+    runs-on: ubuntu-latest
+    # The L0-L3 honesty rule applies to onboarding output too. Four
+    # phrasings the skill must never use, regardless of host or
+    # profile. The skill must also read adapters/ for capability
+    # values rather than synthesize them from host name.
+    steps:
+      - uses: actions/checkout@v4
+      - name: start/SKILL.md does not use forbidden enforcement claims
+        run: |
+          set -e
+          fail=0
+          for phrase in 'always blocks' 'guaranteed blocks' 'all agents enforce' 'hard-blocks on every agent'; do
+            if grep -qiF "$phrase" start/SKILL.md; then
+              echo "FAIL: start/SKILL.md contains forbidden enforcement claim: $phrase"
+              fail=1
+            fi
+          done
+          # Skill must read adapter capabilities from disk.
+          if ! grep -qE 'adapters/' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must read host capabilities from adapters/"
+            fail=1
+          fi
+          exit $fail
+
   workflow-yaml-parses:
     name: Workflow YAML parses
     runs-on: ubuntu-latest

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -3,13 +3,15 @@ name: nano-run
 description: First-time setup and guided sprint. Configures stack, permissions, and work preferences conversationally. Run once after installing nanostack. Triggers on /nano-run.
 concurrency: exclusive
 depends_on: []
-summary: "Onboarding. Detects stack, configures project, guides first sprint."
-estimated_tokens: 300
+summary: "Onboarding. Detects host, configures project, writes a setup record, and ends with one next action."
+estimated_tokens: 350
 ---
 
 # /nano-run — Get Started
 
 You are a friendly onboarding guide. Your job is to configure nanostack for this user and help them run their first sprint. No jargon, no docs, just conversation.
+
+The full per-skill contract lives at [`start/references/onboarding-contract.md`](references/onboarding-contract.md). The setup-artifact JSON shape lives at [`reference/artifact-schema.md`](../reference/artifact-schema.md). Keep this skill aligned with both.
 
 ## Telemetry preamble
 
@@ -21,24 +23,106 @@ _P="$HOME/.claude/skills/nanostack/bin/lib/skill-preamble.sh"
 unset _P
 ```
 
-## Step 1: Detect state
+## Session state (read before anything else)
 
-Check if this project already has nanostack configured:
+Read the v2 session fields per [`reference/session-state-contract.md`](../reference/session-state-contract.md). Onboarding is the first product surface; when uncertain, default to `guided`, not `professional`.
+
+```bash
+SESSION=$NANOSTACK_STORE/session.json
+[ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
+
+PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION" 2>/dev/null || echo "guided")
+RUN_MODE=$(jq -r '.run_mode // "normal"' "$SESSION" 2>/dev/null || echo "normal")
+AUTOPILOT=$(jq -r '.autopilot // false' "$SESSION" 2>/dev/null || echo "false")
+PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' "$SESSION" 2>/dev/null || echo "manual")
+HOST=$(jq -r '.host // "unknown"' "$SESSION" 2>/dev/null || echo "unknown")
+
+if [ "$RUN_MODE" = "report_only" ]; then
+  REPORT_ONLY=1
+else
+  REPORT_ONLY=0
+fi
+```
+
+How `/nano-run` uses each field:
+
+| Field | Effect |
+|---|---|
+| `PROFILE=guided` | Plain language. First screen avoids `artifact`, `PR`, `CI`, `branch`, `diff`, `hook`, `phase`, `security audit`, `QA`, `scope drift`. Output uses the four-block skeleton from `reference/plain-language-contract.md`. |
+| `PROFILE=professional` | Names exact files, capability levels, commands, repair actions. |
+| `RUN_MODE=report_only` | Detect-and-report only. Do NOT run mutating setup scripts; do NOT write `.nanostack/config.json` / `.nanostack/stack.json` / `.claude/settings.json`; do NOT write the setup artifact. |
+| `AUTOPILOT=true` | Continue to the recommended first run without pausing for approval, only after a complete brief gate (delegated to `/think`'s Phase 6.6). |
+| `HOST` | Drives capability honesty. Read `adapters/<HOST>.json` for the exact `enforced` / `reported` / `instructions_only` / `unsupported` levels. Never hardcode host promises. |
+
+If `HOST=unknown`, all capability fields read as `unknown`. Tell the user: "I can still guide the workflow, but I could not verify hard safety checks for this agent." Recommend `/nano-doctor` for a deeper check, and stay in Guided language unless the user explicitly chose Professional.
+
+## Capability honesty (read adapters, do not invent)
+
+`/nano-run` reads host capabilities from disk. Do not synthesize promises from the host name.
+
+```bash
+ADAPTER="$HOME/.claude/skills/nanostack/adapters/${HOST}.json"
+if [ -f "$ADAPTER" ]; then
+  BASH_GUARD=$(jq -r '.bash_guard // "unknown"' "$ADAPTER")
+  WRITE_GUARD=$(jq -r '.write_guard // "unknown"' "$ADAPTER")
+  PHASE_GATE=$(jq -r '.phase_gate // "unknown"' "$ADAPTER")
+else
+  BASH_GUARD=unknown
+  WRITE_GUARD=unknown
+  PHASE_GATE=unknown
+fi
+```
+
+The contract document at [`start/references/onboarding-contract.md`](references/onboarding-contract.md) lists the four phrasings forbidden in any user-facing onboarding output, regardless of profile or host. The README's "What is enforced depends on your agent" section is the public statement of this rule; this skill must not contradict it.
+
+## Step 1: Detect state (read-only)
+
+Inspect what is already on disk. This step never mutates and runs the same way under report-only.
+
+- Project root: `git rev-parse --show-toplevel 2>/dev/null` or current working directory.
+- Stack hints: `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `Dockerfile`.
+- Existing nanostack state: `.nanostack/config.json`, `.nanostack/stack.json`.
+- Existing host state: `.claude/settings.json` (presence of hooks, presence of broad permissions like `Bash(rm:*)` / `Write(*)` / `Edit(*)`).
+
+Run the canonical config probe:
 
 ```bash
 ~/.claude/skills/nanostack/bin/init-config.sh
 ```
 
-**If config exists:** This project is already set up. Ask: "What do you want to do?" and offer:
-1. Start a new project → use Skill tool: skill="think"
-2. Add a feature → use Skill tool: skill="feature"
-3. Reconfigure stack → continue to Step 2
+Decide the path:
 
-**If no config:** Continue to Step 2.
+| Detection | Path |
+|---|---|
+| Config exists, hooks present, no broad permissions | Configured. Ask what they want to do (Step 4). |
+| Config exists but `.claude/settings.json` is missing hooks or has `Bash(rm:*)` / `Write(*)` / `Edit(*)` | Legacy install. See "Repair flow" below. |
+| No config | First-time setup. Continue to Step 2. |
+
+## Repair flow (legacy detection)
+
+If `.claude/settings.json` exists but is missing the PreToolUse hooks, or carries broad permissions like `Bash(rm:*)` / `Write(*)` / `Edit(*)`, do not silently mutate. Show the user what you found in profile-appropriate language and ask once.
+
+`/nano-run` may recommend:
+
+```bash
+bin/init-project.sh --repair
+```
+
+Repair is **additive**: it adds missing hooks and creates a timestamped `.bak` of the existing settings, but does not remove any broad permission entries.
+
+`/nano-run` must NOT silently run:
+
+```bash
+bin/init-project.sh --migrate-permissions
+```
+
+That command removes `Bash(rm:*)` and similar broad rules. Only run it when the user explicitly approves the migration. The setup artifact records `summary.legacy.migration_requires_confirmation = true` so the choice is auditable.
 
 ## Step 2: Configure
 
-Ask the user one question at a time in plain language:
+Skip this step entirely if `REPORT_ONLY=1`. Run only the read-only detection above and jump to the report-only output below.
+
+Ask the user one question at a time in plain language. One decision per prompt; never dump all of them at once.
 
 **Question 1:** "What type of projects do you build?"
 1. Web apps
@@ -47,7 +131,7 @@ Ask the user one question at a time in plain language:
 4. Mobile
 5. Not sure yet
 
-**Question 2:** Check if there's a project open. Read package.json, go.mod, requirements.txt, or equivalent. If detected, show what you found and ask if it's correct. If nothing detected, set defaults based on Question 1.
+**Question 2:** If a stack file was detected in Step 1, show what you found and ask if it is correct. If nothing was detected, set defaults based on Question 1.
 
 Run the configuration:
 
@@ -57,46 +141,54 @@ Run the configuration:
 ```
 
 **Question 3:** "How do you prefer to work?"
-1. Automatic — I describe what I want and the agent does everything
-2. Step by step — I review each phase before continuing
-3. Let's try something simple first
+1. Automatic. I describe what I want and the agent does everything.
+2. Step by step. I review each step before continuing.
+3. Let's try something simple first.
 
-Save the preference in .nanostack/config.json under `preferences.workflow_mode` ("autopilot" or "manual").
+Save the preference in `.nanostack/config.json` under `preferences.workflow_mode` (`autopilot` or `manual`).
 
-## Step 3: First sprint
+## Step 3: Write the setup record
 
-After configuration, guide the user into their first sprint.
+After mutation succeeded (or after detect-only in report mode), write a setup artifact at `.nanostack/setup/<timestamp>.json` with a `latest.json` copy. Schema is in [`reference/artifact-schema.md`](../reference/artifact-schema.md). PR 3 of the vNext spec ships `bin/save-setup-artifact.sh`; until then, write a minimally valid JSON in line per the required-fields list.
 
-If they chose "automatic" or "try something simple":
+Required fields the writer rejects without:
 
-> You're all set. Tell me what you want to build or change in your project and I'll take it from there.
+- `summary.status` (`ready` / `needs_repair` / `report_only` / `partial` / `blocked`)
+- `summary.profile`, `.host`, `.run_mode`, `.project_mode`
+- `summary.capabilities` (all three: `bash_guard`, `write_guard`, `phase_gate`)
+- `summary.configuration` (all four file states; use `skipped_report_only` under report mode)
+- `summary.recommended_first_run.kind` and `.command`
+- `context_checkpoint.summary`
 
-When they describe something, invoke the appropriate skill:
-- New project or big scope → use Skill tool: skill="think", args="--autopilot"
-- Feature on existing project → use Skill tool: skill="feature"
+If a mutation step failed midway, write `summary.status = "partial"`. Do not pretend setup completed.
 
-If they chose "step by step":
+## Step 4: One next action (end with this, not a menu)
 
-> You're all set. When you're ready, tell me what you want to build or change.
->
-> We'll go one step at a time:
-> 1. First we talk about the idea — is it the right size, the right shape?
-> 2. Then we make a plan — which files we touch, what could go wrong.
-> 3. Then we build it.
-> 4. I review the code, check it for security issues, and make sure it works.
-> 5. We save and ship it when you're happy.
->
-> You stay in control between each step. Tell me when you're ready.
+Pick exactly one next action based on state and end the conversation there.
 
-If the user is technical and wants the slash commands, also offer:
+| State | Next action |
+|---|---|
+| `PROFILE=guided` and no project stack detected | Try `examples/starter-todo` first. Sandbox is the default for non-technical users so they do not risk a real product on the first run. |
+| `PROFILE=guided` and project exists | "Tell me the smallest change you want and start with `/think`." |
+| `PROFILE=professional` and project exists | `/think "<change>"` or `/feature "<change>"`. |
+| Setup needs repair | "Let me update the safety checks and keep a backup." |
+| `RUN_MODE=report_only` | "Re-run `/nano-run` in normal mode when you want me to apply this." |
 
-> Quick reference: `/think` → `/nano` → build → `/review` → `/security` → `/qa` → `/ship`. For adding to an existing project, use `/feature` instead.
+When the user describes a change, hand off:
 
-When they describe something, invoke: use Skill tool: skill="think"
+- New project or big scope → use Skill tool: `skill="think"` with args `"--autopilot"`.
+- Feature on existing project → use Skill tool: `skill="feature"`.
+- Otherwise → use Skill tool: `skill="think"`.
+
+## Output contracts (copy these shapes; do not invent your own)
+
+The five canonical outputs live in [`start/references/onboarding-contract.md`](references/onboarding-contract.md). Use them verbatim except for the variable parts (host name, file paths, recommended command). Each Guided output uses the four-block skeleton: Result, How to try, What was checked, What remains.
+
+When `PROFILE=guided`, the Spanish four-block skeleton (Resultado, Como verlo, Que revise, Pendiente) applies on local mode and Spanish-speaking users.
 
 ## Telemetry finalize
 
-Before handing off to /think or returning control:
+Before handing off to `/think` or returning control:
 
 ```bash
 _F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
@@ -104,12 +196,16 @@ _F="$HOME/.claude/skills/nanostack/bin/lib/skill-finalize.sh"
 unset _F
 ```
 
-Pass `abort` or `error` instead of `success` if onboarding did not complete normally.
+Pass `abort`, `error`, or `report_only` instead of `success` if onboarding did not complete a normal run.
 
 ## Rules
 
 - One question at a time. Never dump all questions at once.
-- Plain language. No "SKILL.md", no "artifact", no "frontmatter".
+- Plain language. Never expose internal terms (`SKILL.md`, `artifact`, `frontmatter`, `hook`, `phase`) to a Guided user.
 - If the user seems confused, simplify further.
 - If the user already knows what they want ("just add dark mode"), skip to the sprint.
-- Auto-detect everything you can. Only ask what you can't detect.
+- Auto-detect everything you can. Only ask what you cannot detect.
+- Read the host adapter. Do not invent capability claims.
+- In `report_only`, no mutation. No exception.
+- Legacy repair is explicit. No silent `--migrate-permissions`.
+- End with one next action. No menus.

--- a/start/references/onboarding-contract.md
+++ b/start/references/onboarding-contract.md
@@ -123,6 +123,30 @@ Next:
 Run /nano-run in normal mode when you want me to apply this.
 ```
 
+### Guided success in Spanish (local mode + Spanish-speaking users)
+
+When the user is on local mode or interacting in Spanish, the four-block skeleton has a direct Spanish version per `reference/plain-language-contract.md`:
+
+<!-- guided-output:start -->
+```
+Resultado: Listo para probar sin riesgo.
+
+Como verlo:
+1. Abrí examples/starter-todo y corré /think "agregar fechas a las tareas".
+
+Que revise:
+- Encontré tu agente y revisé qué chequeos de seguridad soporta.
+- Revisé si esta carpeta ya parece una app.
+- Configuré el primer run en lenguaje claro.
+
+Pendiente:
+- No cambié todavía un proyecto real.
+- Algunos chequeos de seguridad dependen de tu agente. Te aviso cuando algo es guía y no bloqueo.
+```
+<!-- guided-output:end -->
+
+The Spanish names are the canonical translations the lint job locks: `Resultado` / `Como verlo` / `Que revise` / `Pendiente`.
+
 ## Behavioral rules
 
 1. **Detect before asking.** Inspect `git rev-parse`, `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `Dockerfile`, `.nanostack/config.json`, `.nanostack/stack.json`, `.claude/settings.json`. Only ask what cannot be detected.


### PR DESCRIPTION
## Summary

`start/SKILL.md` becomes session-aware. Onboarding now reads the same five fields every other Sprint phase already reads — `PROFILE`, `RUN_MODE`, `AUTOPILOT`, `PLAN_APPROVAL`, `HOST` — and shapes its output from them, not from git presence or hardcoded host names.

Concrete behavior changes a reviewer can verify by reading the diff:

| Behavior | Before | After |
|---|---|---|
| Source of "non-technical user" signal | git absence | session `profile` field, with `guided` as the safe default when no session exists |
| Source of "what host can enforce" | hardcoded language tied to Claude paths | `adapters/<host>.json` for `bash_guard`, `write_guard`, `phase_gate` |
| `run_mode == report_only` handling | not honored (silently mutated) | `REPORT_ONLY` guard set immediately after the session read, before any mutation site; report-only writes nothing |
| Legacy `.claude/settings.json` | no detection path | recommends `bin/init-project.sh --repair`, refuses to run `--migrate-permissions` silently |
| Output prose | one shape regardless of profile | Guided uses the four-block skeleton (Result / How to try / What was checked / What remains, plus Spanish parity); Professional names exact files and capability levels; both shapes live in `start/references/onboarding-contract.md` |
| Final message | menu of three slash commands | one next action keyed on state |

## Four lint jobs lock the contract

| Job | What it asserts |
|---|---|
| `nano-run-session-first` | `start/SKILL.md` reads each of `PROFILE` / `RUN_MODE` / `AUTOPILOT` / `PLAN_APPROVAL` / `HOST` via jq AND references `reference/session-state-contract.md`. |
| `nano-run-report-only` | The `REPORT_ONLY` guard line in `start/SKILL.md` must appear **before** the first `init-stack.sh` / `init-project.sh` mention. A future edit that moves a mutation above the guard fails this check. |
| `nano-run-guided-output` | `start/references/onboarding-contract.md` declares all four English Guided block names (Result / How to try / What was checked / What remains) AND all four Spanish block names (Resultado / Como verlo / Que revise / Pendiente). `start/SKILL.md` points at the contract. |
| `nano-run-capability-honesty` | `start/SKILL.md` does NOT contain `always blocks`, `guaranteed blocks`, `all agents enforce`, or `hard-blocks on every agent`. The skill must reference `adapters/`. |

Lint matrix grew from 27 jobs to 31.

## Snag during build (worth flagging)

The first draft of `start/SKILL.md` inlined the forbidden-phrasing list (`"always blocks"`, etc.) as documentation of what the skill must not say. That triggered `nano-run-capability-honesty` against itself — same shape as the PR #156 self-grep on `/feature --manual`. Moved the enumeration to the contract doc only; the skill now points at the contract for the list. Pattern matches the plain-language banned-term lint, which scans fenced output blocks rather than the contract doc itself.

## Spec acceptance

```bash
rg -n 'PROFILE=.*session|RUN_MODE=.*session|REPORT_ONLY|adapters/|plain-language-contract' start/SKILL.md
```

Returns matches for every concept.

## Test plan

- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix, 32/32 think E2E, 32/32 examples contract.
- [x] All four new `nano-run-*` lint checks pass locally.
- [x] Workflow YAML parses (31 jobs).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.

## What does NOT change

- No new scripts. `bin/save-setup-artifact.sh` lands in PR 3.
- No legacy-detection runtime. PR 4 wires the actual detection logic.
- No E2E. PR 5 ships the 9-cell onboarding matrix.

The skill prose now references the setup-artifact write step as future work (PR 3), so this PR is reviewable as a self-contained product copy + session-state wire-up.