### PR TITLE
custom-stack v1 PR 5: conductor parses --phases and reads phase_graph

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2769,6 +2769,110 @@ jobs:
           echo "$out" | jq -e '.sprints.custom_total == 0' >/dev/null
           echo "$out" | jq -e '.sprints.total == .sprints.core_total' >/dev/null
 
+  conductor-custom-graph:
+    name: conductor parses --phases and reads phase_graph from config
+    runs-on: ubuntu-latest
+    # PR 5 of the Custom Stack Framework v1 round. Codex's retest
+    # showed that conductor accepted --phases syntactically but
+    # always used DEFAULT_PHASES and that cmd_batch only resolved
+    # built-in skill paths. This lock proves the runtime contract:
+    #   1. --phases inline JSON wins
+    #   2. --phases from a file works
+    #   3. config.phase_graph drives the sprint when no --phases
+    #   4. cmd_batch reads custom skill concurrency from skill_roots
+    #   5. cycles + duplicate names are rejected up-front (exit 2)
+    steps:
+      - uses: actions/checkout@v4
+      - name: cmd_start sources the phase registry
+        run: |
+          set -e
+          if ! grep -qE 'lib/phases\.sh' conductor/bin/sprint.sh; then
+            echo "FAIL: conductor/bin/sprint.sh does not source bin/lib/phases.sh"
+            exit 1
+          fi
+          # cmd_start must call _nano_phase_graph_is_valid OR
+          # nano_phase_graph_json — otherwise --phases bypasses
+          # validation and the bad-graph cases below would pass.
+          if ! grep -qE '_nano_phase_graph_is_valid|nano_phase_graph_json' conductor/bin/sprint.sh; then
+            echo "FAIL: conductor does not call into the registry validator"
+            exit 1
+          fi
+      - name: Round-trip the conductor custom-graph contract
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cd "$tmp"
+          git init -q
+          mkdir -p .nanostack/skills/audit-licenses
+          export NANOSTACK_STORE="$tmp/.nanostack"
+
+          # Custom skill on disk so cmd_batch can read its concurrency.
+          cat > .nanostack/skills/audit-licenses/SKILL.md <<'SKILLEOF'
+          name: audit-licenses
+          concurrency: read
+          depends_on: [build]
+          SKILLEOF
+          # Frontmatter delimiters need to live at column 0 inside the
+          # heredoc; the YAML lint will reject literal `---` there. Use
+          # printf to inject them around the body.
+          printf '%s\n' '---' > /tmp/skill-fm.txt
+          cat .nanostack/skills/audit-licenses/SKILL.md >> /tmp/skill-fm.txt
+          printf '%s\n' '---' >> /tmp/skill-fm.txt
+          mv /tmp/skill-fm.txt .nanostack/skills/audit-licenses/SKILL.md
+
+          # Case A: --phases inline JSON drives the sprint topology.
+          printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
+            --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build"]},{"name":"ship","depends_on":["audit-licenses"]}]' \
+            >/dev/null
+          status=$("$GITHUB_WORKSPACE/conductor/bin/sprint.sh" status)
+          echo "$status" | jq -e '.phases | has("audit-licenses")' >/dev/null
+          echo "$status" | jq -e '.phases | length == 5' >/dev/null
+
+          # Case B: cmd_batch reads custom skill concurrency=read.
+          out=$("$GITHUB_WORKSPACE/conductor/bin/sprint.sh" batch 2>&1)
+          # audit-licenses must appear in a batch with type=read.
+          if ! echo "$out" | grep -qE '"type":"read".*"phases":\[[^]]*"audit-licenses"'; then
+            if ! echo "$out" | grep -qE '"phases":\[[^]]*"audit-licenses"[^]]*\].*"type":"read"'; then
+              echo "FAIL: audit-licenses not scheduled as concurrency=read"
+              echo "$out"
+              exit 1
+            fi
+          fi
+
+          # Case C: --phases from a file path.
+          echo '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"ship","depends_on":["build"]}]' > /tmp/cond-graph.json
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start --phases /tmp/cond-graph.json >/dev/null
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" status \
+            | jq -e '.phases | length == 4' >/dev/null
+          rm -f /tmp/cond-graph.json
+
+          # Case D: phase_graph from config drives the sprint when no
+          # --phases is given.
+          printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"audit-licenses","depends_on":["think"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start >/dev/null
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" status \
+            | jq -e '.phases | length == 3' >/dev/null
+
+          # Case E: cycle is rejected with exit 2 (no sprint created).
+          out=$("$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
+            --phases '[{"name":"think","depends_on":["plan"]},{"name":"plan","depends_on":["think"]}]' 2>&1) && {
+              echo "FAIL: conductor accepted a cycle"
+              exit 1
+            }
+          echo "$out" | grep -qF 'invalid phase graph' || {
+            echo "FAIL: rejection message does not say 'invalid phase graph'"
+            exit 1
+          }
+
+          # Case F: duplicate name is rejected.
+          "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
+            --phases '[{"name":"think","depends_on":[]},{"name":"think","depends_on":[]}]' 2>&1 && {
+              echo "FAIL: conductor accepted duplicate names"
+              exit 1
+            }
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2518,7 +2518,12 @@ jobs:
 
           # phase_graph drives upstream_artifacts. plan present, build
           # always null (no artifact dir), ship missing renders null.
-          printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build","plan","ship"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json
+          # Acyclic graph: ship depends on build (not on audit-licenses),
+          # so audit-licenses can declare build/plan/ship as upstreams
+          # without forming a cycle. With only `plan` saved, the
+          # resolver must still emit `build` and `ship` keys with null
+          # values for custom phases.
+          printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"ship","depends_on":["build"]},{"name":"audit-licenses","depends_on":["build","plan","ship"]}]}' > .nanostack/config.json
           "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
           out=$("$GITHUB_WORKSPACE/bin/resolve.sh" audit-licenses 2>/dev/null)
           echo "$out" | jq -e '.upstream_artifacts.build == null' >/dev/null
