### PR TITLE
/think archetype lens routing + preset interaction

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1134,6 +1134,82 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-archetype-lens-routing:
+    name: /think archetype lens routing + preset interaction
+    runs-on: ubuntu-latest
+    # Guided Archetypes v1 PR 3. Three rules to lock at lint time:
+    #   1. Explicit --preset wins over the archetype's default lens.
+    #   2. The archetype -> internal lens table is documented in
+    #      think/SKILL.md so the runtime can read it without
+    #      re-deriving rules from prose.
+    #   3. Guided fenced output blocks for each archetype (in
+    #      think/references/archetypes.md) do NOT contain "preset",
+    #      "archetype", or "mode" — the three archetype-specific
+    #      banned terms on top of the plain-language contract bans.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Preset section names explicit-preset-wins rule
+        run: |
+          set -e
+          # Loose grep: any phrasing is fine as long as the rule is
+          # named in the user-facing surface. Common phrasings:
+          # "Explicit --preset always wins", "explicit preset wins",
+          # "--preset always wins".
+          if ! grep -qE 'Explicit `?--preset`?[^\\n]*wins|explicit (--)?preset.*wins' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md must state that explicit --preset wins over the archetype's lens"
+            exit 1
+          fi
+
+      - name: Per-archetype lens map present in think/SKILL.md
+        run: |
+          set -e
+          fail=0
+          # Loose grep: each canonical archetype must appear in the
+          # Preset Selection section (where the lens table lives).
+          # The exact wording can change; the names cannot drift.
+          for arch in founder_validation cli_tooling api_backend landing_experience; do
+            if ! grep -q "$arch" think/SKILL.md; then
+              echo "FAIL: think/SKILL.md missing archetype lens entry: $arch"
+              fail=1
+            fi
+          done
+          # Each archetype's default lens name must appear too.
+          for lens in yc devex eng design; do
+            if ! grep -q "\`$lens\`" think/SKILL.md; then
+              echo "FAIL: think/SKILL.md missing internal lens reference: $lens"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Guided fenced blocks in archetypes.md pass banned-term grep
+        run: |
+          set -e
+          fail=0
+          # Plain-language banned terms PLUS the three archetype-
+          # specific words (archetype, preset, mode). Patterns use
+          # word boundaries so "diff" does not match "different".
+          patterns='\bartifact\b|\bartifacts\b|\bPR\b|\bPRs\b|\bCI\b|\bbranch\b|\bbranches\b|\bdiff\b|\bdiffs\b|\bhook\b|\bhooks\b|\bphase\b|\bphases\b|\bsecurity audit\b|\bQA\b|\bscope drift\b|\barchetype\b|\bpreset\b|\bmode\b'
+          blocks=$(awk '
+            /<!-- guided-output:start -->/ { capture=1; buf=""; next }
+            /<!-- guided-output:end -->/   { if (capture) { print buf; buf="" } capture=0; next }
+            capture { buf = buf " " $0 }
+          ' think/references/archetypes.md)
+          if [ -z "$blocks" ]; then
+            echo "FAIL: archetypes.md must contain at least one <!-- guided-output --> example block"
+            exit 1
+          fi
+          while IFS= read -r block; do
+            [ -z "$block" ] && continue
+            hit=$(echo "$block" | grep -i -oE "$patterns" || true)
+            if [ -n "$hit" ]; then
+              echo "FAIL: archetypes.md guided block contains banned term(s): $(echo "$hit" | sort -u | tr '\n' ' ')"
+              echo "      block: $block"
+              fail=1
+            fi
+          done < <(printf '%s\n' "$blocks")
+          exit $fail
+
   think-archetype-aliases:
     name: /think archetypes alias map present
     runs-on: ubuntu-latest

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -98,9 +98,25 @@ Check the user's invocation for a `--preset` flag. Six presets exist today:
 
 Parsing rules:
 
-- `/think --preset=eng "idea"` or `/think --preset eng "idea"` → preset is `eng`.
-- `/think "idea"` (no flag) → preset is `default`.
+- `/think --preset=eng "idea"` or `/think --preset eng "idea"` → preset is `eng`. **Explicit `--preset` always wins**, regardless of archetype.
+- `/think "idea"` (no `--preset`) → the preset is selected by the archetype's internal lens (Guided Archetypes v1, see below). Falls back to `default` only when archetype is `unknown`.
 - Unknown value → tell the user `Unknown preset '<name>'. Valid: default, yc, garry, eng, design, devex. Running with default.` and proceed with `default`.
+
+Archetype → internal lens map when no `--preset` was provided:
+
+| Archetype | Internal lens |
+|---|---|
+| `founder_validation` | `yc` (Professional) or `garry` (also Professional). In Guided profile, soften further: keep the narrowest-wedge / target-user emphasis but drop the YC delivery edge. |
+| `cli_tooling` | `devex` |
+| `api_backend` | `eng` |
+| `landing_experience` | `design` |
+| `unknown` | `default` |
+
+Worked examples:
+
+- `/think --preset=eng "rewrite the hero copy"` with `archetype=landing_experience` → preset stays `eng`. The explicit flag wins over the archetype's design lens.
+- `/think "add a /version endpoint"` with detected `archetype=api_backend` → preset becomes `eng` automatically. The user did not specify a preset; the archetype provides the internal lens.
+- `/think "validate this idea"` with detected `archetype=founder_validation` and `PROFILE=guided` → preset is the YC lens softened by Guided wording. The first screen does not contain `preset`, `archetype`, or `mode`; it just says `Voy a empezar preguntando quien necesita esto hoy.`
 
 Load the preset internally and show the user only a short headline — the kind of message they actually need ("Preset: eng. I'll pressure-test architecture, failure modes, rollback and tests."). Do NOT dump the preset file to the conversation. The preset markdown is internal voice instruction, not user-facing content; printing it floods the first screen with rules the user did not ask for.
 

--- a/think/references/archetypes.md
+++ b/think/references/archetypes.md
@@ -283,6 +283,90 @@ The Guided first screen names what `/think` will do in plain language. It never 
 
 `always blocks`, `guaranteed blocks`, `all agents enforce`, `hard-blocks on every agent` (per `start/SKILL.md`'s capability-honesty rule). Archetypes do not override capability honesty.
 
+### Canonical Guided output per archetype
+
+Each archetype's Guided four-block output. Copy these shapes verbatim except for the variable parts. Lint scans inside the fences to verify no banned term leaks.
+
+#### founder_validation (Spanish)
+
+<!-- guided-output:start -->
+```
+Resultado: Vale la pena probar una version mas chica antes de construir todo.
+
+Como verlo:
+1. Cuando me digas "dale", lo convierto en un plan concreto.
+
+Que revise:
+- Hay un usuario claro.
+- La primera version puede probarse sin cuentas, pagos ni integraciones.
+- El mayor riesgo es que estemos resolviendo el sintoma equivocado.
+
+Pendiente:
+- No validamos todavia si mas personas tienen este dolor.
+- No medimos retencion ni conversion.
+```
+<!-- guided-output:end -->
+
+#### cli_tooling
+
+<!-- guided-output:start -->
+```
+Result: The feature is small enough if it stays to one command and preserves the existing file format.
+
+How to try:
+1. Run the current command first, then run the new command after the change.
+
+What was checked:
+- The command shape is clear.
+- Existing behavior has to keep working.
+- The main risk is corrupting local data.
+
+What remains:
+- I have not tested the command yet.
+- Windows shell behavior may need a separate check.
+```
+<!-- guided-output:end -->
+
+#### api_backend
+
+<!-- guided-output:start -->
+```
+Result: The safest first version is one endpoint with a real request check.
+
+How to try:
+1. Start the server and call the endpoint with curl.
+
+What was checked:
+- The response shape is clear.
+- Existing status codes must keep working.
+- Logging and headers are the main safety risks.
+
+What remains:
+- I have not load-tested it.
+- I have not checked production deployment settings.
+```
+<!-- guided-output:end -->
+
+#### landing_experience (Spanish)
+
+<!-- guided-output:start -->
+```
+Resultado: Primero conviene aclarar el mensaje, no agregar mas secciones.
+
+Como verlo:
+1. Abrir la pagina y leer el hero como si fueras un visitante nuevo.
+
+Que revise:
+- El visitante tiene que entender el producto en cinco segundos.
+- La accion principal tiene que ser obvia.
+- No hace falta agregar scripts ni trackers para esta prueba.
+
+Pendiente:
+- No medimos conversion real.
+- No probamos con usuarios externos.
+```
+<!-- guided-output:end -->
+
 ## Artifact Fields
 
 The five archetype fields the `/think` artifact may include in `summary`:


### PR DESCRIPTION
## Summary

Wires the archetype's default internal lens into the existing Preset Selection section so the runtime can resolve "which voice should I use?" without re-deriving rules from prose.

## Three concrete behavior changes

| Change | Where | Effect |
|---|---|---|
| Parsing rules distinguish "no `--preset`" from "no lens at all" | Preset Selection table in `think/SKILL.md` | Explicit `--preset` wins. Without `--preset`, the archetype's internal lens takes over (`founder_validation` → `yc`/`garry` softened by Guided, `cli_tooling` → `devex`, `api_backend` → `eng`, `landing_experience` → `design`, `unknown` → `default`). |
| New "Worked examples" block | Preset Selection section | Three real cases named end-to-end: explicit-flag wins over archetype, no-flag archetype routes to lens, Guided + founder_validation softens YC and never leaks `preset`/`archetype`/`mode`. |
| Four canonical Guided fenced output blocks (one per archetype, two in Spanish) | `think/references/archetypes.md` | Runtime contract for what each archetype's first screen looks like. Lint scans these blocks. |

## Three new lint subchecks (`think-archetype-lens-routing`)

1. `think/SKILL.md` states the explicit-preset-wins rule. Loose grep on common phrasings.
2. `think/SKILL.md` mentions every canonical archetype name AND every internal lens name (`yc`, `devex`, `eng`, `design`). A future edit that drops one fails this check.
3. `archetypes.md` has at least one fenced `<!-- guided-output -->` block AND every fenced block passes the extended banned-term grep — the 10 plain-language banned terms plus the three archetype-specific words (`archetype`, `preset`, `mode`).

Lint matrix grew from 37 to 38 jobs.

## Test plan

- [x] All 7 suites green: 44/44 + 57/57 + 17/17 + 32/32 + 34/34 + 32/32 + 40/40.
- [x] Three new lens-routing subchecks pass locally: 4 fenced blocks scanned, 0 banned-term hits, every archetype + lens name resolves.
- [x] Em-dashes added by this PR: 0.
- [x] Workflow YAML parses (38 jobs).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.

## What does NOT change

- No artifact-save edits. PR 4 still owns adding archetype to `THINK_JSON`.
- No detection scoring rewrites; PR 2's deterministic scoring feeds this lens routing.
- No new examples. Same four archetypes, same four source sandboxes.
- No runtime scripts.