### PR TITLE
custom-stack v1 PR 1: shared phase registry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2418,6 +2418,50 @@ jobs:
             fi
           done
           exit $fail
+      - name: Default phase_graph mirrors conductor's canonical topology
+        run: |
+          set -e
+          # PR 5 will land a conductor that consumes nano_phase_graph_json.
+          # The default graph must match the conductor today (think -> plan
+          # -> build -> review/qa/security -> ship), otherwise PR 5 ships
+          # review/qa/security before build runs.
+          out=$(bash -c 'source bin/lib/phases.sh && nano_phase_graph_json')
+          echo "$out" | jq -e '. | length == 7' >/dev/null
+          echo "$out" | jq -e 'any(.name == "build")' >/dev/null
+          echo "$out" | jq -e '.[] | select(.name == "build") | .depends_on == ["plan"]' >/dev/null
+          for p in review qa security; do
+            echo "$out" | jq -e ".[] | select(.name == \"$p\") | .depends_on == [\"build\"]" >/dev/null
+          done
+          echo "$out" | jq -e '.[] | select(.name == "ship") | .depends_on | sort == ["qa","review","security"]' >/dev/null
+          # Cross-check: conductor's runtime graph still names build between
+          # plan and review. If the conductor changes its topology the lint
+          # is not the right place to update — this lock is a tripwire that
+          # forces the change to happen in both files together.
+          if ! grep -qE '"name":"build","depends_on":\["plan"\]' conductor/bin/sprint.sh; then
+            echo "FAIL: conductor/bin/sprint.sh DEFAULT_PHASES no longer routes build between plan and review"
+            exit 1
+          fi
+      - name: Library validates phase_graph entries before returning them
+        run: |
+          set -e
+          # Invalid graphs must fall back to the default so downstream
+          # consumers (PR 5 conductor) never see an invalid topology.
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          mkdir -p "$tmp/.nanostack"
+          export NANOSTACK_STORE="$tmp/.nanostack"
+          # Case 1: name not in core/custom and not the build stage.
+          printf '%s' '{"phase_graph":[{"name":"think","depends_on":[]},{"name":"NOT_REGISTERED","depends_on":["think"]}]}' > "$tmp/.nanostack/config.json"
+          out=$(bash -c 'source bin/lib/phases.sh && nano_phase_graph_json' 2>/dev/null)
+          echo "$out" | jq -e '. | length == 7' >/dev/null
+          # Case 2: depends_on points at a name that is not in the graph.
+          printf '%s' '{"phase_graph":[{"name":"think","depends_on":["plan"]}]}' > "$tmp/.nanostack/config.json"
+          out=$(bash -c 'source bin/lib/phases.sh && nano_phase_graph_json' 2>/dev/null)
+          echo "$out" | jq -e '. | length == 7' >/dev/null
+          # Case 3: name fails the phase regex.
+          printf '%s' '{"phase_graph":[{"name":"BAD_NAME","depends_on":[]}]}' > "$tmp/.nanostack/config.json"
+          out=$(bash -c 'source bin/lib/phases.sh && nano_phase_graph_json' 2>/dev/null)
+          echo "$out" | jq -e '. | length == 7' >/dev/null
 
   guard-rule-ids-unique:
     name: Guard rule ids are unique

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2369,6 +2369,56 @@ jobs:
             exit 1
           fi
 
