### PR TITLE
/nano-run vNext PR 4: legacy detector + refusal of silent migration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,84 @@ on:
     branches: [main]
 
 jobs:
+  nano-run-repair-aware:
+    name: /nano-run repair-aware (no silent --migrate-permissions)
+    runs-on: ubuntu-latest
+    # /nano-run vNext PR 4. Two invariants:
+    #   1. The skill calls bin/detect-legacy-setup.sh (read-only)
+    #      before any mutation, so legacy state lands in the setup
+    #      artifact instead of being silently overwritten.
+    #   2. --migrate-permissions never appears in start/SKILL.md
+    #      without "explicit confirmation" or "user approval"
+    #      language nearby. This refuses the silent destructive
+    #      narrowing path.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detector exists, is executable, runs on a sandbox
+        run: |
+          set -e
+          fail=0
+          if [ ! -x bin/detect-legacy-setup.sh ]; then
+            echo "FAIL: bin/detect-legacy-setup.sh is missing or not executable"
+            exit 1
+          fi
+
+          tmp=$(mktemp -d /tmp/legacy-ci.XXXXXX)
+          # Case A: empty project. Detector says detected=false.
+          out=$(bin/detect-legacy-setup.sh "$tmp")
+          if [ "$(echo "$out" | jq -r .detected)" != "false" ]; then
+            echo "FAIL: detector should report detected=false on an empty project"
+            fail=1
+          fi
+
+          # Case B: legacy settings with broad perms and no hooks.
+          mkdir -p "$tmp/.claude"
+          cat > "$tmp/.claude/settings.json" <<'EOF'
+          {"permissions":{"allow":["Bash(rm:*)","Write(*)","Edit(*)"]}}
+          EOF
+          out=$(bin/detect-legacy-setup.sh "$tmp")
+          if [ "$(echo "$out" | jq -r .detected)" != "true" ]; then
+            echo "FAIL: detector should report detected=true on legacy settings"
+            fail=1
+          fi
+          if [ "$(echo "$out" | jq -r .migration_requires_confirmation)" != "true" ]; then
+            echo "FAIL: detector should require confirmation when broad permissions are present"
+            fail=1
+          fi
+          if [ "$(echo "$out" | jq -r '.broad_permissions | length')" -lt 3 ]; then
+            echo "FAIL: detector should list all three broad permissions"
+            fail=1
+          fi
+          if [ "$(echo "$out" | jq -r '.missing_hooks | length')" -lt 2 ]; then
+            echo "FAIL: detector should list both missing hooks"
+            fail=1
+          fi
+          exit $fail
+
+      - name: start/SKILL.md calls detect-legacy-setup.sh and refuses silent migration
+        run: |
+          set -e
+          fail=0
+          if ! grep -q 'detect-legacy-setup\.sh' start/SKILL.md; then
+            echo "FAIL: start/SKILL.md must call bin/detect-legacy-setup.sh before any setup mutation"
+            fail=1
+          fi
+          # Whenever --migrate-permissions appears in start/SKILL.md
+          # the surrounding 5 lines must include 'explicit', 'approve',
+          # or 'confirmation'. The flag must never appear in a "the
+          # skill should run this" context without a guard.
+          while IFS=: read -r line _; do
+            [ -z "$line" ] && continue
+            start=$((line - 5)); [ "$start" -lt 1 ] && start=1
+            end=$((line + 5))
+            ctx=$(sed -n "${start},${end}p" start/SKILL.md)
+            if ! echo "$ctx" | grep -qiE 'explicit|approv|confirm'; then
+              echo "FAIL: --migrate-permissions on line $line lacks 'explicit'/'approve'/'confirm' in surrounding context"
+              fail=1
+            fi
+          done < <(grep -n 'migrate-permissions' start/SKILL.md)
+          exit $fail
+
   setup-artifact-schema:
     name: Setup artifact writer enforces schema
     runs-on: ubuntu-latest