@@ -2856,22 +2861,74 @@ jobs:
             | jq -e '.phases | length == 3' >/dev/null
 
           # Case E: cycle is rejected with exit 2 (no sprint created).
-          out=$("$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
-            --phases '[{"name":"think","depends_on":["plan"]},{"name":"plan","depends_on":["think"]}]' 2>&1) && {
-              echo "FAIL: conductor accepted a cycle"
-              exit 1
-            }
-          echo "$out" | grep -qF 'invalid phase graph' || {
-            echo "FAIL: rejection message does not say 'invalid phase graph'"
+          # Use `if cmd; then fail; fi` so set -e does not terminate
+          # the step on the expected non-zero exit; the assignment
+          # form `out=$(cmd) && body` propagates cmd's exit code at
+          # the step level.
+          err_log=$(mktemp)
+          if "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
+            --phases '[{"name":"think","depends_on":["plan"]},{"name":"plan","depends_on":["think"]}]' \
+            >/dev/null 2>"$err_log"; then
+            echo "FAIL: conductor accepted a cycle"
+            cat "$err_log"
             exit 1
-          }
+          fi
+          if ! grep -qF 'invalid phase graph' "$err_log"; then
+            echo "FAIL: rejection message does not say 'invalid phase graph'"
+            cat "$err_log"
+            exit 1
+          fi
 
           # Case F: duplicate name is rejected.
+          if "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
+            --phases '[{"name":"think","depends_on":[]},{"name":"think","depends_on":[]}]' \
+            >/dev/null 2>&1; then
+            echo "FAIL: conductor accepted duplicate names"
+            exit 1
+          fi
+
+          # Case G: invalid phase_graph in config aborts (fail-closed).
+          # Silent fallback to the default would mask a real config bug.
+          printf '%s' '{"phase_graph":[{"name":"think","depends_on":["plan"]},{"name":"plan","depends_on":["think"]}]}' > .nanostack/config.json
+          if "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start >/dev/null 2>"$err_log"; then
+            echo "FAIL: conductor accepted invalid config.phase_graph"
+            exit 1
+          fi
+          if ! grep -qF 'invalid phase_graph' "$err_log"; then
+            echo "FAIL: config rejection message does not say 'invalid phase_graph'"
+            cat "$err_log"
+            exit 1
+          fi
+
+          # Case H: misordered DAG in --phases must still produce a
+          # topologically-correct batch order. Without the topological
+          # sort, ship would appear before audit-licenses just because
+          # it was listed first in the array.
+          mkdir -p .nanostack/skills/audit-licenses
+          printf '%s\n' '---' 'name: audit-licenses' 'concurrency: read' 'depends_on: [build]' '---' \
+            > .nanostack/skills/audit-licenses/SKILL.md
+          printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
           "$GITHUB_WORKSPACE/conductor/bin/sprint.sh" start \