+  phase-registry-contract:
+    name: Phase registry library exposes the public API
+    runs-on: ubuntu-latest
+    # bin/lib/phases.sh is the single source of truth for which phases
+    # exist for a project. Lifecycle scripts (save, restore, discard,
+    # journal, analytics, conductor) all read from it. The unit suite
+    # already exercises the runtime; this lint locks the API surface so
+    # future edits cannot rename or remove a function the consumers
+    # depend on.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Library file exists and is sourceable
+        run: |
+          set -e
+          test -f bin/lib/phases.sh
+          bash -n bin/lib/phases.sh
+      - name: Required public functions are defined
+        run: |
+          set -e
+          fail=0
+          for fn in nano_core_phases nano_custom_phases nano_all_phases nano_phase_exists nano_phase_kind nano_phase_graph_json nano_phase_skill_path; do
+            if ! grep -qE "^${fn}\(\)" bin/lib/phases.sh; then
+              echo "FAIL: bin/lib/phases.sh is missing function $fn"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Lifecycle scripts that take a phase argument source the registry
+        run: |
+          set -e
+          fail=0
+          for f in bin/save-artifact.sh bin/restore-context.sh bin/discard-sprint.sh; do
+            if ! grep -qE 'lib/phases\.sh' "$f"; then
+              echo "FAIL: $f does not source bin/lib/phases.sh"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Hardcoded core-phase strings are gone from the migrated scripts
+        run: |
+          set -e
+          fail=0
+          for f in bin/save-artifact.sh bin/restore-context.sh bin/discard-sprint.sh; do
+            if grep -nE 'PHASES?="think plan review qa security ship"' "$f"; then
+              echo "FAIL: $f still hardcodes the core phase list (use nano_all_phases)"
+              fail=1
+            fi
+          done
+          exit $fail
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/bin/discard-sprint.sh
+++ b/bin/discard-sprint.sh
@@ -9,6 +9,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
 
 STORE="$NANOSTACK_STORE"
 KNOW_HOW="$STORE/know-how"
@@ -17,7 +18,9 @@ PROJECT_NAME=$(basename "$PROJECT")
 DATE=$(date -u +"%Y-%m-%d")
 PHASE=""
 DRY_RUN=false
