### PR TITLE
custom-stack v1 PR 4: lifecycle outputs surface custom phases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2701,6 +2701,74 @@ jobs:
           # The smoke runner picks the helper from its own dir.
           "$tmp/audit-licenses/bin/smoke.sh"
 
+  lifecycle-custom-phase-outputs:
+    name: analytics + sprint-journal + discard-sprint emit custom phase data
+    runs-on: ubuntu-latest
+    # PR 4 of the Custom Stack Framework v1 round. Codex's retest
+    # documented that analytics returned total=0 even with custom
+    # artifacts saved, sprint-journal silently omitted custom phase
+    # sections, and default discard missed custom artifacts. PR 1
+    # already fixed default discard via the registry migration; PR 4
+    # finishes analytics + journal and locks the round-trip.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Migrated scripts source the phase registry
+        run: |
+          set -e
+          fail=0
+          for f in bin/analytics.sh bin/sprint-journal.sh; do
+            if ! grep -qE 'lib/phases\.sh' "$f"; then
+              echo "FAIL: $f does not source bin/lib/phases.sh"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Lifecycle round-trip on a real /tmp project
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack
+          export NANOSTACK_STORE="$tmp/.nanostack"
+
+          # Register a custom phase, save one core + one custom artifact.
+          printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+          "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan \
+            '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+          "$GITHUB_WORKSPACE/bin/save-artifact.sh" audit-licenses \
+            '{"phase":"audit-licenses","summary":{"status":"OK","headline":"47 deps scanned, 0 GPL/AGPL flagged"},"context_checkpoint":{"summary":"ok"}}' >/dev/null
+
+          # analytics: total includes custom; core_total/custom_total split.
+          out=$("$GITHUB_WORKSPACE/bin/analytics.sh" --json)
+          echo "$out" | jq -e '.sprints.plan == 1' >/dev/null
+          echo "$out" | jq -e '.sprints.core_total == 1' >/dev/null
+          echo "$out" | jq -e '.sprints."custom"."audit-licenses" == 1' >/dev/null
+          echo "$out" | jq -e '.sprints.custom_total == 1' >/dev/null
+          echo "$out" | jq -e '.sprints.total == 2' >/dev/null
+
+          # sprint-journal: emits /<phase> section with status + headline.
+          journal=$("$GITHUB_WORKSPACE/bin/sprint-journal.sh")
+          test -f "$journal"
+          grep -qF '## /audit-licenses' "$journal"
+          grep -qF '**Status:** OK' "$journal"
+          grep -qF '47 deps scanned, 0 GPL/AGPL flagged' "$journal"
+          grep -qF '**Artifact:**' "$journal"
+
+          # discard-sprint: default --dry-run includes the custom file.
+          out=$("$GITHUB_WORKSPACE/bin/discard-sprint.sh" --dry-run)
+          echo "$out" | grep -qF 'audit-licenses'
+          echo "$out" | grep -qF 'plan'
+
+          # Backward compat: with no custom_phases registered, analytics
+          # JSON's `total` equals `core_total` and `custom` is {}.
+          echo '{}' > .nanostack/config.json
+          out=$("$GITHUB_WORKSPACE/bin/analytics.sh" --json)
+          echo "$out" | jq -e '.sprints.custom == {}' >/dev/null
+          echo "$out" | jq -e '.sprints.custom_total == 0' >/dev/null
+          echo "$out" | jq -e '.sprints.total == .sprints.core_total' >/dev/null
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/bin/analytics.sh
+++ b/bin/analytics.sh
@@ -6,6 +6,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
 
 STORE="$NANOSTACK_STORE"
 KNOW_HOW="$NANOSTACK_STORE/know-how"
@@ -50,14 +51,31 @@ count_phase() {
   echo "$count"
 }
 
-# Collect stats
+# Collect stats — core phases keep their named fields for backward
+# compatibility; custom phases are tallied separately below.
 THINK=$(count_phase think)
 PLAN=$(count_phase plan)
 REVIEW=$(count_phase review)
 QA=$(count_phase qa)
 SECURITY=$(count_phase security)
 SHIP=$(count_phase ship)
