### PR TITLE
custom-stack v1 PR 2: resolve.sh handles registered custom phases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2463,6 +2463,92 @@ jobs:
           out=$(bash -c 'source bin/lib/phases.sh && nano_phase_graph_json' 2>/dev/null)
           echo "$out" | jq -e '. | length == 7' >/dev/null
 
+  resolver-custom-phase-contract:
+    name: resolve.sh handles registered custom phases
+    runs-on: ubuntu-latest
+    # PR 2 of the Custom Stack Framework v1 round. resolve.sh used to
+    # exit 1 on any phase that wasn't in its hardcoded routing table,
+    # which broke custom skills running under set -e. Lock the
+    # contract from reference/custom-stack-contract.md: a registered
+    # custom phase exits 0 with phase_kind=custom; an unregistered
+    # phase still exits 1; phase_graph drives upstream_artifacts;
+    # missing deps render as null for custom phases only.
+    steps:
+      - uses: actions/checkout@v4
+      - name: resolve.sh sources the phase registry
+        run: |
+          set -e
+          if ! grep -qE 'lib/phases\.sh' bin/resolve.sh; then
+            echo "FAIL: bin/resolve.sh does not source bin/lib/phases.sh"
+            exit 1
+          fi
+      - name: Custom phase contract round-trip
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+
+          # Unregistered phase exits 1 with the legacy error message.
+          echo '{}' > .nanostack/config.json
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" performance 2>&1) && {
+            echo "FAIL: resolve.sh accepted unregistered phase"
+            exit 1
+          }
+          echo "$out" | grep -qF 'unknown phase' || {
+            echo "FAIL: rejection message does not say 'unknown phase'"
+            exit 1
+          }
+
+          # Core phase still works and now carries phase_kind=core.
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" review 2>/dev/null)
+          echo "$out" | jq -e '.phase_kind == "core"' >/dev/null
+
+          # Registered custom phase: exits 0, phase_kind=custom, empty
+          # solutions/diarizations, no upstreams declared yet.
+          printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" audit-licenses 2>/dev/null)
+          echo "$out" | jq -e '.phase_kind == "custom"' >/dev/null
+          echo "$out" | jq -e '.solutions == []' >/dev/null
+          echo "$out" | jq -e '.diarizations == []' >/dev/null
+          echo "$out" | jq -e '.upstream_artifacts == {}' >/dev/null
+
+          # phase_graph drives upstream_artifacts. plan present, build
+          # always null (no artifact dir), ship missing renders null.
+          printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build","plan","ship"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json
+          "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" audit-licenses 2>/dev/null)
+          echo "$out" | jq -e '.upstream_artifacts.build == null' >/dev/null
+          echo "$out" | jq -e '.upstream_artifacts.plan | type == "string"' >/dev/null
+          echo "$out" | jq -e '.upstream_artifacts.ship == null' >/dev/null
+
+          # Core phases still omit missing upstreams (back-compat for
+          # downstream skills). Reset config and try a core phase that
+          # has no upstream artifacts saved.
+          rm -rf .nanostack/plan
+          echo '{}' > .nanostack/config.json
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" review 2>/dev/null)
+          # plan was a declared upstream but not present: core phase
+          # should leave the key OUT, not render it as null.
+          if echo "$out" | jq -e '.upstream_artifacts | has("plan")' >/dev/null; then
+            echo "FAIL: core phase resolver should omit missing upstreams"
+            exit 1
+          fi
+      - name: Contract doc lists the custom-phase output shape
+        run: |
+          set -e
+          fail=0
+          for token in 'phase_kind' '"custom"' 'phase_graph' 'depends_on' 'unregistered' 'unknown phase'; do
+            if ! grep -qF "$token" reference/custom-stack-contract.md; then
+              echo "FAIL: reference/custom-stack-contract.md missing token: $token"
+              fail=1
+            fi
+          done
+          exit $fail
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2537,12 +2537,34 @@ jobs:
             echo "FAIL: core phase resolver should omit missing upstreams"
             exit 1
           fi