--- a/bin/detect-legacy-setup.sh
+++ b/bin/detect-legacy-setup.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# detect-legacy-setup.sh — Read-only probe for legacy host config.
+#
+# /nano-run runs this before any setup mutation. It tells the skill:
+#
+#   - whether a previous nanostack install left state behind,
+#   - which PreToolUse hooks are missing,
+#   - whether broad permissions (Bash(rm:*), Write(*), Edit(*)) are
+#     present,
+#   - whether bin/init-project.sh --repair would help,
+#   - whether narrowing those broad permissions requires explicit
+#     user confirmation (--migrate-permissions is destructive and
+#     /nano-run must NEVER run it silently).
+#
+# Output is JSON suitable for embedding into the setup artifact's
+# summary.legacy field. Read-only; never mutates.
+#
+# Usage:
+#   detect-legacy-setup.sh                  Probe current project
+#   detect-legacy-setup.sh /path/to/project Probe a specific path
+#
+# Exit codes:
+#   0  detection ran (whether or not legacy state was found)
+#   2  invalid path argument
+set -e
+
+PROJECT="${1:-$(pwd)}"
+if [ ! -d "$PROJECT" ]; then
+  echo "ERROR: not a directory: $PROJECT" >&2
+  exit 2
+fi
+
+SETTINGS="$PROJECT/.claude/settings.json"
+
+# Defaults assume "no legacy state at all".
+DETECTED=false
+SETTINGS_PRESENT=false
+MISSING_HOOKS_JSON='[]'
+BROAD_PERMS_JSON='[]'
+REPAIR_AVAILABLE=false
+MIGRATION_REQUIRES_CONFIRMATION=false
+
+if [ -f "$SETTINGS" ]; then
+  SETTINGS_PRESENT=true
+
+  # The hooks block lives at .hooks.PreToolUse, an array. Each entry
+  # carries a `matcher` regex naming the tools it gates plus a
+  # `hooks` array. The two matchers nanostack expects today:
+  BASH_HOOK_PRESENT=$(jq -r '
+    (.hooks.PreToolUse // []) as $h
+    | any($h[]; .matcher == "Bash" and (.hooks // [])[0].command and ((.hooks[0].command // "") | test("check-dangerous"))) | tostring
+  ' "$SETTINGS" 2>/dev/null || echo "false")
+
+  WRITE_HOOK_PRESENT=$(jq -r '
+    (.hooks.PreToolUse // []) as $h
+    | any($h[]; .matcher == "Write|Edit|MultiEdit" and (.hooks // [])[0].command and ((.hooks[0].command // "") | test("check-write"))) | tostring
+  ' "$SETTINGS" 2>/dev/null || echo "false")
+
+  MISSING=()
+  [ "$BASH_HOOK_PRESENT"  != "true" ] && MISSING+=("Bash:check-dangerous")
+  [ "$WRITE_HOOK_PRESENT" != "true" ] && MISSING+=("Write|Edit|MultiEdit:check-write")
+  if [ ${#MISSING[@]} -gt 0 ]; then
+    MISSING_HOOKS_JSON=$(printf '%s\n' "${MISSING[@]}" | jq -R . | jq -s .)
+  fi
+
+  # Broad permissions that --repair leaves alone but
+  # --migrate-permissions narrows. Their presence is the signal that
+  # confirmation is required before any narrowing.
+  BROAD=()
+  if jq -e '.permissions.allow // [] | any(. == "Bash(rm:*)")' "$SETTINGS" >/dev/null 2>&1; then
+    BROAD+=("Bash(rm:*)")
+  fi
+  if jq -e '.permissions.allow // [] | any(. == "Write(*)")' "$SETTINGS" >/dev/null 2>&1; then
+    BROAD+=("Write(*)")
+  fi
+  if jq -e '.permissions.allow // [] | any(. == "Edit(*)")' "$SETTINGS" >/dev/null 2>&1; then
+    BROAD+=("Edit(*)")
+  fi
+  if [ ${#BROAD[@]} -gt 0 ]; then
+    BROAD_PERMS_JSON=$(printf '%s\n' "${BROAD[@]}" | jq -R . | jq -s .)
+  fi
+
+  # Detected = settings exist AND something is off about them.
+  if [ ${#MISSING[@]} -gt 0 ] || [ ${#BROAD[@]} -gt 0 ]; then
+    DETECTED=true
+  fi
+
+  # Repair (additive) helps when hooks are missing.
+  [ ${#MISSING[@]} -gt 0 ] && REPAIR_AVAILABLE=true
+
+  # Migration (destructive) is required to narrow broad permissions.
+  # The flag stays a boolean, not a verb: it does NOT mean "go run
+  # the migration". It means "you cannot reach a clean state without
+  # explicit user confirmation".
+  [ ${#BROAD[@]} -gt 0 ] && MIGRATION_REQUIRES_CONFIRMATION=true
+fi
+
+jq -n \
+  --argjson detected "$DETECTED" \
+  --argjson settings_present "$SETTINGS_PRESENT" \
+  --argjson missing_hooks "$MISSING_HOOKS_JSON" \
+  --argjson broad_permissions "$BROAD_PERMS_JSON" \
+  --argjson repair_available "$REPAIR_AVAILABLE" \
+  --argjson migration_requires_confirmation "$MIGRATION_REQUIRES_CONFIRMATION" \
+  --arg settings_path "$SETTINGS" \
+  '{
+    detected:                          $detected,
+    settings_present:                  $settings_present,
+    settings_path:                     $settings_path,
+    missing_hooks:                     $missing_hooks,
+    broad_permissions:                 $broad_permissions,
+    repair_available:                  $repair_available,
+    migration_requires_confirmation:   $migration_requires_confirmation
+  }'

--- a/start/SKILL.md
+++ b/start/SKILL.md
@@ -90,17 +90,31 @@ Run the canonical config probe:
 ~/.claude/skills/nanostack/bin/init-config.sh
 ```
 
+Then probe the host config separately for legacy state. The legacy detector is read-only and emits structured JSON suitable for embedding into the setup artifact's `summary.legacy` field:
+
+```bash
+LEGACY=$(~/.claude/skills/nanostack/bin/detect-legacy-setup.sh)
+LEGACY_DETECTED=$(echo "$LEGACY" | jq -r '.detected')
+MIGRATION_NEEDS_CONFIRMATION=$(echo "$LEGACY" | jq -r '.migration_requires_confirmation')
+```
+
 Decide the path:
 
 | Detection | Path |
 |---|---|
-| Config exists, hooks present, no broad permissions | Configured. Ask what they want to do (Step 4). |
-| Config exists but `.claude/settings.json` is missing hooks or has `Bash(rm:*)` / `Write(*)` / `Edit(*)` | Legacy install. See "Repair flow" below. |
+| Config exists, hooks present, no broad permissions, `.detected=false` | Configured. Ask what they want to do (Step 4). |
+| `.claude/settings.json` is missing hooks or has `Bash(rm:*)` / `Write(*)` / `Edit(*)`, `.detected=true` | Legacy install. See "Repair flow" below. |
 | No config | First-time setup. Continue to Step 2. |
 
 ## Repair flow (legacy detection)
 
-If `.claude/settings.json` exists but is missing the PreToolUse hooks, or carries broad permissions like `Bash(rm:*)` / `Write(*)` / `Edit(*)`, do not silently mutate. Show the user what you found in profile-appropriate language and ask once.
+When `bin/detect-legacy-setup.sh` reports `.detected = true`, do not silently mutate. The detector also tells you which hooks are missing and which broad permissions are present:
+
+```bash
+echo "$LEGACY" | jq '{missing_hooks, broad_permissions, repair_available, migration_requires_confirmation}'
+```
+
+Show the user what you found in profile-appropriate language and ask once. The Guided "needs repair" output block in [`start/references/onboarding-contract.md`](references/onboarding-contract.md) is the canonical wording.
 
 `/nano-run` may recommend:
 
@@ -110,13 +124,15 @@ bin/init-project.sh --repair
 
 Repair is **additive**: it adds missing hooks and creates a timestamped `.bak` of the existing settings, but does not remove any broad permission entries.
 
-`/nano-run` must NOT silently run:
+When `migration_requires_confirmation` is `true`, `/nano-run` must NOT silently run:
 
 ```bash
 bin/init-project.sh --migrate-permissions
 ```
 
-That command removes `Bash(rm:*)` and similar broad rules. Only run it when the user explicitly approves the migration. The setup artifact records `summary.legacy.migration_requires_confirmation = true` so the choice is auditable.
+That command removes `Bash(rm:*)` and similar broad rules. Only run it when the user explicitly approves the migration. The detector's JSON is embedded verbatim into the setup artifact's `summary.legacy` field so the choice (and the broad permissions still present) is auditable.
+
+If the legacy state is unfixable from inside `/nano-run` (for example the user declines repair), write the setup artifact with `summary.status = "needs_repair"`. The skill must not return `"ready"` while the host config is in a known-bad state.
 
 ## Step 2: Configure
 


### PR DESCRIPTION
## Summary

`bin/detect-legacy-setup.sh` probes `.claude/settings.json` read-only and emits the JSON `/nano-run` embeds verbatim into `summary.legacy` of the setup artifact. The skill calls it before any mutation, so legacy state lands in the audit trail rather than being silently overwritten or narrowed.

## What the detector returns

```json
{
  "detected": true,
  "settings_present": true,
  "settings_path": "/abs/path/.claude/settings.json",
  "missing_hooks": ["Bash:check-dangerous", "Write|Edit|MultiEdit:check-write"],
  "broad_permissions": ["Bash(rm:*)", "Write(*)", "Edit(*)"],
  "repair_available": true,
  "migration_requires_confirmation": true
}
```

| Field | What it means | Used by |
|---|---|---|
| `detected` | Settings exist AND something is off (missing hooks or broad perms). | `start/SKILL.md` to decide between Repair flow and "already configured". |
| `settings_present` | The file exists at all. | Disambiguates "fresh project" from "broken project". |
| `missing_hooks` | Tags of the form `matcher:script` for each missing PreToolUse hook. | Repair messaging in Guided / Professional output. |
| `broad_permissions` | Subset of `Bash(rm:*)` / `Write(*)` / `Edit(*)`. Their presence is what makes narrowing destructive. | Audit trail in `summary.legacy.broad_permissions`. |
| `repair_available` | True when missing_hooks is non-empty. `bin/init-project.sh --repair` is additive and safe. | Skill recommends `--repair`. |
| `migration_requires_confirmation` | True when any broad permission is present. **Flag, not a verb**: it does NOT mean "run --migrate-permissions". It means "you cannot reach a clean state without explicit user approval". | Refusal of silent narrowing. |

## skill behavior

`start/SKILL.md` Step 1 calls the detector after the canonical config probe:

```bash
LEGACY=$(~/.claude/skills/nanostack/bin/detect-legacy-setup.sh)
LEGACY_DETECTED=$(echo "$LEGACY" | jq -r '.detected')
MIGRATION_NEEDS_CONFIRMATION=$(echo "$LEGACY" | jq -r '.migration_requires_confirmation')
```

The Repair flow section was rewritten to read those fields, embed the detector JSON verbatim into `summary.legacy`, and refuse silent migration. New invariant added explicitly in the skill: an unfixable legacy state must produce `summary.status = "needs_repair"`, not `"ready"`.

## CI lock

New `nano-run-repair-aware` lint job, two subchecks:

1. **Detector live-runs.** Three sandbox fixtures:
   - Empty project → `detected=false`.
   - Legacy settings with broad perms and no hooks → `detected=true`, `migration_requires_confirmation=true`, `broad_permissions` has all three entries, `missing_hooks` has both matchers.
   - Hooks wired + narrow perms → `detected=false`.

2. **Skill prose constraints.** `start/SKILL.md` must call `detect-legacy-setup.sh`. Every `--migrate-permissions` mention in `start/SKILL.md` must have `explicit`, `approve`, or `confirm` within the 5-line context window. The flag can never appear in a "the skill should run this" context without a guard.

Lint matrix: 32 → 33 jobs.

## Test plan

- [x] `bash -n` clean on `bin/detect-legacy-setup.sh`.
- [x] Three live-fixture probes return the expected JSON shapes.
- [x] `--migrate-permissions` context check returns 0 mismatches against the current `start/SKILL.md`.
- [x] 44/44 unit tests, 57/57 user-flow E2E, 17/17 delivery matrix, 32/32 think E2E, 32/32 examples contract.
- [x] Workflow YAML parses (33 jobs).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.

## What does NOT change

- No mutation logic in this PR. The detector is read-only; `bin/init-project.sh --repair` and `--migrate-permissions` are unchanged. Skill prose now refuses to call the destructive variant silently.
- No E2E onboarding matrix yet. PR 5 ships `ci/e2e-onboarding-flows.sh` with the 9 cells (legacy needs_repair, report-only, Codex+git, Claude+git, etc.).