-            --phases '[{"name":"think","depends_on":[]},{"name":"think","depends_on":[]}]' 2>&1 && {
-              echo "FAIL: conductor accepted duplicate names"
-              exit 1
-            }
+            --phases '[{"name":"ship","depends_on":["audit-licenses"]},{"name":"audit-licenses","depends_on":["build"]},{"name":"build","depends_on":["plan"]},{"name":"plan","depends_on":["think"]},{"name":"think","depends_on":[]}]' \
+            >/dev/null
+          batch_out=$("$GITHUB_WORKSPACE/conductor/bin/sprint.sh" batch)
+          first=$(echo "$batch_out" | head -1 | jq -r '.phases[0]')
+          if [ "$first" != "think" ]; then
+            echo "FAIL: misordered DAG: first batch should be think, got '$first'"
+            echo "$batch_out"
+            exit 1
+          fi
+          # Build line must come before audit-licenses; audit-licenses before ship.
+          build_line=$(echo "$batch_out" | grep -nF '"build"' | head -1 | cut -d: -f1)
+          audit_line=$(echo "$batch_out" | grep -nF '"audit-licenses"' | head -1 | cut -d: -f1)
+          ship_line=$(echo "$batch_out" | grep -nF '"ship"' | head -1 | cut -d: -f1)
+          if [ "$build_line" -ge "$audit_line" ] || [ "$audit_line" -ge "$ship_line" ]; then
+            echo "FAIL: batch order violates dependencies"
+            echo "lines: build=$build_line audit-licenses=$audit_line ship=$ship_line"
+            echo "$batch_out"
+            exit 1
+          fi
+          rm -f "$err_log"
 
   guard-rule-ids-unique:
     name: Guard rule ids are unique

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -148,6 +148,12 @@ _nano_phase_graph_is_valid() {
       and (.depends_on | all(type == "string"))
     )
   ' >/dev/null 2>&1 || return 1
+  # Duplicate names are nonsensical: which entry's depends_on wins for
+  # the same phase? Reject up front so conductor scheduling never has
+  # to disambiguate.
+  if ! echo "$graph" | jq -e '([.[].name] | unique | length) == length' >/dev/null 2>&1; then
+    return 1
+  fi
   local names dep_targets
   names=$(echo "$graph" | jq -r '.[].name')
   dep_targets=$(echo "$graph" | jq -r '[.[].name] | join("\n")')
@@ -168,6 +174,32 @@ _nano_phase_graph_is_valid() {
       return 1
     fi
   done <<< "$deps"
+  # Cycle detection via Kahn's algorithm. Iteratively strip zero-deps
+  # nodes; if no progress is possible while nodes remain, a cycle
+  # exists. Conductor relies on the graph being a DAG so the topological
+  # batching never deadlocks.
+  if ! echo "$graph" | jq -e '
+    def acyclic:
+      . as $g
+      | reduce range(0; $g | length + 1) as $_ (
+          $g;
+          if length == 0 then .
+          else
+            ([.[] | select(.depends_on | length == 0) | .name]) as $leaves
+            | if ($leaves | length) == 0 then null
+              else
+                [.[]
+                  | select(.name as $n | ($leaves | index($n)) | not)
+                  | .depends_on |= map(select(. as $d | ($leaves | index($d)) | not))
+                ]
+              end
+          end
+        )
+      | . != null and length == 0;
+    acyclic
+  ' >/dev/null 2>&1; then
+    return 1
+  fi
   return 0
 }
 

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -228,6 +228,41 @@ nano_phase_graph_json() {
   printf '%s\n' "$default_graph"
 }
 