-PHASES="think plan review qa security ship"
+# Default to every registered phase (core + custom). The explicit
+# --phase flag below narrows to a single phase when given.
+PHASES=$(nano_all_phases)
 
 # Parse args
 while [ $# -gt 0 ]; do

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# phases.sh — Shared phase registry for nanostack lifecycle scripts.
+#
+# Source this library so every script (save-artifact, restore-context,
+# resolve, sprint-journal, analytics, discard-sprint, conductor) sees
+# the same view of which phases exist for the current project.
+#
+# Phases come from two places:
+#   - The immutable core list (think, plan, review, qa, security, ship).
+#   - The .custom_phases array in .nanostack/config.json (project) or
+#     ~/.nanostack/config.json (global fallback).
+#
+# Custom phase names must match ^[a-z][a-z0-9-]*$. Invalid names are
+# silently dropped with a stderr warning; the lifecycle scripts must
+# keep working even when config is malformed.
+#
+# Public functions:
+#   nano_core_phases                 # echoes the six built-in phases
+#   nano_custom_phases [config]      # echoes registered custom phases
+#   nano_all_phases    [config]      # echoes core + custom (deduped)
+#   nano_phase_exists  <name> [cfg]  # exit 0 if known
+#   nano_phase_kind    <name> [cfg]  # echoes core | custom | unknown
+#   nano_phase_graph_json [cfg]      # echoes phase_graph JSON array
+#   nano_phase_skill_path <name> [cfg] # echoes resolved skill dir or exit 1
+
+# Idempotent guard: skip if already sourced in this shell.
+if [ "${_NANO_PHASES_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_PHASES_LOADED=1
+
+NANO_CORE_PHASES_LIST="think plan review qa security ship"
+NANO_PHASE_NAME_RE='^[a-z][a-z0-9-]*$'
+
+# Resolve config path. Order: explicit arg, $NANOSTACK_STORE/config.json,
+# then ~/.nanostack/config.json. Returns 1 if none exists.
+_nano_phases_resolve_config() {
+  local explicit="${1:-}"
+  if [ -n "$explicit" ] && [ -f "$explicit" ]; then
+    printf '%s\n' "$explicit"; return 0
+  fi
+  if [ -n "${NANOSTACK_STORE:-}" ] && [ -f "$NANOSTACK_STORE/config.json" ]; then
+    printf '%s\n' "$NANOSTACK_STORE/config.json"; return 0
+  fi
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.nanostack/config.json" ]; then
+    printf '%s\n' "$HOME/.nanostack/config.json"; return 0
+  fi
+  return 1
+}
+
+nano_core_phases() {
+  printf '%s\n' "$NANO_CORE_PHASES_LIST"
+}
+
+nano_custom_phases() {
+  local config
+  config=$(_nano_phases_resolve_config "${1:-}") || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local raw
+  raw=$(jq -r '.custom_phases // [] | .[]' "$config" 2>/dev/null) || return 0
+  [ -z "$raw" ] && return 0
+  local result=""
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    case " $NANO_CORE_PHASES_LIST " in
+      *" $name "*) continue ;;
+    esac
+    if ! printf '%s' "$name" | grep -qE "$NANO_PHASE_NAME_RE"; then
+      printf 'phases: rejecting invalid custom phase name "%s"\n' "$name" >&2
+      continue
+    fi
+    case " $result " in
+      *" $name "*) continue ;;
+    esac
+    if [ -z "$result" ]; then result="$name"; else result="$result $name"; fi
+  done <<< "$raw"
+  [ -n "$result" ] && printf '%s\n' "$result"
+  return 0
+}
+
+nano_all_phases() {
+  local custom
+  custom=$(nano_custom_phases "${1:-}")
+  if [ -n "$custom" ]; then
+    printf '%s %s\n' "$NANO_CORE_PHASES_LIST" "$custom"
+  else
+    printf '%s\n' "$NANO_CORE_PHASES_LIST"
+  fi
+}
+
+nano_phase_exists() {
+  local name="${1:?nano_phase_exists requires a phase name}"
+  local all
+  all=$(nano_all_phases "${2:-}")
+  case " $all " in
+    *" $name "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+nano_phase_kind() {
+  local name="${1:?nano_phase_kind requires a phase name}"
+  case " $NANO_CORE_PHASES_LIST " in
+    *" $name "*) printf 'core\n'; return 0 ;;
+  esac
+  local custom
+  custom=$(nano_custom_phases "${2:-}")
+  case " $custom " in
+    *" $name "*) printf 'custom\n'; return 0 ;;
+  esac
+  printf 'unknown\n'
+  return 1
+}
+
+# Returns the phase_graph as a JSON array of {name, depends_on}. If
+# config is missing or has no phase_graph, returns the canonical core
+# graph. Conductor's PR will consume this; for now lifecycle scripts
+# ignore it.
+nano_phase_graph_json() {
+  local config
+  config=$(_nano_phases_resolve_config "${1:-}") || true
+  if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
+    local graph
+    graph=$(jq -c '.phase_graph // empty' "$config" 2>/dev/null)
+    if [ -n "$graph" ] && [ "$graph" != "null" ]; then
+      printf '%s\n' "$graph"
+      return 0
+    fi
+  fi
+  printf '%s\n' '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"review","depends_on":["plan"]},{"name":"qa","depends_on":["plan"]},{"name":"security","depends_on":["plan"]},{"name":"ship","depends_on":["review","qa","security"]}]'
+}
+
+# Best-effort skill-path resolution. Core phases live one directory
+# above bin/ (the nanostack repo). Custom phases live under skill_roots
+# from config, falling back to .nanostack/skills, ~/.claude/skills,
+# ~/.agents/skills. Returns the directory path on stdout, exit 1 if
+# nothing matches.
+nano_phase_skill_path() {
+  local phase="${1:?nano_phase_skill_path requires a phase name}"
+  local config
+  config=$(_nano_phases_resolve_config "${2:-}") || true
+  local repo_root="${NANOSTACK_ROOT:-}"
+  if [ -z "$repo_root" ]; then
+    repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd) || repo_root=""
+  fi
+  case " $NANO_CORE_PHASES_LIST " in
+    *" $phase "*)
+      if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ]; then
+        printf '%s\n' "$repo_root/$phase"
+        return 0
+      fi
+      return 1
+      ;;
+  esac
+  local roots=""
+  if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
+    roots=$(jq -r '.skill_roots // [] | .[]' "$config" 2>/dev/null)
+  fi
+  local default_roots=".nanostack/skills $HOME/.claude/skills $HOME/.agents/skills"
+  for root in $roots $default_roots; do
+    case "$root" in
+      "~/"*) root="$HOME/${root#~/}" ;;
+    esac
+    if [ -d "$root/$phase" ] && [ -f "$root/$phase/SKILL.md" ]; then
+      printf '%s\n' "$root/$phase"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -112,22 +112,88 @@ nano_phase_kind() {
   return 1
 }
 
