### PR TITLE
/nano-run vNext PR 3: setup artifact writer with schema enforcement

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,87 @@ on:
     branches: [main]
 
 jobs:
+  setup-artifact-schema:
+    name: Setup artifact writer enforces schema
+    runs-on: ubuntu-latest
+    # /nano-run vNext PR 3. The writer is the only thing that can
+    # reject a malformed setup payload before it reaches disk; if a
+    # required field gets dropped or an enum widens silently, the
+    # downstream contract for /nano-doctor and support breaks. This
+    # job exercises the writer with one valid payload, three invalid
+    # payloads, and the report_only invariant.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Writer roundtrip and rejection paths
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d /tmp/setup-ci.XXXXXX)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          SCRIPT=$GITHUB_WORKSPACE/bin/save-setup-artifact.sh
+
+          # 1. Valid payload writes both files and the spec acceptance jq passes.
+          PAYLOAD=$(jq -n '{
+            phase:"setup",
+            summary:{
+              status:"ready", profile:"guided", host:"codex",
+              run_mode:"normal", project_mode:"local",
+              capabilities:{bash_guard:"instructions_only", write_guard:"instructions_only", phase_gate:"instructions_only"},
+              configuration:{config_json:"created", stack_json:"created", project_settings:"not_applicable", gitignore:"not_applicable"},
+              recommended_first_run:{kind:"sandbox", command:"/think x", path:"examples/starter-todo", reason:"safe first run"}
+            },
+            context_checkpoint:{summary:"setup ok"}
+          }')
+          "$SCRIPT" "$PAYLOAD" >/dev/null
+          if ! jq -e '.phase=="setup" and .summary.status and .summary.profile and .summary.capabilities and .summary.recommended_first_run.command' .nanostack/setup/latest.json >/dev/null; then
+            echo "FAIL: spec acceptance jq did not pass on writer output"
+            fail=1
+          fi
+          if [ ! -f .nanostack/setup/latest.json ]; then
+            echo "FAIL: latest.json was not written"
+            fail=1
+          fi
+
+          # 2. Missing required field is rejected.
+          if "$SCRIPT" '{"phase":"setup","summary":{"status":"ready"},"context_checkpoint":{"summary":"x"}}' >/dev/null 2>&1; then
+            echo "FAIL: writer accepted a payload missing required fields"
+            fail=1
+          fi
+
+          # 3. Bad capability enum is rejected.
+          BAD=$(jq -n '{phase:"setup", summary:{status:"ready", profile:"guided", host:"codex", run_mode:"normal", project_mode:"local", capabilities:{bash_guard:"hooked", write_guard:"unknown", phase_gate:"unknown"}, configuration:{config_json:"exists", stack_json:"exists", project_settings:"exists", gitignore:"exists"}, recommended_first_run:{kind:"sandbox", command:"x"}}, context_checkpoint:{summary:"x"}}')
+          if "$SCRIPT" "$BAD" >/dev/null 2>&1; then
+            echo "FAIL: writer accepted a payload with capability='hooked' (not in enum)"
+            fail=1
+          fi
+
+          # 4. report_only with claimed file creation is rejected.
+          REPORT_LIE=$(jq -n '{phase:"setup", summary:{status:"report_only", profile:"guided", host:"codex", run_mode:"report_only", project_mode:"local", capabilities:{bash_guard:"unknown", write_guard:"unknown", phase_gate:"unknown"}, configuration:{config_json:"created", stack_json:"skipped_report_only", project_settings:"skipped_report_only", gitignore:"skipped_report_only"}, recommended_first_run:{kind:"report_only", command:"re-run"}}, context_checkpoint:{summary:"x"}}')
+          if "$SCRIPT" "$REPORT_LIE" >/dev/null 2>&1; then
+            echo "FAIL: writer accepted a report_only payload claiming a file was created"
+            fail=1
+          fi
+
+          # 5. report_only with honest skipped_report_only is accepted.
+          REPORT_OK=$(jq -n '{phase:"setup", summary:{status:"report_only", profile:"guided", host:"codex", run_mode:"report_only", project_mode:"local", capabilities:{bash_guard:"unknown", write_guard:"unknown", phase_gate:"unknown"}, configuration:{config_json:"skipped_report_only", stack_json:"skipped_report_only", project_settings:"skipped_report_only", gitignore:"skipped_report_only"}, recommended_first_run:{kind:"report_only", command:"re-run"}}, context_checkpoint:{summary:"x"}}')
+          if ! "$SCRIPT" --validate "$REPORT_OK" >/dev/null 2>&1; then
+            echo "FAIL: writer rejected a valid report_only payload"
+            fail=1
+          fi
+
+          exit $fail
+
+      - name: start/SKILL.md mentions the writer
+        run: |
+          set -e
+          if ! grep -qE 'save-setup-artifact\.sh|setup artifact' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must reference save-setup-artifact.sh or 'setup artifact'"
+            exit 1
+          fi
+
   nano-run-session-first:
     name: /nano-run reads session state
     runs-on: ubuntu-latest