-TOTAL=$((THINK + PLAN + REVIEW + QA + SECURITY + SHIP))
+CORE_TOTAL=$((THINK + PLAN + REVIEW + QA + SECURITY + SHIP))
+
+# Custom phases come from .custom_phases in .nanostack/config.json.
+# Build a JSON object {phase: count} and a running custom_total. An
+# empty object is the right default when no custom phases are
+# registered, so existing consumers see the same shape.
+CUSTOM_JSON="{}"
+CUSTOM_TOTAL=0
+CUSTOM_PHASES=$(nano_custom_phases 2>/dev/null)
+if [ -n "$CUSTOM_PHASES" ]; then
+  for phase in $CUSTOM_PHASES; do
+    n=$(count_phase "$phase")
+    CUSTOM_JSON=$(echo "$CUSTOM_JSON" | jq --arg p "$phase" --argjson n "$n" '. + {($p): $n}')
+    CUSTOM_TOTAL=$((CUSTOM_TOTAL + n))
+  done
+fi
+TOTAL=$((CORE_TOTAL + CUSTOM_TOTAL))
 
 # Mode breakdown from review/qa/security
 count_mode() {
@@ -114,13 +132,22 @@ if $JSON_OUTPUT; then
     --argjson security "$SECURITY" \
     --argjson ship "$SHIP" \
     --argjson total "$TOTAL" \
+    --argjson core_total "$CORE_TOTAL" \
+    --argjson custom_total "$CUSTOM_TOTAL" \
+    --argjson custom "$CUSTOM_JSON" \
     --argjson quick "$QUICK" \
     --argjson standard "$STANDARD" \
     --argjson thorough "$THOROUGH" \
     --arg last_security "$LAST_SECURITY" \
     '{
       month: $month,
-      sprints: { think: $think, plan: $plan, review: $review, qa: $qa, security: $security, ship: $ship, total: $total },
+      sprints: {
+        think: $think, plan: $plan, review: $review, qa: $qa, security: $security, ship: $ship,
+        core_total: $core_total,
+        custom: $custom,
+        custom_total: $custom_total,
+        total: $total
+      },
       modes: { quick: $quick, standard: $standard, thorough: $thorough },
       last_security_findings: $last_security
     }')
@@ -161,6 +188,16 @@ echo "  review      $REVIEW"
 echo "  qa          $QA"
 echo "  security    $SECURITY"
 echo "  ship        $SHIP"
+if [ -n "$CUSTOM_PHASES" ]; then
+  for phase in $CUSTOM_PHASES; do
+    n=$(echo "$CUSTOM_JSON" | jq -r --arg p "$phase" '.[$p] // 0')
+    # %-12s pads short names to the core-column width; long names
+    # (e.g. audit-licenses) overflow and still keep one separator
+    # space before the count thanks to the trailing space in the
+    # format string.
+    printf "  %-12s %s\n" "$phase" "$n"
+  done
+fi
 echo "  total       $TOTAL"
 echo ""
 echo "  Intensity modes"
@@ -222,6 +259,12 @@ if $OBSIDIAN_OUTPUT; then
     echo "| qa | $QA |"
     echo "| security | $SECURITY |"
     echo "| ship | $SHIP |"
+    if [ -n "$CUSTOM_PHASES" ]; then
+      for phase in $CUSTOM_PHASES; do
+        n=$(echo "$CUSTOM_JSON" | jq -r --arg p "$phase" '.[$p] // 0')
+        echo "| $phase | $n |"
+      done
+    fi
     echo "| **total** | **$TOTAL** |"
     echo ""
     echo "## Intensity Modes"

--- a/bin/sprint-journal.sh
+++ b/bin/sprint-journal.sh
@@ -6,6 +6,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
 
 STORE="$NANOSTACK_STORE"
 KNOW_HOW="$NANOSTACK_STORE/know-how"