+# Internal: graph nodes accept core phases plus the conductor's "build"
+# stage (which produces no artifact and is not in nano_core_phases).
+_NANO_GRAPH_BUILTIN_NODES="$NANO_CORE_PHASES_LIST build"
+
+_nano_graph_node_known() {
+  local name="$1" config="${2:-}"
+  case " $_NANO_GRAPH_BUILTIN_NODES " in
+    *" $name "*) return 0 ;;
+  esac
+  local custom
+  custom=$(nano_custom_phases "$config")
+  case " $custom " in
+    *" $name "*) return 0 ;;
+  esac
+  return 1
+}
+
+# Validates a phase_graph JSON array. Each entry must have a string
+# .name matching the phase regex AND known to the registry (core,
+# custom, or the conductor's "build" stage). Every .depends_on[] entry
+# must reference a name that appears elsewhere in the same graph.
+# Returns 0 on success, 1 on failure (silently — caller emits the user
+# warning).
+_nano_phase_graph_is_valid() {
+  local graph="$1" config="${2:-}"
+  command -v jq >/dev/null 2>&1 || return 1
+  echo "$graph" | jq -e '
+    type == "array"
+    and length > 0
+    and all(
+      .[];
+      (.name | type == "string")
+      and (.depends_on | type == "array")
+      and (.depends_on | all(type == "string"))
+    )
+  ' >/dev/null 2>&1 || return 1
+  local names dep_targets
+  names=$(echo "$graph" | jq -r '.[].name')
+  dep_targets=$(echo "$graph" | jq -r '[.[].name] | join("\n")')
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    if ! printf '%s' "$name" | grep -qE "$NANO_PHASE_NAME_RE"; then
+      return 1
+    fi
+    if ! _nano_graph_node_known "$name" "$config"; then
+      return 1
+    fi
+  done <<< "$names"
+  local deps
+  deps=$(echo "$graph" | jq -r '.[].depends_on[]?')
+  while IFS= read -r dep; do
+    [ -z "$dep" ] && continue
+    if ! echo "$dep_targets" | grep -qFx "$dep"; then
+      return 1
+    fi
+  done <<< "$deps"
+  return 0
+}
+
 # Returns the phase_graph as a JSON array of {name, depends_on}. If
-# config is missing or has no phase_graph, returns the canonical core
-# graph. Conductor's PR will consume this; for now lifecycle scripts
-# ignore it.
+# config has a valid phase_graph, returns it. Otherwise returns the
+# canonical default graph that mirrors conductor/bin/sprint.sh:
+# think -> plan -> build -> review/qa/security (parallel) -> ship.
+# An invalid phase_graph in config falls back to the default and emits
+# a stderr warning so a malformed config never produces an invalid
+# topology downstream.
 nano_phase_graph_json() {
   local config
   config=$(_nano_phases_resolve_config "${1:-}") || true
+  local default_graph='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"ship","depends_on":["review","qa","security"]}]'
   if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
     local graph
     graph=$(jq -c '.phase_graph // empty' "$config" 2>/dev/null)
     if [ -n "$graph" ] && [ "$graph" != "null" ]; then
-      printf '%s\n' "$graph"
-      return 0
+      if _nano_phase_graph_is_valid "$graph" "$config"; then
+        printf '%s\n' "$graph"
+        return 0
+      fi
+      printf 'phases: rejecting invalid phase_graph in config; using default graph\n' >&2
     fi
   fi
-  printf '%s\n' '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"review","depends_on":["plan"]},{"name":"qa","depends_on":["plan"]},{"name":"security","depends_on":["plan"]},{"name":"ship","depends_on":["review","qa","security"]}]'
+  printf '%s\n' "$default_graph"
 }
 
 # Best-effort skill-path resolution. Core phases live one directory

--- a/bin/restore-context.sh
+++ b/bin/restore-context.sh
@@ -7,17 +7,18 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
 
 PROJECT="$(pwd)"
 MAX_AGE=30
