### PR TITLE
/think flow fixes: canonical sprint order, /qa in early guide, mode-aware diagnostic, deterministic founder lens

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2173,3 +2173,125 @@ jobs:
             done < <(printf '%s\n' "$blocks")
           done
           exit $fail
+
+  think-sprint-order-canonical:
+    name: /think autopilot + sprint guide use canonical order
+    runs-on: ubuntu-latest
+    # The canonical post-build order is /review -> /security -> /qa -> /ship.
+    # A retest caught think/SKILL.md emitting /review, /qa, /security, /ship
+    # in the autopilot announcement; that contradicts the README, the new-user
+    # sprint guide, and downstream skills. Lock the order so it cannot drift
+    # again.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Autopilot announcement uses canonical order
+        run: |
+          set -e
+          if ! grep -nF '/review, /security, /qa, /ship' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md autopilot announcement does not use canonical /review, /security, /qa, /ship order"
+            exit 1
+          fi
+          if grep -nF '/review, /qa, /security, /ship' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md still emits the wrong /review, /qa, /security, /ship order"
+            exit 1
+          fi
+      - name: New-user sprint guide lists /review then /security then /qa then /ship
+        run: |
+          set -e
+          # Pull the fenced quoted block that starts with "Here's the full sprint:"
+          # and stops at the first blank quote line. Then assert the four steps
+          # appear in canonical order.
+          guide=$(awk '
+            /Here.s the full sprint:/ { capture=1 }
+            capture { print }
+            capture && /Or say.*--autopilot/ { print; capture=0 }
+          ' think/SKILL.md)
+          if [ -z "$guide" ]; then
+            echo "FAIL: could not locate the new-user sprint guide block in think/SKILL.md"
+            exit 1
+          fi
+          review_line=$(echo "$guide" | grep -nF '/review' | head -1 | cut -d: -f1)
+          security_line=$(echo "$guide" | grep -nF '/security' | head -1 | cut -d: -f1)
+          qa_line=$(echo "$guide" | grep -nF '/qa' | head -1 | cut -d: -f1)
+          ship_line=$(echo "$guide" | grep -nF '/ship' | head -1 | cut -d: -f1)
+          for var in review_line security_line qa_line ship_line; do
+            eval "val=\$$var"
+            if [ -z "$val" ]; then
+              echo "FAIL: sprint guide missing step ($var)"
+              echo "$guide"
+              exit 1
+            fi
+          done
+          if [ "$review_line" -lt "$security_line" ] && \
+             [ "$security_line" -lt "$qa_line" ] && \
+             [ "$qa_line" -lt "$ship_line" ]; then
+            exit 0
+          fi
+          echo "FAIL: sprint guide order is not /review -> /security -> /qa -> /ship"
+          echo "lines: review=$review_line security=$security_line qa=$qa_line ship=$ship_line"
+          echo "$guide"
+          exit 1
+
+  think-early-guide-includes-qa:
+    name: /think early-sprint guide includes /qa
+    runs-on: ubuntu-latest
+    # The new-user sprint guide is the first place a non-technical user
+    # learns what the workflow does. Dropping /qa removes the "open the app
+    # like a real user" step that is exactly the value for non-technical
+    # users. This job blocks that regression.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sprint guide block names /qa explicitly
+        run: |
+          set -e
+          guide=$(awk '
+            /Here.s the full sprint:/ { capture=1 }
+            capture { print }
+            capture && /Or say.*--autopilot/ { print; capture=0 }
+          ' think/SKILL.md)
+          if [ -z "$guide" ]; then
+            echo "FAIL: could not locate the new-user sprint guide block in think/SKILL.md"
+            exit 1
+          fi
+          if ! echo "$guide" | grep -qF '/qa'; then
+            echo "FAIL: new-user sprint guide does not list /qa"
+            echo "$guide"
+            exit 1
+          fi
+
+  think-builder-archetypes-do-not-force-startup:
+    name: /think Builder archetypes are not forced into Startup mode
+    runs-on: ubuntu-latest
+    # archetypes.md maps cli_tooling and api_backend to Builder mode. The
+    # Phase 2 instruction "Always cover the Startup Mode forcing-question
+    # set" contradicts that mapping and pushes Builder users through
+    # founder-style questions. Lock the wording so it stays mode-aware.
+    steps:
+      - uses: actions/checkout@v4
+      - name: think/SKILL.md does not force Startup forcing questions on every archetype
+        run: |
+          set -e
+          # The exact phrase that triggered the regression. Block any
+          # variation that says "always" + "Startup Mode" + "forcing".
+          if grep -niE 'always cover the startup mode forcing' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md still forces Startup forcing questions on every archetype"
+            exit 1
+          fi
+          # Positive check: the Phase 2 paragraph mentions Builder explicitly,
+          # so non-technical readers and Codex retest both see the mode is
+          # archetype-driven.
+          if ! grep -nE 'Builder forcing questions for .*cli_tooling.*api_backend|Builder forcing questions for .*api_backend.*cli_tooling' think/SKILL.md; then
+            echo "FAIL: Phase 2 paragraph does not mention Builder forcing questions for cli_tooling and api_backend"
+            exit 1
+          fi
+          # Cross-check: archetypes.md still maps cli_tooling and api_backend
+          # to Builder. If that source of truth changes, this lint becomes
+          # stale and should be updated alongside it.
+          if ! grep -nE '\| .cli_tooling. \| Builder \|' think/references/archetypes.md; then
+            echo "FAIL: archetypes.md no longer maps cli_tooling to Builder; update this lint or the spec"
+            exit 1
+          fi
+          if ! grep -nE '\| .api_backend. \| Builder \|' think/references/archetypes.md; then
+            echo "FAIL: archetypes.md no longer maps api_backend to Builder; update this lint or the spec"
+            exit 1
+          fi

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -106,7 +106,7 @@ Archetype → internal lens map when no `--preset` was provided:
 
 | Archetype | Internal lens |
 |---|---|
-| `founder_validation` | `yc` (Professional) or `garry` (also Professional). In Guided profile, soften further: keep the narrowest-wedge / target-user emphasis but drop the YC delivery edge. |
+| `founder_validation` | `yc` by default. `garry` only when the user explicitly passes `--preset=garry` (which the explicit-flag rule above already routes). In Guided profile, soften further: keep the narrowest-wedge / target-user emphasis but drop the YC delivery edge. |
 | `cli_tooling` | `devex` |
 | `api_backend` | `eng` |
 | `landing_experience` | `design` |
@@ -441,7 +441,7 @@ Whatever mode you used, write the result to `summary.search_summary` in the stru
 
 ### Phase 2: The Diagnostic
 
-**Apply the archetype lens to the opening question and the diagnostic emphasis** (see lens definitions in `think/references/archetypes.md`). The archetype selects and reorders the forcing questions, it does not replace them. Always cover the Startup Mode forcing-question set; the lens decides which one opens the conversation and which risks get extra airtime.
+**Apply the archetype lens to the opening question and the diagnostic emphasis** (see lens definitions in `think/references/archetypes.md`). The archetype selects and reorders the forcing questions, it does not replace them. Cover the **active mode's** diagnostic set: Startup forcing questions for `founder_validation` and `landing_experience`; Builder forcing questions for `cli_tooling` and `api_backend`. The archetype→mode mapping lives in `think/references/archetypes.md` ("Mode interaction"). The lens decides which question opens the conversation and which risks get extra airtime.
 
 | Archetype | Primary opening question | Diagnostic emphasis |
 |---|---|---|
@@ -649,7 +649,7 @@ When `RUN_MODE=report_only`, skip the gate entirely. The brief is saved as the r
 
 **If `--autopilot` was used** (or the user said "autopilot", "run everything", "ship it end to end") AND the Brief Gate passed:
 
-> Autopilot active. Proceeding with the full sprint: /nano, build, /review, /qa, /security, /ship. I'll only stop for blocking issues or product questions I can't answer.
+> Autopilot active. Proceeding with the full sprint: /nano, build, /review, /security, /qa, /ship. I'll only stop for blocking issues or product questions I can't answer.
 
 Then proceed directly to `/nano` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
 
@@ -669,7 +669,8 @@ If 0 or 1 archived sessions (new user), show the sprint guide:
 > 2. Build the feature
 > 3. `/review` — two-pass code review (structure + adversarial edge cases)
 > 4. `/security` — OWASP audit + secrets scan
-> 5. `/ship` — PR, CI verification, sprint journal
+> 5. `/qa` — open the app like a real user; cover the golden path and edge cases
+> 6. `/ship` — PR, CI verification, sprint journal
 >
 > Or say `/think --autopilot` next time and I run everything after you approve the brief.
 


### PR DESCRIPTION
## Summary

Codex retest of `main@5e247cd` found four flow gaps in `think/SKILL.md` that the static lint matrix and the 9-cell archetype E2E did not cover. They are wording bugs, not detection bugs, but they steer the agent into the wrong conversation for non-technical and Builder users alike.

- **Phase 7 autopilot announcement** now uses the canonical post-build order `/review` → `/security` → `/qa` → `/ship`. The previous wording put `/qa` before `/security`, which contradicts the README, the new-user sprint guide, and every downstream skill.
- **New-user sprint guide** adds step 5 (`/qa` — "open the app like a real user; cover the golden path and edge cases"). For non-technical users the QA step is exactly the value proposition; dropping it left the guide ending at `/ship` without ever telling the user to use the app.
- **Phase 2 diagnostic instruction** no longer says "Always cover the Startup Mode forcing-question set". `think/references/archetypes.md` maps `cli_tooling` and `api_backend` to Builder mode, and the Phase 2 sentence was overriding that mapping. The new wording routes by archetype: Startup forcing questions for `founder_validation` and `landing_experience`, Builder forcing questions for `cli_tooling` and `api_backend`.
- **`founder_validation` lens** is deterministic: `yc` by default, `garry` only when the user passes `--preset=garry` explicitly. The previous "`yc` or `garry`" left the choice up to the agent and the matrix harness could not assert against it.

## Three lint locks

- `think-sprint-order-canonical` — blocks regression to `/review, /qa, /security, /ship` and asserts the new-user guide block lists the steps in `/review` → `/security` → `/qa` → `/ship` order.
- `think-early-guide-includes-qa` — blocks dropping `/qa` from the new-user guide.
- `think-builder-archetypes-do-not-force-startup` — blocks the "Always cover the Startup Mode forcing" phrasing and asserts the Phase 2 paragraph names Builder forcing questions for `cli_tooling` and `api_backend`. Also cross-checks that `archetypes.md` still maps both to Builder so the lock and the spec stay in sync.

## Test plan

- [x] All seven suites green locally: 44/44 unit, 57/57 user-flow, 17/17 delivery matrix, 32/32 think E2E, 25/25 think archetypes E2E, 34/34 onboarding E2E, 32/32 examples contract
- [x] YAML parses for both lint.yml and e2e.yml
- [x] Each new lock executed locally against the patched `think/SKILL.md` and confirmed PASS