@@ -164,6 +165,39 @@ numfield() {
     [ -n "$PR" ] && echo "**PR:** #$PR | **Status:** $STATUS | **CI:** $CI"
     echo ""
   fi
+
+  # Custom phases — generic sections after the core ones. Skills that
+  # save artifacts with .summary.status / .summary.headline /
+  # .summary.result / .summary.next_action get those fields surfaced.
+  # If none of those are populated, the section falls back to a
+  # compact JSON dump of the .summary object so the entry is never
+  # silently empty.
+  CUSTOM_PHASES=$(nano_custom_phases 2>/dev/null)
+  for phase in $CUSTOM_PHASES; do
+    [ -z "$phase" ] && continue
+    CUSTOM_FILE=$(find_latest "$phase")
+    [ -z "$CUSTOM_FILE" ] && continue
+    echo "## /$phase"
+    echo ""
+    C_STATUS=$(field '.summary.status' "$CUSTOM_FILE")
+    C_HEADLINE=$(field '.summary.headline' "$CUSTOM_FILE")
+    C_RESULT=$(field '.summary.result' "$CUSTOM_FILE")
+    C_NEXT=$(field '.summary.next_action' "$CUSTOM_FILE")
+    [ -n "$C_STATUS" ] && echo "**Status:** $C_STATUS"
+    if [ -n "$C_HEADLINE" ]; then
+      echo "**Summary:** $C_HEADLINE"
+    elif [ -n "$C_RESULT" ]; then
+      echo "**Summary:** $C_RESULT"
+    elif [ -z "$C_STATUS" ]; then
+      # No structured field — emit a compact JSON dump so the section
+      # still carries information.
+      C_JSON=$(jq -c '.summary // {}' "$CUSTOM_FILE" 2>/dev/null || echo "{}")
+      echo "**Summary:** \`$C_JSON\`"
+    fi
+    [ -n "$C_NEXT" ] && echo "**Next:** $C_NEXT"
+    echo "**Artifact:** $CUSTOM_FILE"
+    echo ""
+  done
 
   # Lessons section (empty, for manual fill)
   echo "## Lessons"

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -525,6 +525,29 @@ flow_phase_registry() {
   resolved_kind=$( echo "$resolved" | jq -r '.phase_kind' )
   assert_eq "resolve.sh emits phase_kind=custom" "custom" "$resolved_kind"
 
+  # Lifecycle round-trip with one custom artifact saved (PR 4): analytics
+  # counts it, sprint-journal emits a section for it, default discard
+  # --dry-run includes its file path.
+  "$REPO/bin/save-artifact.sh" audit-licenses \
+    '{"phase":"audit-licenses","summary":{"status":"OK","headline":"smoke audit"},"context_checkpoint":{"summary":"ok"}}' \
+    >/dev/null
+  local analytics_json
+  analytics_json=$( "$REPO/bin/analytics.sh" --json )
+  assert_true "analytics.sprints.custom.audit-licenses == 1" \
+    bash -c "echo '$analytics_json' | jq -e '.sprints.\"custom\".\"audit-licenses\" == 1' >/dev/null"
+  assert_true "analytics.sprints.total includes the custom count" \
+    bash -c "echo '$analytics_json' | jq -e '.sprints.total >= 1' >/dev/null"
+  local journal_path
+  journal_path=$( "$REPO/bin/sprint-journal.sh" )
+  assert_true "sprint-journal emits a /audit-licenses section" \
+    bash -c "grep -qF '## /audit-licenses' '$journal_path'"
+  assert_true "sprint-journal includes the custom artifact path" \
+    bash -c "grep -qF 'Artifact:' '$journal_path'"
+  local discard_out
+  discard_out=$( "$REPO/bin/discard-sprint.sh" --dry-run )
+  assert_true "default discard --dry-run includes the custom artifact" \
+    bash -c "echo '$discard_out' | grep -qF 'audit-licenses'"
+
   # Add a phase_graph so the resolver populates upstream_artifacts;
   # build appears as null (no artifact dir), plan appears as a path.
   printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build","plan"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -82,6 +82,60 @@ The resolver looks for the custom phase's dependency list in this order:
 - It does not enforce the conductor's `concurrency` field. That work belongs to PR 5 (conductor custom graph).
 - It does not check skill discovery files (`agents/openai.yaml`). That belongs to PR 3 (copy-paste template) and PR 6 (`bin/check-custom-skill.sh`).
 
+## Lifecycle outputs
+
+`bin/analytics.sh`, `bin/sprint-journal.sh`, and `bin/discard-sprint.sh` each include registered custom phases.
+
+### Analytics
+
+`bin/analytics.sh --json` adds three fields to the existing `sprints` object:
+
+```json
+{
+  "sprints": {
+    "think": 1, "plan": 1, "review": 1, "qa": 1, "security": 1, "ship": 1,
+    "core_total": 6,
+    "custom": { "audit-licenses": 1 },
+    "custom_total": 1,
+    "total": 7
+  }
+}
+```
+
+Rules:
+
+- The six core phase keys keep their historical names and counts. Existing consumers see no shape change.
+- `core_total` is the sum of the six core counts. `custom_total` is the sum of all registered custom phases. `total` is the sum of both.
+- `custom` is an object keyed on registered custom phase names. With no registered custom phases, it is `{}` and `custom_total` is `0`. In that case `total` equals `core_total`, matching the historical behavior.
+
+The text and Obsidian-dashboard outputs add one row per registered custom phase under the existing "Sprint phases" block.
+
+### Sprint journal
+
+`bin/sprint-journal.sh` emits the existing `/think`, `/plan`, `/review`, `/qa`, `/security`, `/ship` sections for core phases, then iterates over registered custom phases and emits a generic section per phase that has an artifact for the current project:
+
+```
+## /audit-licenses
+
+**Status:** OK
+**Summary:** 47 deps scanned, 0 GPL/AGPL flagged
+**Next:** none
+**Artifact:** .nanostack/audit-licenses/20260426-145855.json
+```
+
+Field resolution order for the section body:
+
+- **Status** — `summary.status`. Skipped if absent.
+- **Summary** — first hit of `summary.headline`, then `summary.result`. If both are missing AND `summary.status` is also missing, falls back to a compact JSON dump of `summary` so the section is never silently empty.
+- **Next** — `summary.next_action`. Skipped if absent.
+- **Artifact** — always present, full path to the JSON file.
+
+A custom phase with no artifact for the current project produces no section.
+
+### Discard
+
+`bin/discard-sprint.sh --dry-run` (no `--phase` flag) iterates over every registered phase, core and custom, and lists `[dry-run] would delete: <path>` for each artifact in the date window. Without registered custom phases this is identical to the historical behavior; with custom phases registered, the default discard cleans them too. The explicit `--phase <name>` flag still narrows to a single phase.
+
 ## Stability
 
 `phase_kind` is the load-bearing addition. Once shipped, downstream skills can branch on it. Future PRs may add new fields to the resolver output, but the existing shape stays — consumers should keep using `jq` field access rather than positional or shape-strict parsing.


### PR DESCRIPTION
## Summary

Fourth of six PRs in the Custom Stack Framework v1 round. Codex's product-limit retest documented three lifecycle scripts that ignored registered custom phases:

- `bin/analytics.sh --json` returned `total=0` even when `audit-licenses` artifacts existed for the month.
- `bin/sprint-journal.sh` emitted core sections only; custom work silently disappeared from the journal.
- `bin/discard-sprint.sh` default behavior missed custom artifacts (PR 1's registry migration already closed this; PR 4 locks the contract round-trip).

## Changes

- **`bin/analytics.sh`** sources the registry and counts every registered custom phase. JSON `sprints` object gains three fields: `core_total`, `custom` (a `{phase: count}` map), `custom_total`. The six historical core keys keep their names and counts. `total` is now the sum of core + custom; with no registered custom phases, `total` equals `core_total` and `custom` is `{}` — same effective shape as before. Text + Obsidian dashboard outputs add one row per custom phase under "Sprint phases".
- **`bin/sprint-journal.sh`** sources the registry and, after the existing core sections, iterates registered custom phases and emits a generic section per phase that has an artifact for the project:

  ```
  ## /audit-licenses

  **Status:** OK
  **Summary:** 47 deps scanned, 0 GPL/AGPL flagged
  **Next:** none
  **Artifact:** .nanostack/audit-licenses/20260426-145855.json
  ```

  Field resolution: `summary.status`, then `summary.headline` (falls back to `summary.result`), `summary.next_action`, full artifact path. If neither `status` nor `headline`/`result` is populated, the section falls back to a compact JSON dump of `summary` so the entry is never silently empty.
- **`reference/custom-stack-contract.md`** grows a "Lifecycle outputs" section documenting each script's behavior, the field resolution rules, and the backward-compat invariants.

## CI lock

`lifecycle-custom-phase-outputs` runs the spec's PR 4 acceptance round-trip on a real `/tmp` project:

- Register one custom phase, save one core + one custom artifact.
- Assert `analytics --json` shape: `core_total=1`, `custom["audit-licenses"]=1`, `custom_total=1`, `total=2`, plus the unchanged core fields.
- Assert `sprint-journal.sh` emits a `## /audit-licenses` section with `**Status:** OK`, the headline, and an `**Artifact:**` line.
- Assert `discard-sprint.sh --dry-run` (no `--phase` flag) lists both `plan` and `audit-licenses` files.
- Backward compat: with no `custom_phases` registered, `analytics --json` has `custom == {}`, `custom_total == 0`, and `total == core_total`.

`ci/e2e-user-flows.sh` `phase_registry` flow gains five cells covering the same round-trip.

## Test plan

- [x] tests/run.sh: 72/72 (was 66; +6 PR 4 tests, local only)
- [x] ci/e2e-user-flows.sh: 96/96 (was 91; +5 lifecycle round-trip cells)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses

## Out of scope (PRs 5-6 of the round)

- PR 5: conductor parses `--phases` and reads `phase_graph` from config (with cycle + duplicate-name detection per Codex's earlier note)
- PR 6: `bin/create-skill.sh`, `bin/check-custom-skill.sh`, `examples/custom-stack-template/`, EXTENDING.md rewrite, `ci/e2e-custom-stack-flows.sh`

After this PR merges, the public phrasing rule from the spec relaxes for analytics + journal: we can finally claim those work with custom phases, because the harness proves it. Conductor + tooling stay marked "being hardened" until PRs 5-6 land.