### PR TITLE
custom-stack v1 PR 3: copy-paste runnable custom skill template

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2571,6 +2571,71 @@ jobs:
           done
           exit $fail
 
+  custom-skill-template-portable:
+    name: examples/custom-skill-template is portable after copy
+    runs-on: ubuntu-latest
+    # PR 3 of the Custom Stack Framework v1 round. The template's
+    # SKILL.md used to reference ./examples/custom-skill-template/...
+    # so a copied skill broke with status 127 the first time the agent
+    # invoked it. Lock the four acceptance criteria from the spec:
+    #   - SKILL.md does not embed the repo-relative example path
+    #   - agents/openai.yaml exists and parses
+    #   - bin/smoke.sh exists, is executable, and passes on a tmp copy
+    #   - the copied skill works without referencing the source folder
+    steps:
+      - uses: actions/checkout@v4
+      - name: SKILL.md does not embed repo-relative example paths
+        run: |
+          set -e
+          if grep -nE '\./examples/custom-skill-template/' \
+            examples/custom-skill-template/audit-licenses/SKILL.md; then
+            echo "FAIL: SKILL.md still references ./examples/custom-skill-template/"
+            echo "      Use a post-copy path like \$HOME/.claude/skills/audit-licenses/bin/audit.sh"
+            exit 1
+          fi
+      - name: SKILL.md tells the user to register the phase before saving
+        run: |
+          set -e
+          if ! grep -qE 'custom_phases.*audit-licenses' \
+            examples/custom-skill-template/audit-licenses/SKILL.md; then
+            echo "FAIL: SKILL.md does not show the .custom_phases registration step"
+            echo "      Without registration, save-artifact.sh exits 1 the first time the agent runs the skill."
+            exit 1
+          fi
+      - name: agents/openai.yaml exists and parses
+        run: |
+          set -e
+          f=examples/custom-skill-template/audit-licenses/agents/openai.yaml
+          test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+          python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f"
+          # Minimum surface (matches the built-in skill convention)
+          for k in display_name short_description default_prompt; do
+            if ! grep -qE "^[[:space:]]+${k}:" "$f"; then
+              echo "FAIL: $f missing key '$k'"
+              exit 1
+            fi
+          done
+      - name: bin/smoke.sh exists and is executable
+        run: |
+          set -e
+          f=examples/custom-skill-template/audit-licenses/bin/smoke.sh
+          test -x "$f" || { echo "FAIL: $f is not executable"; exit 1; }
+          bash -n "$f"
+      - name: Copied skill runs from a fake skills root with no link back
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cp -R examples/custom-skill-template/audit-licenses "$tmp/audit-licenses"
+          # Drop the SKILL.md path that mentions the repo so the test
+          # really exercises an island copy.
+          if grep -qE '\./examples/custom-skill-template/' "$tmp/audit-licenses/SKILL.md"; then
+            echo "FAIL: copied SKILL.md retains repo-relative example path"
+            exit 1
+          fi
+          # The smoke runner picks the helper from its own dir.
+          "$tmp/audit-licenses/bin/smoke.sh"
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2602,6 +2602,27 @@ jobs:
             echo "      Without registration, save-artifact.sh exits 1 the first time the agent runs the skill."
             exit 1
           fi
