### PR TITLE
guard: block JSON credential basenames, allow env templates, deduplicate G-031

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -752,6 +752,36 @@ jobs:
           run_case 0 'envsubst < template'
           run_case 0 'jq . package.json'
           run_case 0 'awk NR==1 file.csv'
+          # G-035 covers JSON credential basenames (Codex retest 2026-04-26).
+          # The previous .env-extension rule allowed credentials.json,
+          # secrets.json, service-account.json, etc.
+          run_case 1 'cat credentials.json'
+          run_case 1 'jq . secrets.json'
+          run_case 1 'cat service-account.json'
+          run_case 1 'cat firebase-adminsdk.json'
+          run_case 1 'rg token client_secret.json'
+          run_case 1 'cat client-secrets.json'
+          run_case 1 'cat aws-credentials.json'
+          run_case 1 'cat google-credentials.json'
+          # Same retest: env templates were blocked even though they are the
+          # safe onboarding surface. They must read.
+          run_case 0 'cat .env.example'
+          run_case 0 'cat .env.sample'
+          run_case 0 'cat .env.template'
+          run_case 0 'head .env.example'
+          run_case 0 'rg API_KEY .env.example'
+          # Real env files (no template suffix) keep blocking.
+          run_case 1 'cat .env.local'
+          run_case 1 'cat .env.production'
+          run_case 1 'cat .env.staging'
+          run_case 1 'cat .env.dev'
+          run_case 1 'cat .env.development'
+          run_case 1 'cat .env.test'
+          # Project config JSON must keep passing; the JSON credential rule
+          # is keyed on credential-flavored basenames, not on .json itself.
+          run_case 0 'jq . tsconfig.json'
+          run_case 0 'cat firebase.json'
+          run_case 0 'cat wrangler.json'
           exit $fail
 
   write-guard-regression:
@@ -2338,3 +2368,98 @@ jobs:
             echo "FAIL: archetypes.md no longer maps api_backend to Builder; update this lint or the spec"
             exit 1
           fi