-PHASES="think plan review qa security ship"
+PHASES_OVERRIDE=""
 JSON_OUTPUT=false
 TOKEN_BUDGET=0  # 0 = no budget, load full artifacts
 
 # Parse arguments
 while [ $# -gt 0 ]; do
   case "$1" in
-    --phases) PHASES="$2"; shift 2 ;;
+    --phases) PHASES_OVERRIDE="$2"; shift 2 ;;
     --max-age-days) MAX_AGE="$2"; shift 2 ;;
     --json) JSON_OUTPUT=true; shift ;;
     --budget) TOKEN_BUDGET="$2"; shift 2 ;;
@@ -25,11 +26,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Load custom phases from config
-CONFIG="$NANOSTACK_STORE/config.json"
-if [ -f "$CONFIG" ]; then
-  CUSTOM=$(jq -r '.custom_phases // [] | join(" ")' "$CONFIG" 2>/dev/null || echo "")
-  [ -n "$CUSTOM" ] && PHASES="$PHASES $CUSTOM"
+# Phases come from the registry (core + registered custom). An explicit
+# --phases flag overrides the registry for advanced callers.
+if [ -n "$PHASES_OVERRIDE" ]; then
+  PHASES="$PHASES_OVERRIDE"
+else
+  PHASES=$(nano_all_phases)
 fi
 
 # If budget is set, estimate total upstream size and decide mode

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -58,22 +58,15 @@ fi
 PHASE="${1:?Usage: save-artifact.sh <phase> <json>}"
 JSON="${2:?Missing JSON argument}"
 STORE="$NANOSTACK_STORE/$PHASE"
-CORE_PHASES="think plan review qa security ship"
 
-# Load custom phases from config if exists
-CUSTOM_PHASES=""
-CONFIG="$NANOSTACK_STORE/config.json"
-if [ -f "$CONFIG" ]; then
-  CUSTOM_PHASES=$(jq -r '.custom_phases // [] | join(" ")' "$CONFIG" 2>/dev/null || echo "")
+# Phase registry is the single source of truth for which phases exist.
+# Core phases are always valid; custom phases come from
+# .nanostack/config.json (.custom_phases).
+. "$SCRIPT_DIR/lib/phases.sh"
+if ! nano_phase_exists "$PHASE"; then
+  echo "error: invalid phase '$PHASE'. Must be one of: $(nano_all_phases)" >&2
+  exit 1
 fi
-
-VALID_PHASES="$CORE_PHASES $CUSTOM_PHASES"
-
-# Validate phase name
-case " $VALID_PHASES " in
-  *" $PHASE "*) ;;
-  *) echo "error: invalid phase '$PHASE'. Must be one of: $VALID_PHASES" >&2; exit 1 ;;
-esac
 
 # Validate JSON is parseable
 if ! echo "$JSON" | jq '.' >/dev/null 2>&1; then

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -476,6 +476,52 @@ flow_local_no_git() {
   unset NANOSTACK_STORE
 }
 
+# ─── Flow 8: phase registry ──────────────────────────────────────────
+# bin/lib/phases.sh is the single source of truth. Lifecycle scripts
+# read from it; this flow proves a registered custom phase saves and a
+# missing registration is rejected with the right message, end-to-end
+# from a real project directory.
+
+flow_phase_registry() {
+  local proj="$TMP_ROOT/phase-registry"
+  mkdir -p "$proj/.nanostack"
+  cd "$proj"
+  git init -q
+  export NANOSTACK_STORE="$proj/.nanostack"
+
+  # No custom phases yet: rejection path.
+  printf '%s' '{}' > .nanostack/config.json
+  assert_false "save-artifact rejects unregistered phase" \
+    "$REPO/bin/save-artifact.sh" audit-licenses \
+    '{"phase":"audit-licenses","summary":{"flagged":[]},"context_checkpoint":{"summary":"ok"}}'
+  local rej_out
+  rej_out=$( "$REPO/bin/save-artifact.sh" audit-licenses \
+    '{"phase":"audit-licenses","summary":{"flagged":[]},"context_checkpoint":{"summary":"ok"}}' 2>&1 || true )
+  assert_true "rejection message says 'invalid phase'" \
+    bash -c "echo '$rej_out' | grep -qF 'invalid phase'"
+
+  # After registration: save and read.
+  printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+  "$REPO/bin/save-artifact.sh" audit-licenses \
+    '{"phase":"audit-licenses","summary":{"flagged":[],"counts":{"permissive":1}},"context_checkpoint":{"summary":"7 deps scanned","key_files":["package.json"]}}' \
+    >/dev/null
+  assert_true "registered custom phase artifact exists" \
+    bash -c "ls $proj/.nanostack/audit-licenses/*.json 2>/dev/null | head -1"
+
+  local found
+  found=$( "$REPO/bin/find-artifact.sh" audit-licenses 30 2>/dev/null )
+  assert_true "find-artifact returns the saved path" test -f "$found"
+
+  # Library smoke from a real project: nano_all_phases includes the
+  # registered custom phase; nano_phase_kind classifies it correctly.
+  local kind
+  kind=$( source "$REPO/bin/lib/phases.sh" && nano_phase_kind audit-licenses )
+  assert_eq "nano_phase_kind == custom for registered phase" "custom" "$kind"
+
+  cd "$REPO"
+  unset NANOSTACK_STORE
+}
+
 # ─── Run ──────────────────────────────────────────────────────────────
 
 echo "Nanostack E2E user flows"