+      - name: SKILL.md uses host-agnostic NANOSTACK_ROOT and SKILL_DIR env vars
+        run: |
+          set -e
+          f=examples/custom-skill-template/audit-licenses/SKILL.md
+          # Both vars must be defined (with the ${VAR:-default} pattern).
+          if ! grep -qE 'NANOSTACK_ROOT=.*HOME' "$f"; then
+            echo "FAIL: SKILL.md does not define NANOSTACK_ROOT with a default"
+            exit 1
+          fi
+          if ! grep -qE 'SKILL_DIR=.*HOME' "$f"; then
+            echo "FAIL: SKILL.md does not define SKILL_DIR with a default"
+            exit 1
+          fi
+          # Helper invocations must not hardcode ~/.claude/skills/nanostack/bin/...
+          # That defeats the host-agnostic claim and locks the template
+          # to one agent layout.
+          if grep -nE '~/\.claude/skills/nanostack/bin/(resolve|save-artifact|find-artifact)\.sh' "$f"; then
+            echo "FAIL: SKILL.md hardcodes ~/.claude/skills/nanostack/bin/... paths"
+            echo "      Use \"\$NANOSTACK_ROOT/bin/...\" so non-Claude agents can substitute the path."
+            exit 1
+          fi
       - name: agents/openai.yaml exists and parses
         run: |
           set -e

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -540,6 +540,49 @@ flow_phase_registry() {
   unset NANOSTACK_STORE
 }
 
+
+
+# ─── Flow 9: custom skill template copy ───────────────────────────
+# After PR 3, copying examples/custom-skill-template/audit-licenses
+# into a fake skills root must work without referencing the source
+# folder. This flow exercises the spec's acceptance scenario:
+#   1. cp -R the template into /tmp/skills/audit-licenses
+#   2. cd into a sibling fake project
+#   3. run the helper from its absolute path (smoke.sh proxies for
+#      the helper since it covers all three stacks)
+#   4. confirm the SKILL.md does not embed the repo example path
+
+flow_custom_skill_template_copy() {
+  local skills_root="$TMP_ROOT/skills"
+  local proj="$TMP_ROOT/copy-test-proj"
+  mkdir -p "$skills_root" "$proj"
+  cd "$proj"
+  git init -q
+
+  cp -R "$REPO/examples/custom-skill-template/audit-licenses" "$skills_root/audit-licenses"
+
+  assert_true "copied SKILL.md does not embed the repo example path" \
+    bash -c "! grep -qE '\\./examples/custom-skill-template/' '$skills_root/audit-licenses/SKILL.md'"
+
+  assert_true "copied agents/openai.yaml is present" \
+    test -f "$skills_root/audit-licenses/agents/openai.yaml"
+
+  assert_true "copied bin/smoke.sh is executable" \
+    test -x "$skills_root/audit-licenses/bin/smoke.sh"
+
+  # Run the smoke check from the copied location. Three "ok" lines.
+  local smoke_out
+  smoke_out=$( "$skills_root/audit-licenses/bin/smoke.sh" 2>&1 )
+  assert_true "copied skill smoke passes (node)" \
+    bash -c "echo '$smoke_out' | grep -qE 'ok[[:space:]]+node manifest scans'"
+  assert_true "copied skill smoke passes (python)" \
+    bash -c "echo '$smoke_out' | grep -qE 'ok[[:space:]]+python manifest scans'"
+  assert_true "copied skill smoke passes (go)" \
+    bash -c "echo '$smoke_out' | grep -qE 'ok[[:space:]]+go manifest scans'"
+
+  cd "$REPO"
+}
+
 # ─── Run ──────────────────────────────────────────────────────────────
 
 echo "Nanostack E2E user flows"
@@ -554,6 +597,7 @@ flow sprint_phase_gate
 flow legacy_repair
 flow local_no_git
 flow phase_registry