--- a/bin/save-setup-artifact.sh
+++ b/bin/save-setup-artifact.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# save-setup-artifact.sh — Save the /nano-run setup artifact.
+#
+# Why a separate script: setup runs before any session exists and
+# before the canonical sprint phase machinery is wired. save-artifact.sh
+# auto-calls session.sh phase-complete and validates against the
+# sprint phase schema; setup is not a sprint phase. Keeping the two
+# writers separate avoids hacking sprint mechanics for first-run.
+#
+# Schema source of truth: reference/artifact-schema.md, "/nano-run
+# (setup)" section.
+#
+# Usage:
+#   save-setup-artifact.sh <json>                Validate and save
+#   save-setup-artifact.sh --validate <json>     Validate only, do not write
+#
+# Output paths (project-local store via store-path.sh):
+#   $NANOSTACK_STORE/setup/<UTC-timestamp>.json     versioned write
+#   $NANOSTACK_STORE/setup/latest.json              copy (no symlink, portability)
+#
+# Exit codes:
+#   0  saved (or validated when --validate)
+#   1  invalid JSON or missing required field
+#   2  io error (could not write store)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+[ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
+
+VALIDATE_ONLY=0
+if [ "${1:-}" = "--validate" ]; then
+  VALIDATE_ONLY=1
+  shift
+fi
+
+JSON="${1:-}"
+if [ -z "$JSON" ]; then
+  echo "Usage: save-setup-artifact.sh [--validate] <json>" >&2
+  exit 1
+fi
+
+# ─── Parse + validate ──────────────────────────────────────────────────
+# Required fields per reference/artifact-schema.md /nano-run (setup).
+# Each line is one jq path. Missing or empty values fail closed; the
+# spec calls report_only "honest about not having mutated" so the
+# script must not accept a payload that lies about what happened.
+
+REQUIRED_PATHS='
+.phase
+.summary.status
+.summary.profile
+.summary.host
+.summary.run_mode
+.summary.project_mode
+.summary.capabilities.bash_guard
+.summary.capabilities.write_guard
+.summary.capabilities.phase_gate
+.summary.configuration.config_json
+.summary.configuration.stack_json
+.summary.configuration.project_settings
+.summary.configuration.gitignore
+.summary.recommended_first_run.kind
+.summary.recommended_first_run.command
+.context_checkpoint.summary
+'
+
+if ! echo "$JSON" | jq -e . >/dev/null 2>&1; then
+  echo "ERROR: input is not valid JSON" >&2
+  exit 1
+fi
+
+PHASE=$(echo "$JSON" | jq -r '.phase // ""')
+if [ "$PHASE" != "setup" ]; then
+  echo "ERROR: phase must be 'setup', got '$PHASE'" >&2
+  exit 1
+fi
+
+# Loop the required paths. jq's `has` only walks one level, so we
+# evaluate each path with a small filter and fail when the result
+# is null OR empty string (both count as missing).
+fail=0
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  value=$(echo "$JSON" | jq -r "$path // empty")
+  if [ -z "$value" ] || [ "$value" = "null" ]; then
+    echo "ERROR: required field missing or empty: $path" >&2
+    fail=1
+  fi
+done <<EOF
+$REQUIRED_PATHS
+EOF
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+# Enum validation. Adapter values map to the L0-L3 honesty rule.
+# Five legal values; any other shape is a bug, not a new value.
+for cap in bash_guard write_guard phase_gate; do
+  v=$(echo "$JSON" | jq -r ".summary.capabilities.$cap // \"\"")
+  case "$v" in
+    enforced|reported|instructions_only|unsupported|unknown) ;;
+    *)
+      echo "ERROR: summary.capabilities.$cap must be one of enforced|reported|instructions_only|unsupported|unknown, got '$v'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Status enum.
+status=$(echo "$JSON" | jq -r '.summary.status')
+case "$status" in
+  ready|needs_repair|report_only|partial|blocked) ;;
+  *)
+    echo "ERROR: summary.status must be one of ready|needs_repair|report_only|partial|blocked, got '$status'" >&2
+    exit 1
+    ;;
+esac
+
+# report_only contract: configuration values must reflect that
+# nothing was written. A status=report_only payload that claims
+# files were created/updated is a lie and the writer rejects it.
+if [ "$status" = "report_only" ]; then
+  for cfg in config_json stack_json project_settings gitignore; do
+    v=$(echo "$JSON" | jq -r ".summary.configuration.$cfg")
+    case "$v" in
+      created|updated)
+        echo "ERROR: report_only artifact cannot claim configuration.$cfg='$v' — must be exists, skipped_report_only, not_applicable, or error" >&2
+        exit 1
+        ;;
+    esac
+  done
+fi
+
+if [ "$VALIDATE_ONLY" -eq 1 ]; then
+  echo "ok"
+  exit 0
+fi
+
+# ─── Write ─────────────────────────────────────────────────────────────
+
+OUT_DIR="$NANOSTACK_STORE/setup"
+mkdir -p "$OUT_DIR" || { echo "ERROR: cannot create $OUT_DIR" >&2; exit 2; }
+
+TS=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+TS_FILE="$OUT_DIR/${TS}.json"
+LATEST="$OUT_DIR/latest.json"
+
+# Inject timestamp + project at write time, the way save-artifact.sh
+# does for sprint phases. The skill writer can omit these.
+NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+PROJECT="$(pwd)"
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+ENRICHED=$(echo "$JSON" | jq \
+  --arg ts "$NOW_ISO" \
+  --arg project "$PROJECT" \
+  --arg branch "$BRANCH" \
+  '. + {
+     timestamp: (.timestamp // $ts),
+     project:   (.project   // $project),
+     branch:    (.branch    // (if $branch == "" then null else $branch end)),
+     schema_version: (.schema_version // "1")
+  }')
+
+if ! printf '%s\n' "$ENRICHED" > "$TS_FILE"; then
+  echo "ERROR: cannot write $TS_FILE" >&2
+  exit 2
+fi
+
+# latest.json is a copy, not a symlink. Some Windows / WSL setups
+# refuse symlinks across drives; the test suite runs on those too.
+if ! cp "$TS_FILE" "$LATEST"; then
+  echo "ERROR: cannot copy $TS_FILE to $LATEST" >&2
+  exit 2
+fi
+
+echo "$TS_FILE"

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -149,7 +149,13 @@ Save the preference in `.nanostack/config.json` under `preferences.workflow_mode
 
 ## Step 3: Write the setup record
 
-After mutation succeeded (or after detect-only in report mode), write a setup artifact at `.nanostack/setup/<timestamp>.json` with a `latest.json` copy. Schema is in [`reference/artifact-schema.md`](../reference/artifact-schema.md). PR 3 of the vNext spec ships `bin/save-setup-artifact.sh`; until then, write a minimally valid JSON in line per the required-fields list.
+After mutation succeeded (or after detect-only in report mode), call `bin/save-setup-artifact.sh` with the structured JSON payload. The writer validates required fields, enum values, and the report-only honesty invariant before anything reaches disk:
+
+```bash
+~/.claude/skills/nanostack/bin/save-setup-artifact.sh "$SETUP_JSON"
+```
+
+It writes `.nanostack/setup/<timestamp>.json` and copies it to `.nanostack/setup/latest.json` (no symlinks, for portability). Schema is in [`reference/artifact-schema.md`](../reference/artifact-schema.md).
 
 Required fields the writer rejects without:
 
@@ -159,6 +165,8 @@ Required fields the writer rejects without:
 - `summary.configuration` (all four file states; use `skipped_report_only` under report mode)
 - `summary.recommended_first_run.kind` and `.command`
 - `context_checkpoint.summary`
+
+The writer also enforces enums (`bash_guard` must be one of `enforced` / `reported` / `instructions_only` / `unsupported` / `unknown`) and the report-only honesty invariant (a `report_only` payload cannot claim `configuration.<file> = "created"` or `"updated"`; it must say `skipped_report_only`).
 
 If a mutation step failed midway, write `summary.status = "partial"`. Do not pretend setup completed.
 


### PR DESCRIPTION
## Summary

`bin/save-setup-artifact.sh` validates and writes the onboarding setup artifact. The writer is the only thing that can reject a malformed payload before it reaches disk; without it the schema lives only in documentation. Three classes of rejection and one honesty invariant make `summary.status` trustworthy downstream.

## What the writer does

| Step | Behavior |
|---|---|
| Parse | `jq -e .` on input. Non-JSON → exit 1. |
| Required-field check | Walks the 12 jq paths from the schema. Null and empty string both count as missing; lists every missing path in one pass. |
| Enum check | `summary.capabilities.{bash_guard, write_guard, phase_gate}` must be one of `enforced` / `reported` / `instructions_only` / `unsupported` / `unknown`. `summary.status` must be one of `ready` / `needs_repair` / `report_only` / `partial` / `blocked`. |
| **Honesty invariant** | A `summary.status = "report_only"` payload cannot claim `configuration.<file> = "created"` or `"updated"`. report-only must say `skipped_report_only` (or `exists` / `not_applicable` / `error`). The schema docs the claim; the writer enforces it. |
| Inject metadata | `timestamp`, `project`, `branch`, `schema_version` filled at write time if caller did not provide them. |
| Write | `$NANOSTACK_STORE/setup/<UTC-timestamp>.json` plus a copy at `setup/latest.json` (not a symlink, for Windows / WSL portability). |

## Why a separate script (and not an extension of save-artifact.sh)

Setup runs before any session exists and before sprint phase machinery is wired. `save-artifact.sh` auto-calls `session.sh phase-complete` and validates against the sprint phase schema; setup is not a sprint phase. Forcing setup through that path would couple two unrelated lifecycles. Two writers, one shape per use case.

## Side effects of writing

The writer adds these fields at write time when missing:

- `timestamp` — `now()` UTC.
- `project` — `pwd`.
- `branch` — `git branch --show-current` if a git repo is present.
- `schema_version` — `"1"`.

Caller can override any of these by passing them in the payload.

## Flags + exit codes

```bash
save-setup-artifact.sh <json>             # validate + write
save-setup-artifact.sh --validate <json>  # validate only, no write
```

| Code | Meaning |
|---|---|
| 0 | Saved (or validated under `--validate`). |
| 1 | Invalid JSON, missing required field, bad enum, or report_only lying about mutation. |
| 2 | I/O error: could not create `$NANOSTACK_STORE/setup/` or write the timestamped file. |

## CI lock

New `setup-artifact-schema` lint job runs five smoke paths against a fresh `/tmp` project on every PR:

1. Valid payload writes both files; spec acceptance `jq` query passes against `latest.json`.
2. Missing-field payload is rejected.
3. Bad-capability-enum (`bash_guard = "hooked"`) is rejected.
4. `report_only` payload claiming `config_json = "created"` is rejected.
5. Honest `report_only` payload (`skipped_report_only`) is accepted under `--validate`.

Plus a sub-check that `start/SKILL.md` actually mentions the writer by name. Lint matrix grew from 31 to 32 jobs.

## skill prose update

`start/SKILL.md` Step 3 now calls the script by name, lists the enum constraints, and names the honesty invariant. The previous wording said "PR 3 will ship the writer; until then, write a minimally valid JSON in line" — that's stale now.

## Test plan

- [x] `bash -n` clean on the new script.
- [x] Smoke roundtrip on a `/tmp` project: valid payload writes both files, spec acceptance jq passes.
- [x] Four rejection paths fail with specific error messages naming the bad field.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix, 32/32 think E2E, 32/32 examples contract.
- [x] Workflow YAML parses (32 jobs).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.

## What does NOT change

- No skill behavior change beyond Step 3 prose pointing at the new script.
- No legacy detection logic. PR 4 wires `summary.legacy.*` population.
- No E2E coverage. PR 5 ships the 9-cell onboarding matrix.