@@ -489,6 +535,7 @@ flow write_guard
 flow sprint_phase_gate
 flow legacy_repair
 flow local_no_git
+flow phase_registry
 
 echo ""
 echo "========================"


### PR DESCRIPTION
## Summary

First of six PRs implementing Codex's Custom Stack Framework v1 spec. The spec found that `save-artifact.sh` already accepts a registered custom phase, but every other lifecycle script (resolver, journal, analytics, default discard, conductor) ignores or partially supports custom phases. Each script holds its own copy of the core list `think plan review qa security ship`. This PR collapses that to one library that every script reads from.

- **`bin/lib/phases.sh`** — new. Public functions: `nano_core_phases`, `nano_custom_phases`, `nano_all_phases`, `nano_phase_exists`, `nano_phase_kind`, `nano_phase_graph_json`, `nano_phase_skill_path`. Custom phase names must match `^[a-z][a-z0-9-]*$`; invalid names and core overrides are silently dropped with a stderr warning so a malformed config does not bring down lifecycle scripts.
- **`bin/save-artifact.sh`** loses its inline `CORE_PHASES` + `CUSTOM_PHASES` parsing and calls `nano_phase_exists` instead.
- **`bin/restore-context.sh`** loses the inline core list and the duplicated `.custom_phases` jq read; it now sources the library and calls `nano_all_phases`. The `--phases` override flag still wins for advanced callers.
- **`bin/discard-sprint.sh`** loses the hardcoded list. Default discard now includes every registered phase (core + custom), which closes Codex's "default discard misses custom artifacts" finding as a side effect.

`analytics.sh` and `sprint-journal.sh` keep their core-only output in this PR. Their custom-phase emission lives in **PR 4 (Custom Lifecycle Outputs)** where it sits alongside the rest of the output changes; sourcing the library here without using it would be dead code until that PR.

## CI locks

- **`phase-registry-contract`** asserts the library file exists, every public function is defined, the three migrated scripts source the library, and no migrated script still hardcodes the core list.
- **`ci/e2e-user-flows.sh`** grows a `phase_registry` flow (5 cells): rejection-with-message before registration, save after registration, `find-artifact` returns the saved path, `nano_phase_kind` classifies the registered phase as `custom`.

## Out of scope (PR 2-6 of the spec)

- PR 2: `resolve.sh` returns minimal JSON for registered custom phases
- PR 3: copy-paste custom skill template (path bug + `agents/openai.yaml`)
- PR 4: analytics + journal + discard-dry-run custom output
- PR 5: conductor parses `--phases` and reads `phase_graph` from config
- PR 6: `create-skill.sh` / `check-custom-skill.sh` / docs / `e2e-custom-stack-flows.sh`

## Test plan

- [x] tests/run.sh: 55/55 (was 44; +11 new phase-registry tests, local only per the standing rule)
- [x] ci/e2e-user-flows.sh: 73/73 (was 68; +5 phase_registry cells)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses