### PR TITLE
/think archetype fields in the artifact save block

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1134,6 +1134,137 @@ jobs:
           echo "$out" | jq -e '.session_profile == "guided"' >/dev/null || { echo "FAIL: doctor must propagate session.profile"; fail=1; }
           exit $fail
 
+  think-archetype-schema:
+    name: /think archetype fields land in the artifact
+    runs-on: ubuntu-latest
+    # Guided Archetypes v1 PR 4. The artifact is the only durable
+    # signal a downstream skill (or analytics, or support) gets
+    # about what archetype shaped this sprint. Three things must
+    # line up:
+    #   1. The schema doc declares the fields (PR 1).
+    #   2. The skill's THINK_JSON build site emits them (this PR).
+    #   3. A live save+read roundtrip on a sandbox preserves the
+    #      five archetype fields without breaking the brief gate.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Field names appear across schema, skill, and contract docs
+        run: |
+          set -e
+          fail=0
+          for path in reference/artifact-schema.md think/SKILL.md think/references/archetypes.md; do
+            for field in archetype archetype_confidence archetype_source example_reference; do
+              if ! grep -q "$field" "$path"; then
+                echo "FAIL: $path missing field name: $field"
+                fail=1
+              fi
+            done
+          done
+          exit $fail
+
+      - name: THINK_JSON build site assigns each archetype field
+        run: |
+          set -e
+          fail=0
+          # The Phase 6 jq -n block must declare every archetype
+          # field as a key in summary. Loose grep on each colon-form
+          # the existing block uses.
+          for field in archetype archetype_confidence archetype_source archetype_reason example_reference; do
+            if ! grep -qE "${field}:[[:space:]]+\\\$${field}" think/SKILL.md; then
+              echo "FAIL: think/SKILL.md THINK_JSON does not assign summary.$field"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Live save+read roundtrip with archetype + example_reference
+        run: |
+          set -e
+          fail=0
+          tmp=$(mktemp -d /tmp/arch-ci.XXXXXX)
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+
+          # Two payloads cover the full envelope: detected high-
+          # confidence + example, and the unknown/fallback case.
+          api_payload=$(jq -n '{
+            phase:"think",
+            summary:{
+              value_proposition:"Add /version endpoint",
+              scope_mode:"reduce", target_user:"backend dev",
+              narrowest_wedge:"GET /version", key_risk:"could break /health",
+              premise_validated:true, out_of_scope:[], manual_delivery_test:{possible:true,steps:[]},
+              search_summary:{mode:"local_only",result:"",existing_solution:"none"},
+              archetype:"api_backend", archetype_confidence:"high",
+              archetype_source:"detected_from_files",
+              archetype_reason:"Project has server.js.",
+              example_reference:{name:"api-healthcheck",path:"examples/api-healthcheck",why_relevant:"backend sandbox"}
+            },
+            context_checkpoint:{summary:"x"}
+          }')
+          $GITHUB_WORKSPACE/bin/save-artifact.sh think "$api_payload" >/dev/null
+
+          # Spec acceptance jq.
+          if ! jq -e '.summary.archetype == "api_backend" and .summary.archetype_confidence == "high" and .summary.archetype_source == "detected_from_files" and .summary.example_reference.path == "examples/api-healthcheck"' .nanostack/think/*.json >/dev/null; then
+            echo "FAIL: api_backend artifact did not preserve all archetype fields"
+            fail=1
+          fi
+
+          # Brief gate must still pass on the same artifact, with no
+          # archetype-aware filter. Same five fields the existing
+          # gate checks. A v1 reader without archetype knowledge
+          # must still see the artifact as complete.
+          gate=$(jq -r '
+            (.summary.value_proposition // "") != "" and
+            (.summary.target_user        // "") != "" and
+            (.summary.narrowest_wedge    // "") != "" and
+            (.summary.key_risk           // "") != "" and
+            ((.summary.premise_validated | type) == "boolean")
+          ' .nanostack/think/*.json)
+          if [ "$gate" != "true" ]; then
+            echo "FAIL: brief gate filter rejected an archetype-aware artifact"
+            fail=1
+          fi
+
+          # Reset and try the unknown/fallback envelope.
+          rm .nanostack/think/*.json
+          unknown_payload=$(jq -n '{
+            phase:"think",
+            summary:{
+              value_proposition:"Generic feature ask",
+              scope_mode:"reduce", target_user:"any",
+              narrowest_wedge:"smallest version", key_risk:"premise unclear",
+              premise_validated:false, out_of_scope:[], manual_delivery_test:{possible:false,steps:[]},
+              search_summary:{mode:"local_only",result:"",existing_solution:"none"},
+              archetype:"unknown", archetype_confidence:"low",
+              archetype_source:"fallback", archetype_reason:"",
+              example_reference:null
+            },
+            context_checkpoint:{summary:"x"}
+          }')
+          $GITHUB_WORKSPACE/bin/save-artifact.sh think "$unknown_payload" >/dev/null
+
+          if ! jq -e '.summary.archetype == "unknown" and .summary.archetype_source == "fallback" and .summary.example_reference == null' .nanostack/think/*.json >/dev/null; then
+            echo "FAIL: unknown archetype artifact did not preserve fallback fields"
+            fail=1
+          fi
+          # Brief gate still passes with archetype=unknown and
+          # premise_validated=false (PR #173 fix held).
+          gate=$(jq -r '
+            (.summary.value_proposition // "") != "" and
+            (.summary.target_user        // "") != "" and
+            (.summary.narrowest_wedge    // "") != "" and
+            (.summary.key_risk           // "") != "" and
+            ((.summary.premise_validated | type) == "boolean")
+          ' .nanostack/think/*.json)
+          if [ "$gate" != "true" ]; then
+            echo "FAIL: brief gate filter rejected unknown/false-premise artifact (PR #173 regression)"
+            fail=1
+          fi
+
+          exit $fail
+
   think-archetype-lens-routing:
     name: /think archetype lens routing + preset interaction
     runs-on: ubuntu-latest

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -526,6 +526,11 @@ Build the JSON inline and pass it to `save-artifact.sh`. Required fields (the au
 Use `jq -n` so the output is real JSON, not a string with embedded quotes:
 
 ```bash
+# Archetype fields. Set archetype="unknown" + archetype_source="fallback"
+# when no archetype was used; the brief gate does not consult these
+# fields so the artifact is always backward-compatible with v1
+# /think readers. example_reference is null when archetype is
+# "unknown".
 THINK_JSON=$(jq -n \
   --arg value_proposition "..."   \
   --arg scope_mode        "..."   \
@@ -536,6 +541,11 @@ THINK_JSON=$(jq -n \
   --argjson out_of_scope          '[]' \
   --argjson manual_delivery_test  '{"possible": false, "steps": []}' \
   --argjson search_summary        '{"mode": "local_only", "result": "", "existing_solution": "none"}' \
+  --arg archetype                 "unknown" \
+  --arg archetype_confidence      "low" \
+  --arg archetype_source          "fallback" \
+  --arg archetype_reason          "" \
+  --argjson example_reference     'null' \
   --argjson context_checkpoint    '{"summary":"", "key_files":[], "decisions_made":[], "open_questions":[]}' \
   '{
      phase: "think",
@@ -548,12 +558,41 @@ THINK_JSON=$(jq -n \
        premise_validated: $premise_validated,
        out_of_scope:      $out_of_scope,
        manual_delivery_test: $manual_delivery_test,
-       search_summary:    $search_summary
+       search_summary:    $search_summary,
+       archetype:            $archetype,
+       archetype_confidence: $archetype_confidence,
+       archetype_source:     $archetype_source,
+       archetype_reason:     $archetype_reason,
+       example_reference:    $example_reference
      },
      context_checkpoint: $context_checkpoint
    }')
 
 ~/.claude/skills/nanostack/bin/save-artifact.sh think "$THINK_JSON"
+```
+
+When an archetype WAS detected or set explicitly, replace the five default values with the actual ones:
+
+| Source | `archetype_source` | `archetype_confidence` |
+|---|---|---|
+| `--archetype` / `--type` flag | `explicit_flag` | `user_selected` |
+| User answered the one-question classifier | `user_answer` | `user_selected` |
+| Current path matches `examples/<archetype>` | `detected_from_files` | `high` |
+| Strong project-file signal | `detected_from_files` | `high` or `medium` |
+| Prompt keyword score | `detected_from_prompt` | `medium` or `low` |
+| `session.archetype` field | `session` | `user_selected` |
+| No signal hit threshold | `fallback` | `low` |
+
+`archetype_reason` is one short sentence the user could read: e.g. `"Current project has server.js and the prompt references an endpoint."` Empty string is acceptable for the `unknown`/`fallback` case.
+
+`example_reference` is `null` when archetype is `unknown`. Otherwise it is the object documented in `think/references/archetypes.md` for that archetype:
+
+```json
+{
+  "name": "starter-todo|cli-notes|api-healthcheck|static-landing",
+  "path": "examples/<example>",
+  "why_relevant": "string"
+}
 ```
 
 This is the first thing you do after the summary. Not optional. Not "Step 2". The summary and the save are one action. After this:


### PR DESCRIPTION
## Summary

Phase 6 of `think/SKILL.md` now writes the five archetype fields the schema doc (PR 1) declared optional. The brief gate filter is unchanged: an artifact with `archetype="unknown"` still passes, and an artifact with `archetype="api_backend"` passes the same filter. v1 readers without archetype awareness see the artifact as complete.

## Concrete behavior changes a reviewer can verify by reading the diff

| Change | Effect |
|---|---|
| New `--arg archetype`, `--arg archetype_confidence`, `--arg archetype_source`, `--arg archetype_reason`, `--argjson example_reference` in the `jq -n` build | Five optional fields land in `summary` of every saved think artifact. |
| Defaults emit `archetype="unknown"` + `archetype_source="fallback"` + `example_reference=null` when no detection signal fired | Backward-compatible: the artifact always has the five v1 required fields, plus five optional new ones. |
| New "Source → archetype_source / archetype_confidence" table | Seven rows, one per priority level the detection algorithm uses. The skill knows exactly which pair to write based on which signal won. |
| `example_reference` shape documented inline | name (one of `starter-todo` / `cli-notes` / `api-healthcheck` / `static-landing`), path under `examples/`, `why_relevant` one-sentence justification. |

## New `think-archetype-schema` lint job

Three subchecks:

1. The four canonical field names appear in `reference/artifact-schema.md` (PR 1 placed them), `think/SKILL.md` (this PR places them at the build site), and `think/references/archetypes.md` (PR 1 placed them in the Artifact Fields table).
2. The `THINK_JSON` jq block assigns each archetype field as a key in `summary` (pattern `<field>: $<field>`). Future edits that drop one fail this check.
3. **Live save+read roundtrip** on a sandbox: write an `api_backend` payload with full `example_reference`, confirm the spec acceptance jq passes against the saved artifact, confirm the brief gate filter still returns true. Reset, write an `unknown`/`fallback` payload with `premise_validated=false`, confirm fields preserve and the brief gate filter still returns true (the PR #173 fix has not regressed).

Lint matrix grew from 38 to 39 jobs.

## Spec acceptance

```bash
jq -e '.summary.archetype and .summary.archetype_confidence and .summary.archetype_source' "$THINK_ARTIFACT"
```

Returns `true` on every artifact written by the new build site.

## Test plan

- [x] All 7 suites green: 44/44 + 57/57 + 17/17 + 32/32 + 34/34 + 32/32 + 40/40.
- [x] Three live-fixture roundtrips pass locally on a sandbox `/tmp` project: high-confidence api_backend with example_reference, unknown/fallback with premise_validated=false, brief gate filter unchanged in both cases.
- [x] Field names and assignment patterns grep clean across the three doc/skill files.
- [x] Em-dashes added: 0.
- [x] Workflow YAML parses (39 jobs).
- [x] `git diff --check` clean.
- [ ] CI lint matrix green on push.

## What does NOT change

- Brief gate jq filter unchanged. The five required fields stay required; archetype is optional.
- No detection scoring or alias-map edits (PR 2 owns those).
- No lens routing edits (PR 3 owns those).
- No new examples or runtime scripts.

## What's left

PR 5 ships `ci/e2e-think-archetypes.sh` with the 9-cell matrix from the spec. After this PR the artifact contract is complete; PR 5 exercises the runtime contract end-to-end across all four archetypes plus the explicit-override, ambiguous-Guided, ambiguous-Professional, report-only, and autopilot-low-confidence cells.