+
+          # phase_graph with depends_on:[] for the phase WINS over
+          # SKILL.md depends_on. The two cases (phase not in graph)
+          # versus (phase in graph but declares no deps) must stay
+          # distinct, otherwise SKILL.md silently re-introduces deps
+          # the user explicitly removed in their graph.
+          mkdir -p .nanostack/skills/audit-licenses
+          # printf instead of heredoc: a heredoc body containing
+          # `---` at column 0 would be parsed as a second YAML
+          # document by github-actions YAML loaders.
+          printf '%s\n' '---' 'name: audit-licenses' 'depends_on: [plan, ship]' '---' \
+            > .nanostack/skills/audit-licenses/SKILL.md
+          printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"audit-licenses","depends_on":[]}]}' > .nanostack/config.json
+          out=$("$GITHUB_WORKSPACE/bin/resolve.sh" audit-licenses 2>/dev/null)
+          if ! echo "$out" | jq -e '.upstream_artifacts == {}' >/dev/null; then
+            echo "FAIL: phase_graph with depends_on:[] must override SKILL.md depends_on"
+            echo "$out" | jq .upstream_artifacts
+            exit 1
+          fi
       - name: Contract doc lists the custom-phase output shape
         run: |
           set -e
           fail=0
+          # Token presence check is case-insensitive: the doc uses
+          # heading case ("Unregistered phase") and prose case
+          # ("unregistered"); both should satisfy the lock.
           for token in 'phase_kind' '"custom"' 'phase_graph' 'depends_on' 'unregistered' 'unknown phase'; do
-            if ! grep -qF "$token" reference/custom-stack-contract.md; then
+            if ! grep -qiF "$token" reference/custom-stack-contract.md; then
               echo "FAIL: reference/custom-stack-contract.md missing token: $token"
               fail=1
             fi

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -112,17 +112,23 @@ case "$PHASE" in
     if [ "$(nano_phase_kind "$PHASE" 2>/dev/null)" = "custom" ]; then
       PHASE_KIND="custom"
       DEPS=""
+      GRAPH_LISTED_PHASE=false
       # First source: phase_graph from config (already validated by
       # bin/lib/phases.sh; invalid graphs already fell back to default).
+      # An entry with depends_on=[] is a deliberate "no dependencies"
+      # declaration, distinct from the phase not being in the graph at
+      # all — so we track presence separately and only fall back to
+      # SKILL.md when the phase is absent from the graph.
       GRAPH=$(nano_phase_graph_json 2>/dev/null || echo "")
-      if [ -n "$GRAPH" ]; then
+      if [ -n "$GRAPH" ] && echo "$GRAPH" | jq -e --arg p "$PHASE" 'any(.[]; .name == $p)' >/dev/null 2>&1; then
+        GRAPH_LISTED_PHASE=true
         DEPS=$(echo "$GRAPH" | jq -r --arg p "$PHASE" '.[] | select(.name == $p) | .depends_on[]?' 2>/dev/null | tr '\n' ' ')
       fi
       # Second source: SKILL.md frontmatter `depends_on` field, only if
-      # phase_graph did not list the phase. Supports the inline list
-      # form `depends_on: [build, ship]`. Block-list form is parsed too:
-      # subsequent lines starting with "  - <name>" are picked up.
-      if [ -z "$DEPS" ]; then
+      # the phase is absent from phase_graph. Supports inline list form
+      # `depends_on: [build, ship]` and block list form
+      # (`depends_on:\n  - build`).
+      if [ "$GRAPH_LISTED_PHASE" = false ]; then
         SKILL_DIR=$(nano_phase_skill_path "$PHASE" 2>/dev/null) || SKILL_DIR=""
         if [ -n "$SKILL_DIR" ] && [ -f "$SKILL_DIR/SKILL.md" ]; then
           DEPS=$(awk '

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -19,6 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 [ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
 
 # Portable timeout wrapper: gtimeout (coreutils on macOS) → timeout (Linux) → run as-is.
 # Used to bound expensive solution lookups so resolve.sh never hangs the sprint.
@@ -65,6 +66,7 @@ LOAD_SOLUTIONS=false
 SOLUTION_STRATEGY=""  # keywords, files, both
 LOAD_PRECEDENTS=false
 LOAD_DIARIZATIONS=false
+PHASE_KIND="core"
 
 case "$PHASE" in
   plan)
@@ -102,8 +104,72 @@ case "$PHASE" in
     SOLUTION_STRATEGY="keywords"
     ;;
   *)