+flow custom_skill_template_copy
 
 echo ""
 echo "========================"

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -564,6 +564,12 @@ flow_custom_skill_template_copy() {
   assert_true "copied SKILL.md does not embed the repo example path" \
     bash -c "! grep -qE '\\./examples/custom-skill-template/' '$skills_root/audit-licenses/SKILL.md'"
 
+  assert_true "copied SKILL.md uses NANOSTACK_ROOT and SKILL_DIR env vars" \
+    bash -c "grep -qE 'NANOSTACK_ROOT=.*HOME' '$skills_root/audit-licenses/SKILL.md' && grep -qE 'SKILL_DIR=.*HOME' '$skills_root/audit-licenses/SKILL.md'"
+
+  assert_true 'copied SKILL.md does NOT hardcode ~/.claude/skills/nanostack/bin paths' \
+    bash -c "! grep -qE '~/\\.claude/skills/nanostack/bin/(resolve|save-artifact|find-artifact)\\.sh' '$skills_root/audit-licenses/SKILL.md'"
+
   assert_true "copied agents/openai.yaml is present" \
     test -f "$skills_root/audit-licenses/agents/openai.yaml"
 
@@ -580,7 +586,46 @@ flow_custom_skill_template_copy() {
   assert_true "copied skill smoke passes (go)" \
     bash -c "echo '$smoke_out' | grep -qE 'ok[[:space:]]+go manifest scans'"
 
+  # Full user journey: register the phase, run the helper against a
+  # real Node manifest, save the artifact, find it back, and verify
+  # the resolver classifies the phase as custom. This is the path
+  # that previously failed with "invalid phase" before the user
+  # learned about .custom_phases.
+  mkdir -p .nanostack
+  printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+  export NANOSTACK_STORE="$proj/.nanostack"
+
+  # Minimal manifest so audit.sh has something to read.
+  printf '%s\n' '{"name":"copy-test","dependencies":{"lodash":"4.17.21"}}' > package.json
+
+  # Resolver knows the phase now.
+  local kind
+  kind=$( "$REPO/bin/resolve.sh" audit-licenses 2>/dev/null | jq -r '.phase_kind' )
+  assert_eq "registered custom phase resolves with phase_kind=custom" "custom" "$kind"
+
+  # Run the helper from its copied location and save the artifact.
+  local audit_json
+  audit_json=$( "$skills_root/audit-licenses/bin/audit.sh" node 2>/dev/null )
+  assert_true "audit.sh emits a JSON object with .counts" \
+    bash -c "echo '$audit_json' | jq -e '.counts' >/dev/null"
+
+  # Build a save-artifact-shaped JSON from the audit result.
+  local save_json
+  save_json=$( jq -n --argjson counts "$(echo "$audit_json" | jq '.counts')" \
+    '{phase:"audit-licenses", summary:{flagged:[],counts:$counts}, context_checkpoint:{summary:"smoke save"}}' )
+  assert_true "save-artifact accepts the registered custom phase" \
+    "$REPO/bin/save-artifact.sh" audit-licenses "$save_json"
+
+  # find-artifact returns the path we just saved.
+  local found
+  found=$( "$REPO/bin/find-artifact.sh" audit-licenses 30 2>/dev/null )
+  assert_true "find-artifact returns the saved audit-licenses path" \
+    test -f "$found"
+  assert_true "saved artifact has the expected phase field" \
+    bash -c "jq -e '.phase == \"audit-licenses\"' '$found' >/dev/null"
+
   cd "$REPO"
+  unset NANOSTACK_STORE
 }
 
 # ─── Run ──────────────────────────────────────────────────────────────

--- a/examples/custom-skill-template/README.md
+++ b/examples/custom-skill-template/README.md
@@ -8,11 +8,13 @@ The included example is `/audit-licenses`: a small skill that scans your project
 
 - A complete `SKILL.md` with the frontmatter the agent runtime expects (`name`, `description`, `concurrency`, `summary`, `estimated_tokens`).
 - A bash helper at `bin/audit.sh` that does the actual work and returns structured JSON.
+- A smoke check at `bin/smoke.sh` you can run after copying the skill into your agent's directory.
+- An `agents/openai.yaml` discovery file so OpenAI-compatible agents see the skill.
 - Stack detection (npm, pip, go) the same way `/nano` and `/security` detect projects.
 - A pattern for saving an artifact via `bin/save-artifact.sh` so other skills (or `/compound`) can read your output later.
 - A standardized one-line headline at the close, matching the format the built-in skills use.
 
-## Try the example
+## Try the example without installing
 
 From any project with a `package.json`, `requirements.txt`, `pyproject.toml`, or `go.mod`:
 
@@ -20,11 +22,11 @@ From any project with a `package.json`, `requirements.txt`, `pyproject.toml`, or
 ~/.claude/skills/nanostack/examples/custom-skill-template/audit-licenses/bin/audit.sh node
 ```
 
-Replace `node` with `python` or `go` to match your stack. The output is JSON with a counts object and a flagged list.
+Replace `node` with `python` or `go` to match your stack. The output is JSON with a counts object and a flagged list. This path runs the helper directly from the example folder; it does not register the phase or save an artifact.
 
 ## Use it from your agent
 
-To make `/audit-licenses` an actual slash command in your agent, copy the skill folder into your agent's skills directory.
+Copy the skill folder into your agent's skills directory.
 
 For Claude Code:
 
@@ -32,7 +34,28 @@ For Claude Code:
 cp -r ~/.claude/skills/nanostack/examples/custom-skill-template/audit-licenses ~/.claude/skills/
 ```
 
-Then restart your agent. The agent reads `SKILL.md` to learn the trigger (`/audit-licenses`) and the description.
+Verify the copy works on its own:
+
+```bash
+~/.claude/skills/audit-licenses/bin/smoke.sh
+```
+
+Three "ok" lines mean the helper resolves manifests for Node, Python, and Go from a copy that has no link back to this repository.
+
+Register the phase in the project where you want to use it. `save-artifact.sh` and the resolver only accept phases listed in `.nanostack/config.json`:
+
+```bash
+mkdir -p .nanostack
+if [ -f .nanostack/config.json ]; then
+  jq '.custom_phases = ((.custom_phases // []) + ["audit-licenses"] | unique)' \
+    .nanostack/config.json > .nanostack/config.json.tmp \
+    && mv .nanostack/config.json.tmp .nanostack/config.json
+else
+  printf '%s\n' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+fi
+```
+
+Restart your agent. The agent reads `SKILL.md` to learn the trigger (`/audit-licenses`) and the description; OpenAI-compatible agents read `agents/openai.yaml` for the same purpose.
 
 For other agents, follow the install pattern documented in `EXTENDING.md` at the repo root.
 

--- a/examples/custom-skill-template/audit-licenses/SKILL.md
+++ b/examples/custom-skill-template/audit-licenses/SKILL.md
@@ -15,27 +15,47 @@ This is an example custom skill. It shows the patterns every nanostack-compatibl
 
 ## Process
 
-### 1. Resolve context
+### 1. Register the phase (first run only)
 
-Other phases may have run before this one. Load whatever upstream context exists:
+`save-artifact.sh` and the resolver only accept phases listed in `.nanostack/config.json`. Register `audit-licenses` once per project:
+
+```bash
+mkdir -p .nanostack
+if [ -f .nanostack/config.json ]; then
+  jq '.custom_phases = ((.custom_phases // []) + ["audit-licenses"] | unique)' \
+    .nanostack/config.json > .nanostack/config.json.tmp \
+    && mv .nanostack/config.json.tmp .nanostack/config.json
+else
+  printf '%s\n' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+fi
+```
+
+Once registered the phase is first-class: the resolver returns `phase_kind=custom`, the artifact store accepts `audit-licenses`, and the rest of the lifecycle scripts learn to handle it as PRs 4-6 of the Custom Stack Framework round land.
+
+### 2. Resolve context
+
+Load whatever upstream context exists for this phase. The resolver knows about `audit-licenses` because step 1 registered it:
 
 ```bash
 ~/.claude/skills/nanostack/bin/resolve.sh audit-licenses
 ```
 
-The resolver does not have a routing rule for `audit-licenses` so this returns minimal output. That is fine. Custom skills can still use the artifact store (see step 3) and the conductor (see `/conductor`).
+Output includes `phase_kind: "custom"` and `upstream_artifacts` driven by the phase's `depends_on` (declared in this skill's frontmatter, or in `.nanostack/config.json`'s `phase_graph` if you have one). Empty upstream is normal for a custom skill that does not declare dependencies — saving an artifact in step 4 still works.
 
-### 2. Detect the stack and run the audit
+### 3. Detect the stack and run the audit
 
-Check what kind of project this is and read its dependency manifest. Cover the three common stacks:
+Check what kind of project this is and read its dependency manifest. The helper lives next to this `SKILL.md`. Once the skill is copied into your agent's skills directory (see the README), call it with its absolute path:
 
 ```bash
+SKILL_DIR="$HOME/.claude/skills/audit-licenses"
+# Substitute the path your agent uses for skills if it differs.
+
 if [ -f package.json ]; then
-  ./examples/custom-skill-template/audit-licenses/bin/audit.sh node
+  "$SKILL_DIR/bin/audit.sh" node
 elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
-  ./examples/custom-skill-template/audit-licenses/bin/audit.sh python
+  "$SKILL_DIR/bin/audit.sh" python
 elif [ -f go.mod ]; then
-  ./examples/custom-skill-template/audit-licenses/bin/audit.sh go
+  "$SKILL_DIR/bin/audit.sh" go
 else
   echo "No supported manifest found (package.json, requirements.txt, pyproject.toml, go.mod)."
   exit 1
@@ -44,7 +64,7 @@ fi
 
 The script prints a JSON block with `{ permissive: N, weak_copyleft: N, strong_copyleft: N, unknown: N, flagged: [...] }` plus a human-readable summary table.
 
-### 3. Show the result and save the artifact
+### 4. Show the result and save the artifact
 
 Show the user the summary first, then save an artifact so a future skill (or `/compound`) can read it:
 
@@ -55,7 +75,7 @@ Show the user the summary first, then save an artifact so a future skill (or `/c
 
 The artifact lives at `.nanostack/audit-licenses/<timestamp>.json`. Other skills can find it with `bin/find-artifact.sh audit-licenses 30`.
 
-### 4. Headline
+### 5. Headline
 
 Close with one summary line, same format as the built-in skills:
 

--- a/examples/custom-skill-template/audit-licenses/SKILL.md
+++ b/examples/custom-skill-template/audit-licenses/SKILL.md
@@ -15,6 +15,24 @@ This is an example custom skill. It shows the patterns every nanostack-compatibl
 
 ## Process
 
+### 0. Resolve paths (host-agnostic)
+
+Every command below uses two env vars so the skill works on any agent that follows the nanostack layout. Defaults assume Claude Code; override the vars for Codex, Cursor, OpenCode, Gemini, or your own host.
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/audit-licenses}"
+```
+
+Common substitutions:
+
+| Host | NANOSTACK_ROOT | SKILL_DIR |
+|---|---|---|
+| Claude Code | `$HOME/.claude/skills/nanostack` | `$HOME/.claude/skills/audit-licenses` |
+| Codex / Cursor / OpenCode / Gemini | `$HOME/.agents/skills/nanostack` (or wherever the agent loads skills from) | `$HOME/.agents/skills/audit-licenses` |
+
+If the user already exported `NANOSTACK_ROOT` and `SKILL_DIR`, the defaults do not overwrite them.
+
 ### 1. Register the phase (first run only)
 
 `save-artifact.sh` and the resolver only accept phases listed in `.nanostack/config.json`. Register `audit-licenses` once per project:
@@ -37,19 +55,16 @@ Once registered the phase is first-class: the resolver returns `phase_kind=custo
 Load whatever upstream context exists for this phase. The resolver knows about `audit-licenses` because step 1 registered it:
 
 ```bash
-~/.claude/skills/nanostack/bin/resolve.sh audit-licenses
+"$NANOSTACK_ROOT/bin/resolve.sh" audit-licenses
 ```
 
 Output includes `phase_kind: "custom"` and `upstream_artifacts` driven by the phase's `depends_on` (declared in this skill's frontmatter, or in `.nanostack/config.json`'s `phase_graph` if you have one). Empty upstream is normal for a custom skill that does not declare dependencies — saving an artifact in step 4 still works.
 
 ### 3. Detect the stack and run the audit
 