+
+  guard-rule-ids-unique:
+    name: Guard rule ids are unique
+    runs-on: ubuntu-latest
+    # G-031 was assigned to two different block rules (env/printenv and
+    # sudo destructive) until the 2026-04-26 retest. Audit log entries
+    # and user-facing block output need every rule id to map to exactly
+    # one rule, so this lock blocks the regression.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block rule ids must be unique
+        run: |
+          set -e
+          dupes=$(jq -r '.tiers.block.rules[].id' guard/rules.json | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "FAIL: duplicate block rule id(s):"
+            echo "$dupes"
+            exit 1
+          fi
+      - name: Warn rule ids must be unique (within tier)
+        run: |
+          set -e
+          dupes=$(jq -r '.tiers.warn.rules[].id // empty' guard/rules.json | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "FAIL: duplicate warn rule id(s):"
+            echo "$dupes"
+            exit 1
+          fi
+
+  guard-secret-file-patterns:
+    name: Guard blocks secret JSON and allows env templates
+    runs-on: ubuntu-latest
+    # Functional lock for the 2026-04-26 secrets retest:
+    # - JSON credential basenames (credentials.json, secrets.json,
+    #   service-account.json, firebase-adminsdk.json, client_secret.json)
+    #   must block; the previous extension-only rule missed them and
+    #   allowed credential reads to land in the agent transcript.
+    # - Env templates (.env.example, .env.sample, .env.template) must
+    #   read; first-run setup needs them and blocking creates a
+    #   "Nanostack is fighting me" moment for non-technical users.
+    # - Real env files (.env, .env.local, .env.production, .env.staging,
+    #   .env.dev, .env.development, .env.test) must keep blocking.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run secret-file matrix
+        run: |
+          set +e
+          set -u
+          script=guard/bin/check-dangerous.sh
+          export NANOSTACK_STORE="$RUNNER_TEMP/store"
+          mkdir -p "$NANOSTACK_STORE"
+          fail=0
+          run_case() {
+            local expected="$1" cmd="$2"
+            (cd "$RUNNER_TEMP" && "$GITHUB_WORKSPACE/$script" "$cmd" >/dev/null 2>&1)
+            local got=$?
+            if [ "$got" != "$expected" ]; then
+              echo "FAIL: '$cmd' expected exit $expected, got $got"
+              fail=1
+            else
+              printf '  ok   exit=%s  %s\n' "$got" "$cmd"
+            fi
+          }
+          # JSON credential basenames must block.
+          run_case 1 'cat credentials.json'
+          run_case 1 'jq . secrets.json'
+          run_case 1 'cat service-account.json'
+          run_case 1 'cat firebase-adminsdk.json'
+          run_case 1 'rg token client_secret.json'
+          run_case 1 'cat client-secrets.json'
+          run_case 1 'cat google-credentials.json'
+          run_case 1 'cat gcp-credentials.json'
+          run_case 1 'cat aws-credentials.json'
+          run_case 1 'cat supabase-service-role.json'
+          # Env templates must read.
+          run_case 0 'cat .env.example'
+          run_case 0 'cat .env.sample'
+          run_case 0 'cat .env.template'
+          # Real env files must keep blocking.
+          run_case 1 'cat .env'
+          run_case 1 'cat .env.local'
+          run_case 1 'cat .env.production'
+          run_case 1 'cat .env.staging'
+          run_case 1 'cat .env.dev'
+          run_case 1 'cat .env.development'
+          run_case 1 'cat .env.test'
+          # Project config JSON keeps passing; the credential rule is
+          # keyed on credential-flavored basenames, not on .json itself.
+          run_case 0 'jq . tsconfig.json'
+          run_case 0 'cat firebase.json'
+          run_case 0 'cat wrangler.json'
+          run_case 0 'jq . package.json'
+          exit $fail

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -210,7 +210,13 @@ flow_bash_guard() {
     "env" \
     "printenv" \
     "git reset --hard" \
-    "git push --force"
+    "git push --force" \
+    "cat credentials.json" \
+    "jq . secrets.json" \
+    "cat service-account.json" \
+    "cat firebase-adminsdk.json" \
+    "cat .env.local" \
+    "cat .env.production"
   do
     assert_false "guard blocks: $cmd" "$guard" "$cmd"
   done
@@ -220,7 +226,12 @@ flow_bash_guard() {
     "git push --force-with-lease" \
     "git status" \
     "cat README.md" \
-    "rm -rf ./docs"
+    "rm -rf ./docs" \
+    "cat .env.example" \
+    "cat .env.sample" \
+    "cat .env.template" \
+    "jq . tsconfig.json" \
+    "jq . package.json"
   do
     assert_true "guard allows: $cmd" "$guard" "$cmd"
   done

--- a/guard/rules.json
+++ b/guard/rules.json
@@ -242,10 +242,10 @@
         },
         {
           "id": "G-030",
-          "pattern": "(cat|less|more|view|head|tail|vi|vim|nano|code|grep|egrep|fgrep|rg|ag|jq|yq|awk|sed|od|xxd|hexdump|strings|sort|uniq|wc|file|stat|tr)\\s+([^|;]*\\s)?[^|;]*\\.(env|env\\.[a-z]+|pem|key|p12|pfx|credentials|keystore|secrets)([[:space:]]|$)",
+          "pattern": "(cat|less|more|view|head|tail|vi|vim|nano|code|grep|egrep|fgrep|rg|ag|jq|yq|awk|sed|od|xxd|hexdump|strings|sort|uniq|wc|file|stat|tr)\\s+([^|;]*\\s)?[^|;]*\\.(env|env\\.local|env\\.production|env\\.staging|env\\.dev|env\\.development|env\\.test|pem|key|p12|pfx|credentials|keystore|secrets)([[:space:]]|$)",
           "category": "secrets-access",
           "description": "Reading or editing secrets files directly",
-          "alternative": "Use the project's secrets management. Do not read .env or key files into the agent transcript at all."
+          "alternative": "Use the project's secrets management. Do not read .env or key files into the agent transcript at all. Templates like .env.example, .env.sample, and .env.template are allowed."
         },
         {
           "id": "G-031",
@@ -255,25 +255,32 @@
           "alternative": "Read the specific variable you need with echo \"$VAR_NAME\". Do not pipe full env into the model."
         },
         {
-          "id": "G-031",
+          "id": "G-032",
           "pattern": "sudo\\s+(rm|chmod|chown|kill|systemctl|service|apt|yum)",
           "category": "privilege-escalation",
           "description": "Running destructive commands with elevated privileges",
           "alternative": "Run without sudo inside the project directory"
         },
         {
-          "id": "G-032",
+          "id": "G-033",
           "pattern": "docker\\s+run.*(--privileged|-v\\s+/[^t])",
           "category": "container-escape",
           "description": "Docker with privileged mode or host root mount",
           "alternative": "Use specific volume mounts and drop --privileged"
         },
         {
-          "id": "G-033",
+          "id": "G-034",
           "pattern": "(0\\.0\\.0\\.0|INADDR_ANY|--host\\s+0\\.0)",
           "category": "network-exposure",
           "description": "Binding to all interfaces exposes service to the network",
           "alternative": "Bind to 127.0.0.1 for local development"
+        },
+        {
+          "id": "G-035",
+          "pattern": "(cat|less|more|view|head|tail|vi|vim|nano|code|grep|egrep|fgrep|rg|ag|jq|yq|awk|sed|od|xxd|hexdump|strings|sort|uniq|wc|file|stat|tr)\\s+([^|;]*[[:space:]/])?(service[-_]?account|firebase[-_]?adminsdk|google[-_]?credentials|gcp[-_]?credentials|aws[-_]?credentials|supabase[-_]?service[-_]?role|client[-_]?secret[s]?|credentials|credential|secrets|secret)[^/[:space:]]*\\.json([[:space:]]|$)",
+          "category": "secrets-access",
+          "description": "Reading or editing JSON credential files directly",
+          "alternative": "Use the project's secrets management. Do not read credential JSON into the agent transcript."
         }
       ]
     },


### PR DESCRIPTION
## Summary

Codex's product-limit sandbox retest of `main@271cd62` found three guard-secret bugs. They all live in `guard/rules.json` and their consequence is felt at the agent boundary: real credentials slip through, safe templates get blocked, and the public rule-id handle is ambiguous.

- **G-030 missed JSON credential basenames.** `cat credentials.json`, `jq . secrets.json`, `cat service-account.json`, `cat firebase-adminsdk.json`, `rg token client_secret.json` all exited `0` because the rule keyed on extensions like `.env`, `.pem`, `.key`. Firebase/GCP/AWS service-account JSON could leak into the agent transcript.
- **G-030 blocked safe env templates.** `cat .env.example`, `cat .env.sample`, `cat .env.template` all exited `1` because the catch-all `env\.[a-z]+` matched any `.env.<word>`. Templates are exactly the file an agent needs to read during onboarding to explain which variables a non-technical user must set.
- **G-031 was assigned twice** — once to env/printenv (secrets-access), once to sudo destructive (privilege-escalation). Audit log entries and user-facing block output stopped uniquely mapping to a category.

## Changes

- **G-030** now matches an explicit list of unsafe env suffixes: `.env`, `.env.local`, `.env.production`, `.env.staging`, `.env.dev`, `.env.development`, `.env.test`. The `.env.example` / `.env.sample` / `.env.template` triplet falls through to normal allowlist handling.
- **G-035** is new. It matches credential-flavored JSON basenames: `secret(s).json`, `credential(s).json`, `client[-_]?secret(s).json`, `service[-_]?account.json`, `firebase[-_]?adminsdk.json`, `google/gcp/aws-credentials.json`, `supabase-service-role.json`. Project config (`package.json`, `tsconfig.json`, `firebase.json`, `wrangler.json`) keeps reading because the rule is keyed on credential-flavored basenames, not on `.json`.
- **G-031 deduplicated.** Sudo destructive renamed from duplicate G-031 to G-032; docker privileged from G-032 to G-033; network exposure from G-033 to G-034. Block rule ids are now strictly unique and monotonic.

## CI locks

- **`guard-rule-ids-unique`** blocks any future duplicate id in the block or warn tier.
- **`guard-secret-file-patterns`** runs the spec's full retest matrix (24 cases — every JSON credential basename, every env template, every real env file, project config JSON sanity).
- **`guard-regression`** matrix grows by 17 cases covering the new rules and the env template allow-list.
- **`ci/e2e-user-flows.sh`** `flow_bash_guard` grows by 11 cases for runtime coverage on a real `/tmp` project.

## Test plan

- [x] Codex's manual retest matrix (8 must-block + 8 must-allow): all green
- [x] tests/run.sh: 44/44
- [x] ci/e2e-user-flows.sh: 68/68 (was 57; +11 guard cases)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses; rule ids unique (`jq -r '.tiers.block.rules[].id' | sort | uniq -d` empty)