-    echo "{\"error\": \"unknown phase: $PHASE\"}" >&2
-    exit 1
+    # Custom-phase fallback. A phase that's registered in
+    # .nanostack/config.json (custom_phases) returns minimal context:
+    # upstream artifacts driven by phase_graph or skill frontmatter,
+    # everything else empty. An unregistered phase still exits 1 so
+    # set -e callers fail closed.
+    if [ "$(nano_phase_kind "$PHASE" 2>/dev/null)" = "custom" ]; then
+      PHASE_KIND="custom"
+      DEPS=""
+      # First source: phase_graph from config (already validated by
+      # bin/lib/phases.sh; invalid graphs already fell back to default).
+      GRAPH=$(nano_phase_graph_json 2>/dev/null || echo "")
+      if [ -n "$GRAPH" ]; then
+        DEPS=$(echo "$GRAPH" | jq -r --arg p "$PHASE" '.[] | select(.name == $p) | .depends_on[]?' 2>/dev/null | tr '\n' ' ')
+      fi
+      # Second source: SKILL.md frontmatter `depends_on` field, only if
+      # phase_graph did not list the phase. Supports the inline list
+      # form `depends_on: [build, ship]`. Block-list form is parsed too:
+      # subsequent lines starting with "  - <name>" are picked up.
+      if [ -z "$DEPS" ]; then
+        SKILL_DIR=$(nano_phase_skill_path "$PHASE" 2>/dev/null) || SKILL_DIR=""
+        if [ -n "$SKILL_DIR" ] && [ -f "$SKILL_DIR/SKILL.md" ]; then
+          DEPS=$(awk '
+            /^---[[:space:]]*$/ { f=!f; next }
+            f && /^depends_on:/ {
+              # Strip "depends_on:" prefix.
+              sub(/^depends_on:[[:space:]]*/, "")
+              # Inline list: [a, b, c]
+              if ($0 ~ /^\[/) {
+                gsub(/[][,]/, " ")
+                print
+                next
+              }
+              # Empty value: block list follows or no deps at all.
+              if (length($0) == 0) {
+                block_mode = 1
+                next
+              }
+            }
+            f && block_mode && /^[[:space:]]*-[[:space:]]*/ {
+              sub(/^[[:space:]]*-[[:space:]]*/, "")
+              print
+              next
+            }
+            f && block_mode && /^[^[:space:]-]/ { block_mode = 0 }
+          ' "$SKILL_DIR/SKILL.md" | tr '\n' ' ')
+        fi
+      fi
+      # Build UPSTREAM list. Skip the conductor's "build" stage — it has
+      # no artifact directory, so we keep the dep visible to graph
+      # consumers but never look up a file for it. Default age 30 days
+      # (custom phases are typically less time-sensitive than core).
+      for d in $DEPS; do
+        d=$(printf '%s' "$d" | tr -d '[:space:]')
+        [ -z "$d" ] && continue
+        if [ "$d" = "build" ]; then
+          # Recorded so the output keeps the dep, but find-artifact
+          # below will never produce a hit for build.
+          UPSTREAM="${UPSTREAM:+$UPSTREAM }build:0"
+          continue
+        fi
+        UPSTREAM="${UPSTREAM:+$UPSTREAM }$d:30"
+      done
+    else
+      echo "{\"error\": \"unknown phase: $PHASE\"}" >&2
+      exit 1
+    fi
     ;;
 esac
 
@@ -132,6 +198,15 @@ for entry in $UPSTREAM; do
   if [ -n "$RESULT" ]; then
     $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
     ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":\"$RESULT\""
+    FIRST=false
+  elif [ "$PHASE_KIND" = "custom" ]; then
+    # Custom phases keep declared-but-missing deps in the output as
+    # `null` so consumers can tell "we asked for this and found
+    # nothing" apart from "this was never a dep". Core phases keep the
+    # historical "omit if missing" behavior to avoid changing the JSON
+    # shape for downstream skills.
+    $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
+    ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":null"
     FIRST=false
   fi
 done
@@ -287,6 +362,7 @@ fi
 
 jq -n \
   --arg phase "$PHASE" \
+  --arg phase_kind "$PHASE_KIND" \
   --argjson artifacts "$ARTIFACTS_JSON" \
   --argjson solutions "$SOLUTIONS_JSON" \
   --argjson precedents "$PRECEDENTS_JSON" \
@@ -296,6 +372,7 @@ jq -n \
   --argjson metrics "$METRICS_JSON" \
   '{
     phase: $phase,
+    phase_kind: $phase_kind,
     upstream_artifacts: $artifacts,
     solutions: $solutions,
     conflict_precedents: $precedents,

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -518,6 +518,24 @@ flow_phase_registry() {
   kind=$( source "$REPO/bin/lib/phases.sh" && nano_phase_kind audit-licenses )
   assert_eq "nano_phase_kind == custom for registered phase" "custom" "$kind"
 
+  # Resolver returns the custom-phase shape per the contract.
+  local resolved
+  resolved=$( "$REPO/bin/resolve.sh" audit-licenses 2>/dev/null )
+  local resolved_kind
+  resolved_kind=$( echo "$resolved" | jq -r '.phase_kind' )
+  assert_eq "resolve.sh emits phase_kind=custom" "custom" "$resolved_kind"
+
+  # Add a phase_graph so the resolver populates upstream_artifacts;
+  # build appears as null (no artifact dir), plan appears as a path.
+  printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build","plan"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json
+  "$REPO/bin/save-artifact.sh" plan \
+    '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+  resolved=$( "$REPO/bin/resolve.sh" audit-licenses 2>/dev/null )
+  assert_true "resolver: build dep renders as null" \
+    bash -c "echo '$resolved' | jq -e '.upstream_artifacts.build == null' >/dev/null"
+  assert_true "resolver: plan dep renders as a path" \
+    bash -c "echo '$resolved' | jq -e '.upstream_artifacts.plan | type == \"string\"' >/dev/null"
+
   cd "$REPO"
   unset NANOSTACK_STORE
 }

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -1,0 +1,87 @@
+# Custom Stack Contract
+
+What a custom phase guarantees and what it does not. This document is the authoritative description of how `bin/lib/phases.sh`, `bin/resolve.sh`, and the rest of the lifecycle scripts treat a phase that the user registered themselves.
+
+This contract is written incrementally. PR 1 added the registry. PR 2 (this section) adds the resolver. Later PRs extend the same surface.
+
+## Phase kinds
+
+A phase belongs to one of three kinds:
+
+| Kind | Source | Notes |
+|---|---|---|
+| `core` | The immutable list `think plan review qa security ship`. | Built into Nanostack. Cannot be redefined. |
+| `custom` | `.custom_phases` array in `.nanostack/config.json` (project) or `~/.nanostack/config.json` (global). Custom names must match `^[a-z][a-z0-9-]*$`. | The registry rejects invalid names and silently drops attempts to override a core name. |
+| `unknown` | A phase the user mentions that is not in either list. | Lifecycle scripts treat this as an error. |
+
+`bin/lib/phases.sh` is the single source of truth. Every lifecycle script reads from it.
+
+## Resolver behavior
+
+`bin/resolve.sh <phase>` returns one of three shapes.
+
+### Core phase
+
+Routing is hardcoded. Each core phase declares its upstream phases, whether to load solutions, conflict precedents, diarizations, and so on. The output keeps the historical shape and adds one new field, `phase_kind`, set to `"core"`. Skills that already consume the resolver are unaffected.
+
+### Registered custom phase
+
+Output:
+
+```json
+{
+  "phase": "audit-licenses",
+  "phase_kind": "custom",
+  "upstream_artifacts": {
+    "build": null,
+    "plan": "/path/to/plan/artifact.json",
+    "ship": null
+  },
+  "solutions": [],
+  "conflict_precedents": null,
+  "diarizations": [],
+  "config": { ... },
+  "goal": "...",
+  "sprint_metrics": null
+}
+```
+
+Rules:
+
+- `phase_kind` is `"custom"`.
+- `upstream_artifacts` is keyed on each declared dependency. The value is the artifact path if one exists within the configured age window, or `null` if the dep was declared but no artifact was found. This is different from core phases, which omit missing upstreams entirely. Custom phases keep the key so consumers can tell "we asked for this and found nothing" apart from "this was never a dep".
+- `build` is allowed in dependency lists (the conductor's build stage). It produces no artifact, so the resolver records it as `null`.
+- `solutions` is `[]`. Custom skills decide for themselves whether to load solutions; the core resolver does not run that logic for custom phases yet.
+- `conflict_precedents` is `null` and `diarizations` is `[]`. Same reasoning.
+- `config`, `goal`, and `sprint_metrics` are populated using the same logic as for core phases.
+
+The resolver exits `0`. A custom skill that runs under `set -e` can rely on the call succeeding.
+
+### Unregistered phase
+
+Output:
+
+```
+{"error": "unknown phase: <name>"}
+```
+
+Exit code `1`. This is unchanged from previous behavior and matches what `set -e` callers already expect.
+
+## Where dependencies come from
+
+The resolver looks for the custom phase's dependency list in this order:
+
+1. **`phase_graph` in `.nanostack/config.json`**. The library validates the graph (names match the regex, names exist in core ∪ custom ∪ `build`, every `depends_on[]` entry references a name that appears in the graph). Invalid graphs fall back to the default with a stderr warning, so the resolver never sees an invalid topology.
+2. **`depends_on:` in the skill's `SKILL.md` frontmatter**. Both inline (`depends_on: [plan, build]`) and block (`depends_on:\n  - plan\n  - build`) YAML list forms parse. The skill is found via `nano_phase_skill_path`.
+3. If neither lists the phase, `upstream_artifacts` is `{}`.
+
+## What the resolver does NOT do for custom phases (yet)
+
+- It does not load solutions, precedents, or diarizations. Skills that want those can call the helpers directly (`bin/find-solution.sh`, etc.).
+- It does not read custom routing rules from a config file. Routing is currently keyed on the dependency list only.
+- It does not enforce the conductor's `concurrency` field. That work belongs to PR 5 (conductor custom graph).
+- It does not check skill discovery files (`agents/openai.yaml`). That belongs to PR 3 (copy-paste template) and PR 6 (`bin/check-custom-skill.sh`).
+
+## Stability
+
+`phase_kind` is the load-bearing addition. Once shipped, downstream skills can branch on it. Future PRs may add new fields to the resolver output, but the existing shape stays — consumers should keep using `jq` field access rather than positional or shape-strict parsing.


### PR DESCRIPTION
## Summary

Second of six PRs in the Custom Stack Framework v1 round. PR 1 made the registry the single source of truth for which phases exist; this PR makes the resolver agree.

Codex's retest documented that `bin/resolve.sh` exits `1` for any phase not in its hardcoded routing table — including a phase the user just registered in `.nanostack/config.json`. Custom skills running under `set -e` abort before they reach their actual work, so the "framework" promise becomes "save an artifact, but you cannot use the resolver".

## Changes

- **`bin/resolve.sh`** sources the registry and adds a custom-phase fallback to its routing case:
  - Core phase: existing hardcoded routing table. Output gains `phase_kind="core"`; everything else unchanged.
  - Registered custom phase: `phase_kind="custom"`, `upstream_artifacts` driven by `phase_graph` or `SKILL.md` `depends_on`, solutions/precedents/diarizations empty. Exit `0`.
  - Unregistered phase: still exits `1` with the legacy `{"error": "unknown phase: ..."}` message.
- Dependency lookup prefers the project's `phase_graph` (already validated by the registry in PR 1), falls back to `SKILL.md` frontmatter `depends_on`. Both inline (`depends_on: [plan, build]`) and block (`depends_on:\n  - plan`) YAML list forms parse.
- For custom phases only, declared-but-missing upstreams render as `null` in the output so consumers can tell "we asked and found nothing" apart from "this was never a dep". Core phases keep their historical "omit if missing" shape — the JSON contract for `review`, `security`, `qa`, `ship`, `compound`, `feature` is unchanged.
- **`reference/custom-stack-contract.md`** is new and authoritative for what the registry + resolver guarantee. Future PRs (PR 4 lifecycle outputs, PR 5 conductor, PR 6 tooling) extend the same doc.

## CI lock

`resolver-custom-phase-contract` round-trips four cases on a real `/tmp` project:
- unregistered phase exits `1` with `unknown phase`
- core phase carries `phase_kind="core"`
- registered custom phase exits `0` with `phase_kind="custom"`, empty solutions/diarizations, no upstream artifacts when no graph
- `phase_graph` drives `upstream_artifacts`: `build` renders as `null`, populated `plan` renders as a path, missing `ship` renders as `null`
- back-compat: core phase resolver still omits missing upstreams (no shape change for downstream skills)

Also asserts `reference/custom-stack-contract.md` lists the load-bearing tokens.

## Test plan

- [x] tests/run.sh: 65/65 (was 59; +6 resolver tests, local only)
- [x] ci/e2e-user-flows.sh: 76/76 (was 73; +3 phase_registry cells covering the resolver path)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses

## Out of scope (PR 3-6 of the round)

- PR 3: copy-paste custom skill template fixes (path bug + `agents/openai.yaml`)
- PR 4: analytics/journal/discard-dry-run custom output
- PR 5: conductor parses `--phases` and reads `phase_graph` from config (Codex flagged cycle + duplicate-name detection as a follow-up for that PR)
- PR 6: `bin/create-skill.sh`, `bin/check-custom-skill.sh`, EXTENDING.md rewrite, `ci/e2e-custom-stack-flows.sh`