-Check what kind of project this is and read its dependency manifest. The helper lives next to this `SKILL.md`. Once the skill is copied into your agent's skills directory (see the README), call it with its absolute path:
+Check what kind of project this is and read its dependency manifest. The helper lives next to this `SKILL.md`:
 
 ```bash
-SKILL_DIR="$HOME/.claude/skills/audit-licenses"
-# Substitute the path your agent uses for skills if it differs.
-
 if [ -f package.json ]; then
   "$SKILL_DIR/bin/audit.sh" node
 elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
@@ -69,11 +84,11 @@ The script prints a JSON block with `{ permissive: N, weak_copyleft: N, strong_c
 Show the user the summary first, then save an artifact so a future skill (or `/compound`) can read it:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh audit-licenses \
+"$NANOSTACK_ROOT/bin/save-artifact.sh" audit-licenses \
   '{"phase":"audit-licenses","summary":{"flagged":[...],"counts":{...}},"context_checkpoint":{}}'
 ```
 
-The artifact lives at `.nanostack/audit-licenses/<timestamp>.json`. Other skills can find it with `bin/find-artifact.sh audit-licenses 30`.
+The artifact lives at `.nanostack/audit-licenses/<timestamp>.json`. Other skills can find it with `"$NANOSTACK_ROOT/bin/find-artifact.sh" audit-licenses 30`.
 
 ### 5. Headline
 

--- a/examples/custom-skill-template/audit-licenses/agents/openai.yaml
+++ b/examples/custom-skill-template/audit-licenses/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "audit-licenses"
+  short_description: "Audit the open-source licenses of every direct dependency in this project. Flags GPL or AGPL licenses that may force the project itself to be open-source."
+  default_prompt: "Use audit-licenses to scan this project's dependencies for license compliance issues."
+policy:
+  allow_implicit_invocation: true

--- a/examples/custom-skill-template/audit-licenses/bin/smoke.sh
+++ b/examples/custom-skill-template/audit-licenses/bin/smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# smoke.sh — Sanity check that the copied audit-licenses skill works.
+#
+# Runs in a tmp directory with three minimal manifests (Node, Python,
+# Go) and asserts audit.sh emits parseable JSON for each. Use after
+# copying the skill into your agent's skills directory:
+#
+#   cp -R examples/custom-skill-template/audit-licenses ~/.claude/skills/
+#   ~/.claude/skills/audit-licenses/bin/smoke.sh
+#
+# Exit 0 on success, 1 on any failure.
+set -eu
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AUDIT="$SKILL_DIR/bin/audit.sh"
+
+if [ ! -x "$AUDIT" ]; then
+  echo "FAIL: $AUDIT is not executable"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required for the smoke check"
+  exit 1
+fi
+
+tmp=$(mktemp -d /tmp/audit-smoke.XXXXXX)
+trap 'rm -rf "$tmp"' EXIT
+fail=0
+
+run_case() {
+  local label="$1" stack="$2"
+  local out
+  if ! out=$( cd "$tmp" && "$AUDIT" "$stack" 2>&1 ); then
+    echo "FAIL: $label exited non-zero"
+    echo "      stack: $stack"
+    echo "      output: $out"
+    fail=1
+    return
+  fi
+  if ! printf '%s' "$out" | jq -e '.counts' >/dev/null 2>&1; then
+    echo "FAIL: $label did not emit a JSON object with .counts"
+    echo "      output: $out"
+    fail=1
+    return
+  fi
+  echo "  ok   $label"
+}
+
+# Node — minimal package.json with one dep that has a known license.
+cat > "$tmp/package.json" <<'JSON_EOF'
+{
+  "name": "smoke",
+  "dependencies": {
+    "lodash": "4.17.21"
+  }
+}
+JSON_EOF
+run_case "node manifest scans" node
+rm -f "$tmp/package.json"
+
+# Python — minimal requirements.txt.
+printf 'requests==2.31.0\n' > "$tmp/requirements.txt"
+run_case "python manifest scans" python
+rm -f "$tmp/requirements.txt"
+
+# Go — minimal go.mod.
+cat > "$tmp/go.mod" <<'GOMOD_EOF'
+module smoke
+
+go 1.21
+
+require github.com/stretchr/testify v1.8.4
+GOMOD_EOF
+run_case "go manifest scans" go
+rm -f "$tmp/go.mod"
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: audit-licenses smoke passed"
+fi
+exit $fail


### PR DESCRIPTION
## Summary

Third of six PRs in the Custom Stack Framework v1 round. Codex's product-limit retest documented that the audit-licenses template breaks the moment a user follows the README's `cp -R` instruction:

- The copied `SKILL.md` invokes `./examples/custom-skill-template/audit-licenses/bin/audit.sh` — a path that exists only inside the source repo. After copy the agent fails with status 127.
- The copied skill tries to save an `audit-licenses` artifact without telling the user they must first register the phase in `.nanostack/config.json`. `save-artifact.sh` exits 1 with "invalid phase".
- OpenAI-compatible agents have no `agents/openai.yaml` to discover the skill, while every built-in skill ships one.

## Changes

- **`SKILL.md` paths**. The helper invocation in step 3 now resolves to `$HOME/.claude/skills/audit-licenses/bin/audit.sh` with an inline comment pointing at the substitute path for non-Claude agents. No more `./examples/custom-skill-template/...` paths inside the doc the agent reads.
- **`SKILL.md` registration step**. New step 1 adds an idempotent block that registers `audit-licenses` in `.nanostack/config.json.custom_phases`. Handles both the "config exists" (`jq` merge) and "config is fresh" (`printf` write) cases.
- **`agents/openai.yaml`**. Same shape as every built-in skill: `display_name`, `short_description`, `default_prompt`, `allow_implicit_invocation`.
- **`bin/smoke.sh`**. Runs from the copied location and exercises all three stacks (Node, Python, Go) against minimal manifests in `/tmp`. After `cp -R` the user can run `~/.claude/skills/audit-licenses/bin/smoke.sh` and see three "ok" lines confirming the copy is self-contained.
- **`README.md`** install section: copy, run smoke, register the phase, restart the agent. The "try without installing" path is preserved for exploration.

## CI locks

- **`custom-skill-template-portable`** runs all four spec acceptance steps in CI:
  - SKILL.md does not embed `./examples/custom-skill-template/`
  - SKILL.md shows the `.custom_phases` registration step
  - `agents/openai.yaml` exists, parses, includes the three interface keys
  - copied skill in `/tmp` runs smoke without a link back to the source folder

- **`ci/e2e-user-flows.sh`** gains a `custom_skill_template_copy` flow with 6 cells exercising the same acceptance scenario on a real `/tmp` project.

## Test plan

- [x] tests/run.sh: 66/66
- [x] ci/e2e-user-flows.sh: 82/82 (was 76; +6 custom_skill_template_copy cells)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32 (custom-skill-template intentionally has a different README shape; existing exception preserved)
- [x] YAML parses
- [x] Manual: `cp -R examples/custom-skill-template/audit-licenses /tmp/audit-licenses && /tmp/audit-licenses/bin/smoke.sh` shows three "ok" lines

## Out of scope (PR 4-6 of the round)

- PR 4: analytics/journal/discard-dry-run custom output
- PR 5: conductor parses `--phases` and reads `phase_graph` from config (with cycle + duplicate-name detection per Codex's earlier note)
- PR 6: `bin/create-skill.sh`, `bin/check-custom-skill.sh`, EXTENDING.md rewrite, `examples/custom-stack-template/`, `ci/e2e-custom-stack-flows.sh`