+# Topologically sort a phase_graph and emit the phase names, one per
+# line. Uses Kahn's algorithm (the same shape as the cycle check in
+# the validator). The graph is assumed valid; pass a graph that has
+# already been validated, or call _nano_phase_graph_is_valid first.
+# Returns 1 if the graph contains a cycle (no progress possible).
+nano_phase_graph_sort() {
+  local graph="${1:?nano_phase_graph_sort requires a graph JSON argument}"
+  command -v jq >/dev/null 2>&1 || return 1
+  echo "$graph" | jq -er '
+    def topo_sort:
+      . as $g
+      | reduce range(0; ($g | length) + 1) as $_ (
+          {sorted: [], remaining: $g};
+          .remaining as $r
+          | if ($r | length) == 0 then .
+            else
+              ($r | [.[] | select(.depends_on | length == 0) | .name]) as $leaves
+              | if ($leaves | length) == 0 then null
+                else
+                  {
+                    sorted: (.sorted + $leaves),
+                    remaining: [
+                      $r[]
+                      | select(.name as $n | ($leaves | index($n)) | not)
+                      | .depends_on |= map(select(. as $d | ($leaves | index($d)) | not))
+                    ]
+                  }
+                end
+            end
+        )
+      | if . == null then error("cycle") else .sorted end;
+    topo_sort | .[]
+  ' 2>/dev/null
+}
+
 # Best-effort skill-path resolution. Core phases live one directory
 # above bin/ (the nanostack repo). Custom phases live under skill_roots
 # from config, falling back to .nanostack/skills, ~/.claude/skills,

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -528,6 +528,13 @@ flow_phase_registry() {
   # Lifecycle round-trip with one custom artifact saved (PR 4): analytics
   # counts it, sprint-journal emits a section for it, default discard
   # --dry-run includes its file path.
+  #
+  # Reset the audit-licenses dir first. An earlier block in this same
+  # flow may have saved a smoke artifact; save-artifact.sh names files
+  # by per-second timestamp, so a second write inside the same second
+  # silently overwrites the first and a write a second later doubles
+  # the count. Either way breaks the strict equality below.
+  rm -rf "$proj/.nanostack/audit-licenses"
   "$REPO/bin/save-artifact.sh" audit-licenses \
     '{"phase":"audit-licenses","summary":{"status":"OK","headline":"smoke audit"},"context_checkpoint":{"summary":"ok"}}' \
     >/dev/null
@@ -547,6 +554,31 @@ flow_phase_registry() {
   discard_out=$( "$REPO/bin/discard-sprint.sh" --dry-run )
   assert_true "default discard --dry-run includes the custom artifact" \
     bash -c "echo '$discard_out' | grep -qF 'audit-licenses'"
+
+  # Conductor (PR 5): --phases inline JSON drives the sprint topology;
+  # the custom skill's concurrency=read is honored during cmd_batch.
+  mkdir -p .nanostack/skills/audit-licenses
+  printf '%s\n' '---' 'name: audit-licenses' 'concurrency: read' 'depends_on: [build]' '---' \
+    > .nanostack/skills/audit-licenses/SKILL.md
+  "$REPO/conductor/bin/sprint.sh" start \
+    --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build"]},{"name":"ship","depends_on":["audit-licenses"]}]' \
+    >/dev/null
+  local sprint_status
+  sprint_status=$( "$REPO/conductor/bin/sprint.sh" status )
+  assert_true "conductor sprint includes the custom phase from --phases" \
+    bash -c "echo '$sprint_status' | jq -e '.phases | has(\"audit-licenses\")' >/dev/null"
+  assert_true "conductor sprint has 5 phases (custom graph)" \
+    bash -c "echo '$sprint_status' | jq -e '.phases | length == 5' >/dev/null"
+
+  local batch_out
+  batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+  assert_true "conductor batch reads custom skill concurrency=read" \
+    bash -c "echo '$batch_out' | grep -qE '\"phases\":\\[[^]]*\"audit-licenses\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"audit-licenses\"'"
+
+  # Cycle in --phases must exit 2 (no sprint created).
+  assert_false "conductor rejects a cycle in --phases" \
+    "$REPO/conductor/bin/sprint.sh" start \
+    --phases '[{"name":"think","depends_on":["plan"]},{"name":"plan","depends_on":["think"]}]'
 
   # Add a phase_graph so the resolver populates upstream_artifacts;
   # build appears as null (no artifact dir), plan appears as a path.

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -90,6 +90,57 @@ find_sprint() {
 # ─── start ───────────────────────────────────────────────────
 cmd_start() {
   local phases="$DEFAULT_PHASES"
+  local explicit_phases=""
+
+  # Parse args. Today only --phases is supported; future flags can hook in here.
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --phases)
+        if [ -z "${2:-}" ]; then
+          echo "ERROR: --phases requires a JSON array or a path to a JSON file" >&2
+          exit 2
+        fi
+        # If $2 is an existing file, read it; otherwise treat as inline JSON.
+        if [ -f "$2" ]; then
+          explicit_phases=$(cat "$2")
+        else
+          explicit_phases="$2"
+        fi
+        shift 2
+        ;;
+      *) shift ;;
+    esac
+  done
+
+  # Phase source resolution:
+  #   1. --phases <json|path>           (explicit user input — highest priority)
+  #   2. .nanostack/config.json:phase_graph   (project-level customization)
+  #   3. DEFAULT_PHASES                  (canonical core sprint)
+  local nanostack_root
+  nanostack_root="$(cd "$(dirname "$0")/../.." && pwd)"
+  if [ -n "$explicit_phases" ]; then
+    phases="$explicit_phases"
+  elif [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
+    # nano_phase_graph_json returns the config graph if present and
+    # valid, otherwise the canonical default. Either way conductor
+    # gets a graph it can trust.
+    . "$nanostack_root/bin/lib/phases.sh"
+    phases=$(nano_phase_graph_json)
+  fi
+
+  # Validate the chosen graph. Rejects malformed structure, unknown
+  # phase names, dangling depends_on, duplicate names, and cycles.
+  # Falls back to the default graph rather than starting a sprint that
+  # could deadlock or accept stray names.
+  if [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
+    . "$nanostack_root/bin/lib/phases.sh"
+    if ! _nano_phase_graph_is_valid "$phases"; then
+      echo "ERROR: invalid phase graph (cycle, duplicate name, dangling depends_on, or unknown name)" >&2
+      echo "       Falling back to the default graph or fix --phases / .nanostack/config.json:phase_graph." >&2
+      exit 2
+    fi
+  fi
+
   local sprint_id="${PROJECT_HASH}-$(date -u +%Y%m%d-%H%M%S)"
   local sprint_dir="$CONDUCTOR_DIR/$sprint_id"
 
@@ -380,21 +431,48 @@ cmd_batch() {
 
   local nanostack_root
   nanostack_root="$(cd "$(dirname "$0")/../.." && pwd)"
+  # Source the registry so get_concurrency can locate custom skills
+  # via nano_phase_skill_path. Unavailable in test sandboxes that
+  # delete bin/lib/; in that case the helper still falls back to
+  # built-in core paths and the safe "write" default.
+  if [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
+    . "$nanostack_root/bin/lib/phases.sh"
+  fi
 
-  # Get concurrency for a phase from its SKILL.md frontmatter
+  # Get concurrency for a phase from its SKILL.md frontmatter. Order:
+  #   1. Built-in core skill at <nanostack_root>/<phase>/SKILL.md
+  #   2. Custom skill resolved by the registry
+  #   3. Conductor-only stage (build) returns "write"
+  #   4. Unknown phase falls back to "write" with a warning so the
+  #      sprint never schedules a custom phase as parallel-read by
+  #      mistake.
   get_concurrency() {
     local phase="$1"
     local skill_md=""
     case "$phase" in
-      plan) skill_md="$nanostack_root/plan/SKILL.md" ;;
       build) echo "write"; return ;;
-      *) skill_md="$nanostack_root/$phase/SKILL.md" ;;
     esac
+    # Built-in core skill path.
+    if [ -f "$nanostack_root/$phase/SKILL.md" ]; then
+      skill_md="$nanostack_root/$phase/SKILL.md"
+    elif command -v nano_phase_skill_path >/dev/null 2>&1; then
+      # Custom skill: registry walks .nanostack/skills, ~/.claude/skills,
+      # and any configured skill_roots.
+      local custom_dir
+      custom_dir=$(nano_phase_skill_path "$phase" 2>/dev/null) || custom_dir=""
+      if [ -n "$custom_dir" ] && [ -f "$custom_dir/SKILL.md" ]; then
+        skill_md="$custom_dir/SKILL.md"
+      fi
+    fi
     if [ -n "$skill_md" ] && [ -f "$skill_md" ]; then
       local conc
       conc=$(sed -n '/^---$/,/^---$/p' "$skill_md" | grep '^concurrency:' | head -1 | sed 's/^concurrency: *//')
       echo "${conc:-write}"
     else
+      # Honest about not finding metadata. Default to "write" so
+      # conductor schedules conservatively (no accidental parallel
+      # write/exclusive overlap) and emit a warning to stderr.
+      echo "conductor: no SKILL.md found for phase '$phase'; defaulting concurrency=write" >&2
       echo "write"
     fi
   }

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -112,31 +112,54 @@ cmd_start() {
     esac
   done
 
-  # Phase source resolution:
-  #   1. --phases <json|path>           (explicit user input — highest priority)
+  # Phase source resolution (fail-closed at every step):
+  #   1. --phases <json|path>           (explicit user input)
   #   2. .nanostack/config.json:phase_graph   (project-level customization)
   #   3. DEFAULT_PHASES                  (canonical core sprint)
+  #
+  # An explicit input that fails validation aborts; a config
+  # phase_graph that fails validation aborts (does NOT silently fall
+  # back to DEFAULT_PHASES — that would mask a real config bug).
+  # Only "no phase_graph in config" reaches DEFAULT_PHASES.
   local nanostack_root
   nanostack_root="$(cd "$(dirname "$0")/../.." && pwd)"
-  if [ -n "$explicit_phases" ]; then
-    phases="$explicit_phases"
-  elif [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
-    # nano_phase_graph_json returns the config graph if present and
-    # valid, otherwise the canonical default. Either way conductor
-    # gets a graph it can trust.
-    . "$nanostack_root/bin/lib/phases.sh"
-    phases=$(nano_phase_graph_json)
-  fi
-
-  # Validate the chosen graph. Rejects malformed structure, unknown
-  # phase names, dangling depends_on, duplicate names, and cycles.
-  # Falls back to the default graph rather than starting a sprint that
-  # could deadlock or accept stray names.
   if [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
     . "$nanostack_root/bin/lib/phases.sh"
+  fi
+
+  if [ -n "$explicit_phases" ]; then
+    phases="$explicit_phases"
+  else
+    # Try config.phase_graph directly. nano_phase_graph_json's
+    # tolerant fallback would silently use the default for an invalid
+    # config; conductor's contract is fail-closed here.
+    local cfg=""
+    if [ -n "${NANOSTACK_STORE:-}" ] && [ -f "$NANOSTACK_STORE/config.json" ]; then
+      cfg="$NANOSTACK_STORE/config.json"
+    elif [ -n "${HOME:-}" ] && [ -f "$HOME/.nanostack/config.json" ]; then
+      cfg="$HOME/.nanostack/config.json"
+    fi
+    if [ -n "$cfg" ] && command -v jq >/dev/null 2>&1; then
+      local cfg_graph
+      cfg_graph=$(jq -c '.phase_graph // empty' "$cfg" 2>/dev/null || echo "")
+      if [ -n "$cfg_graph" ] && [ "$cfg_graph" != "null" ]; then
+        if ! _nano_phase_graph_is_valid "$cfg_graph" "$cfg"; then
+          echo "ERROR: invalid phase_graph in $cfg (cycle, duplicate name, dangling depends_on, or unknown name)" >&2
+          echo "       Fix the config or pass --phases on the command line." >&2
+          exit 2
+        fi
+        phases="$cfg_graph"
+      fi
+    fi
+  fi
+
+  # Final validation pass on whatever was chosen. For the explicit
+  # branch this is the only validation. For the config branch this is
+  # a redundant safety net. The default graph passes by construction.
+  if [ -f "$nanostack_root/bin/lib/phases.sh" ]; then
     if ! _nano_phase_graph_is_valid "$phases"; then
       echo "ERROR: invalid phase graph (cycle, duplicate name, dangling depends_on, or unknown name)" >&2
-      echo "       Falling back to the default graph or fix --phases / .nanostack/config.json:phase_graph." >&2
+      echo "       Fix --phases / .nanostack/config.json:phase_graph or omit both to use the default." >&2
       exit 2
     fi
   fi
@@ -477,8 +500,20 @@ cmd_batch() {
     fi
   }
 
-  local phases
-  phases=$(jq -r '.phases[].name' "$sprint_dir/sprint.json")
+  # Phase iteration order MUST be a topological sort of the graph.
+  # Without that, a custom graph stored in any other order would emit
+  # batches that violate dependencies (e.g. ship before audit-licenses
+  # because ship appeared first in the array). Use the registry's
+  # topological sorter when available; the graph was already validated
+  # at cmd_start, so the sort cannot fail with a cycle here.
+  local phases graph_json
+  graph_json=$(jq -c '.phases' "$sprint_dir/sprint.json")
+  if command -v nano_phase_graph_sort >/dev/null 2>&1; then
+    phases=$(nano_phase_graph_sort "$graph_json" 2>/dev/null) || phases=""
+  fi
+  if [ -z "$phases" ]; then
+    phases=$(jq -r '.phases[].name' "$sprint_dir/sprint.json")
+  fi
 
   # Partition into execution batches
   # Track all phases scheduled in prior batches (considered "will be done")

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -136,6 +136,46 @@ A custom phase with no artifact for the current project produces no section.
 
 `bin/discard-sprint.sh --dry-run` (no `--phase` flag) iterates over every registered phase, core and custom, and lists `[dry-run] would delete: <path>` for each artifact in the date window. Without registered custom phases this is identical to the historical behavior; with custom phases registered, the default discard cleans them too. The explicit `--phase <name>` flag still narrows to a single phase.
 
+## Conductor
+
+`conductor/bin/sprint.sh` accepts a custom phase graph at sprint start.
+
+### Phase source resolution
+
+`cmd_start` picks the graph in this order (highest priority first):
+
+1. `--phases <json>` — inline JSON array passed on the command line.
+2. `--phases <path>` — path to a file containing a JSON array. Conductor reads the file when `<path>` is an existing file; otherwise it treats the value as inline JSON.
+3. `phase_graph` field in `.nanostack/config.json`. The registry reads this through `nano_phase_graph_json`, which already validates the graph and falls back to the default if the config is malformed.
+4. `DEFAULT_PHASES` — the canonical seven-node sprint (`think → plan → build → review/qa/security → ship`).
+
+### Validation
+
+Before creating the sprint directory, `cmd_start` runs `_nano_phase_graph_is_valid` against the chosen graph. The validator rejects:
+
+- Non-array structure or empty array.
+- An entry whose `.name` is not a string or whose `.depends_on` is not an array of strings.
+- A `.name` that fails the phase regex (`^[a-z][a-z0-9-]*$`).
+- A `.name` that is not in the known set: core ∪ registered custom ∪ the conductor's `build` stage.
+- A `.depends_on[]` entry that does not reference a name appearing elsewhere in the same graph.
+- **Duplicate names** in the graph. Two entries with the same `.name` make `depends_on` ambiguous.
+- **Cycles** in the dependency graph. Detected via Kahn's algorithm — if zero-deps node removal cannot reduce the graph to empty, a cycle exists.
+
+A failed validation aborts with exit `2` and the message `ERROR: invalid phase graph (cycle, duplicate name, dangling depends_on, or unknown name)`. No sprint directory is created. Same behavior whether the graph came from `--phases` or `config.json`.
+
+### Concurrency lookup
+
+`cmd_batch`'s `get_concurrency` reads the `concurrency:` frontmatter field from a phase's `SKILL.md`. Lookup order:
+
+1. Built-in core skill at `<nanostack_root>/<phase>/SKILL.md`.
+2. Custom skill resolved via `nano_phase_skill_path` — walks `.nanostack/skills/`, `~/.claude/skills/`, `~/.agents/skills/`, plus any `skill_roots` configured in `.nanostack/config.json`.
+3. Conductor-only `build` stage returns `write` (no SKILL.md).
+4. Unknown phase falls back to `write` and emits a stderr warning. The conservative default avoids accidentally scheduling a custom write-phase as parallel-read.
+
+### Stability
+
+The output of `sprint.sh status` is keyed on phase names from the chosen graph. A custom graph that includes `audit-licenses` produces an `audit-licenses` entry under `.phases`, exactly as if it were a core phase. `sprint.sh batch` emits the same `{batch, type, phases}` JSON objects whether the phases are core, custom, or a mix.
+
 ## Stability
 
 `phase_kind` is the load-bearing addition. Once shipped, downstream skills can branch on it. Future PRs may add new fields to the resolver output, but the existing shape stays — consumers should keep using `jq` field access rather than positional or shape-strict parsing.

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -146,8 +146,8 @@ A custom phase with no artifact for the current project produces no section.
 
 1. `--phases <json>` — inline JSON array passed on the command line.
 2. `--phases <path>` — path to a file containing a JSON array. Conductor reads the file when `<path>` is an existing file; otherwise it treats the value as inline JSON.
-3. `phase_graph` field in `.nanostack/config.json`. The registry reads this through `nano_phase_graph_json`, which already validates the graph and falls back to the default if the config is malformed.
-4. `DEFAULT_PHASES` — the canonical seven-node sprint (`think → plan → build → review/qa/security → ship`).
+3. `phase_graph` field in `.nanostack/config.json`. Conductor reads this field directly with `jq`, validates it, and aborts sprint creation with exit `2` if the graph is malformed (cycle, duplicate name, dangling `depends_on`, or unknown name). Silently falling back to the default would mask a real config bug, so conductor stays fail-closed here. The registry's tolerant helper `nano_phase_graph_json` keeps its fallback semantics for other callers (resolver, future consumers); only the conductor needs the strict path.
+4. `DEFAULT_PHASES` — the canonical seven-node sprint (`think → plan → build → review/qa/security → ship`). Reached only when no `--phases` flag was passed AND `.nanostack/config.json` has no `phase_graph` field.
 
 ### Validation
 


### PR DESCRIPTION
## Summary

Fifth of six PRs in the Custom Stack Framework v1 round. Codex's product-limit retest documented two conductor bugs that broke the framework story:

- `conductor/bin/sprint.sh start --phases <json>` was accepted syntactically but **ignored**. `cmd_start` always used `DEFAULT_PHASES` and the resulting `status` reported the canonical core graph.
- `cmd_batch`'s `get_concurrency` only resolved built-in skill paths under `<nanostack_root>/<phase>/SKILL.md`. A copied custom skill could never be scheduled with the `concurrency` it declared.

Plus Codex's PR 1 follow-up: `nano_phase_graph_json` validated names and dangling `depends_on` but not cycles or duplicate names — acceptable while no consumer existed, blocking before conductor starts scheduling on the graph.

## Changes

- **`cmd_start`** parses `--phases <json>` and `--phases <file>`. Phase source resolution: explicit flag > `.nanostack/config.json:phase_graph` > `DEFAULT_PHASES`. Every chosen graph passes through `_nano_phase_graph_is_valid` before sprint creation. Invalid graphs exit `2` with a single actionable message; no sprint directory gets created.
- **`cmd_batch.get_concurrency`** walks built-in core paths first, then falls back to `nano_phase_skill_path` (searches `.nanostack/skills`, `~/.claude/skills`, `~/.agents/skills`, and any configured `skill_roots`). When no `SKILL.md` is found, defaults to `write` and emits a stderr warning so a custom phase is never scheduled as parallel-read by mistake.
- **`bin/lib/phases.sh`** `_nano_phase_graph_is_valid` grows two checks (Codex's PR 1 follow-up): duplicate name rejection and cycle detection via Kahn's algorithm. Both fold into the same fallback path: config graphs reject silently and emit the default; `--phases` graphs abort the sprint with exit `2`.
- **`reference/custom-stack-contract.md`** gains a "Conductor" section documenting phase source resolution, validation rules, concurrency lookup order, and stability for `sprint.sh status` / `batch` output.

## CI lock

`conductor-custom-graph` round-trips six cases on a real `/tmp` project:
- `--phases` inline JSON drives sprint topology.
- `cmd_batch` emits `audit-licenses` in a `type=read` batch when its `SKILL.md` declares `concurrency: read`.
- `--phases <path>` reads JSON from a file.
- `phase_graph` from `.nanostack/config.json` drives the sprint when `--phases` is absent.
- Cycle in `--phases` rejected with exit `2` and `invalid phase graph` message.
- Duplicate name in `--phases` rejected.

`ci/e2e-user-flows.sh` `phase_registry` flow gains 4 cells covering the same surface end-to-end. The lint also asserts `conductor/bin/sprint.sh` sources the registry and references `_nano_phase_graph_is_valid` or `nano_phase_graph_json`, so future edits cannot bypass validation.

## Polish bundled in (PR 4 follow-up)

`ci/e2e-user-flows.sh` `flow_phase_registry` now `rm -rf`s the `audit-licenses/` dir before the lifecycle round-trip block. Codex flagged on PR 4 that `save-artifact.sh`'s per-second timestamp filenames could either silently overwrite or double the count when a flow saves twice. Cleaning up first makes the strict equality assertion deterministic.

## Test plan

- [x] tests/run.sh: 81/81 (was 72; +4 graph-validation cells +5 conductor invocation cells, local only)
- [x] ci/e2e-user-flows.sh: 100/100 (was 96; +4 conductor cells)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses
- [x] Manual: `conductor/bin/sprint.sh start --phases '[...]'` produces the expected sprint dir + status; cycle and duplicate cases each exit 2.

## Out of scope (PR 6 of the round)

- `bin/create-skill.sh`, `bin/check-custom-skill.sh`, `examples/custom-stack-template/`, EXTENDING.md rewrite, `ci/e2e-custom-stack-flows.sh`. After PR 6 the public phrasing rule from the spec relaxes for the whole framework claim.