### PR TITLE
custom-stack v1 PR 6: tooling + docs + 12-cell E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,29 @@ jobs:
           chmod +x ci/e2e-think-archetypes.sh
           ci/e2e-think-archetypes.sh
 
+  e2e-custom-stack:
+    name: E2E Custom Stack Framework v1 (12-cell journey)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Custom Stack Framework v1 PR 6. Runs the full new-user journey:
+    # bin/create-skill.sh scaffolds a skill, bin/check-custom-skill.sh
+    # validates it, the lifecycle scripts surface the custom phase
+    # (resolver, journal, analytics, default discard), the conductor
+    # accepts a --phases graph that includes it, and the cmd_batch
+    # honors the custom skill's concurrency. Lint covers each piece;
+    # this harness proves they compose into one workflow.
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq + python3 + node available
+        run: |
+          jq --version
+          python3 --version
+          node --version
+      - name: Run custom-stack E2E
+        run: |
+          chmod +x ci/e2e-custom-stack-flows.sh
+          ci/e2e-custom-stack-flows.sh
+
   e2e-onboarding-flows:
     name: E2E /nano-run vNext flows (9 cells)
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,7 @@ jobs:
           ci/e2e-think-archetypes.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (12-cell journey)
+    name: E2E Custom Stack Framework v1 (15-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,10 +117,9 @@ jobs:
     # this harness proves they compose into one workflow.
     steps:
       - uses: actions/checkout@v4
-      - name: jq + python3 + node available
+      - name: jq + node available
         run: |
           jq --version
-          python3 --version
           node --version
       - name: Run custom-stack E2E
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2930,6 +2930,88 @@ jobs:
           fi
           rm -f "$err_log"
 
+  custom-stack-tooling:
+    name: bin/create-skill.sh + bin/check-custom-skill.sh round-trip
+    runs-on: ubuntu-latest
+    # PR 6 of the Custom Stack Framework v1 round. Lock the contract
+    # between the scaffolder and the validator: a skill created by
+    # bin/create-skill.sh must pass bin/check-custom-skill.sh on a
+    # clean /tmp project. Also asserts the README sections (English +
+    # Spanish) describe what the tools actually do, so public copy
+    # never drifts ahead of the implementation.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Both helpers exist and are executable
+        run: |
+          set -e
+          for f in bin/create-skill.sh bin/check-custom-skill.sh ci/e2e-custom-stack-flows.sh; do
+            test -x "$f" || { echo "FAIL: $f is not executable"; exit 1; }
+            bash -n "$f"
+          done
+      - name: Scaffold and validate on a /tmp project
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cd "$tmp"
+          git init -q
+          # Scaffold a custom skill.
+          "$GITHUB_WORKSPACE/bin/create-skill.sh" license-audit \
+            --concurrency read --depends-on build >/dev/null
+          # Skill landed under .nanostack/skills/<name>/ with the
+          # expected layout.
+          test -f .nanostack/skills/license-audit/SKILL.md
+          test -f .nanostack/skills/license-audit/agents/openai.yaml
+          test -x .nanostack/skills/license-audit/bin/audit.sh
+          # Phase registered idempotently in config.
+          jq -e '.custom_phases | index("license-audit")' \
+            .nanostack/config.json >/dev/null
+          # check-custom-skill exits 0 on the scaffolded skill.
+          out=$("$GITHUB_WORKSPACE/bin/check-custom-skill.sh" \
+            .nanostack/skills/license-audit)
+          echo "$out" | tail -1 | grep -qE '^OK:'
+      - name: Reject invalid skill names
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          cd "$tmp"
+          git init -q
+          # Uppercase fails the phase regex.
+          if "$GITHUB_WORKSPACE/bin/create-skill.sh" BAD_NAME >/dev/null 2>&1; then
+            echo "FAIL: create-skill accepted 'BAD_NAME'"
+            exit 1
+          fi
+          # Core phase name reserved.
+          if "$GITHUB_WORKSPACE/bin/create-skill.sh" review >/dev/null 2>&1; then
+            echo "FAIL: create-skill accepted core phase name 'review'"
+            exit 1
+          fi
+      - name: README + EXTENDING describe the new tooling
+        run: |
+          set -e
+          fail=0
+          for f in README.md README.es.md EXTENDING.md; do
+            if ! grep -qF 'bin/create-skill.sh' "$f"; then
+              echo "FAIL: $f does not mention bin/create-skill.sh"
+              fail=1
+            fi
+            if ! grep -qF 'bin/check-custom-skill.sh' "$f"; then
+              echo "FAIL: $f does not mention bin/check-custom-skill.sh"
+              fail=1
+            fi
+          done
+          # The English README's Build-on-nanostack section claims a
+          # specific list of guarantees. Keep it grounded in the
+          # actual harness.
+          for token in 'phase_kind' 'sprint-journal' 'analytics' 'discard-sprint' 'conductor' 'phase_graph'; do
+            if ! grep -qF "$token" README.md; then
+              echo "FAIL: README.md Build-on-nanostack section dropped token: $token"
+              fail=1
+            fi
+          done
+          exit $fail
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2672,13 +2672,15 @@ jobs:
             echo "      Add a sentence about fresh-shell tool execution near step 0."
             exit 1
           fi
-      - name: agents/openai.yaml exists and parses
+      - name: agents/openai.yaml exists with the three discovery keys
         run: |
           set -e
+          # Narrow grep instead of PyYAML — the user-facing
+          # bin/check-custom-skill.sh dropped the PyYAML dependency
+          # in PR 6, and the lint should validate against the same
+          # surface the tool actually checks.
           f=examples/custom-skill-template/audit-licenses/agents/openai.yaml
           test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
-          python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f"
-          # Minimum surface (matches the built-in skill convention)
           for k in display_name short_description default_prompt; do
             if ! grep -qE "^[[:space:]]+${k}:" "$f"; then
               echo "FAIL: $f missing key '$k'"

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -9,9 +9,9 @@ Add your own skills that plug into nanostack's workflow. Your skills save artifa
 > bin/check-custom-skill.sh .nanostack/skills/license-audit
 > ```
 >
-> The first command scaffolds a working skill from the bundled template, registers it as a custom phase in `.nanostack/config.json`, and rewrites every helper path to be self-contained. The second runs an 11-point check: frontmatter shape, `agents/openai.yaml` parses, `bash -n` on helpers, registration in config, save-and-read smoke through the artifact store. Restart your agent and `/license-audit` is live.
+> The first command scaffolds a working skill from the bundled template, registers it as a custom phase, and rewrites every helper path to be self-contained. It writes to the same store path the lifecycle scripts read from (your repo root's `.nanostack/`, or `$HOME/.nanostack/` outside git), so the skill is visible whether you invoke the tool from the project root or a subdirectory. The second runs a check that covers SKILL.md frontmatter shape, the frontmatter `name:` matches the directory, `agents/openai.yaml` has the required discovery keys, the `display_name` is consistent with the skill, `bash -n` on helpers, registration in config, no leaked example paths, and a `save-artifact` + `find-artifact` round-trip. Restart your agent and `/license-audit` is live.
 >
-> The contract those tools enforce lives in [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). The 12-cell end-to-end harness that proves the journey works is at [`ci/e2e-custom-stack-flows.sh`](ci/e2e-custom-stack-flows.sh).
+> The contract those tools enforce lives in [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). The 15-cell end-to-end harness that proves the journey works (including subdir-scaffold and no-git scaffold paths) is at [`ci/e2e-custom-stack-flows.sh`](ci/e2e-custom-stack-flows.sh).
 >
 > Prefer copying by hand? The template still lives at `examples/custom-skill-template/audit-licenses/` and its README walks through the structure.
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -2,7 +2,18 @@
 
 Add your own skills that plug into nanostack's workflow. Your skills save artifacts, read what other skills produced, and compose with /think, /review and /ship.
 
-> **Quickest way to start:** copy `examples/custom-skill-template/audit-licenses/` and edit it. The template is a working `/audit-licenses` skill (~100 lines) that demonstrates frontmatter, the artifact store, stack detection and the standard output format. See `examples/custom-skill-template/README.md` for the walkthrough.
+> **Quickest way to start:**
+>
+> ```bash
+> bin/create-skill.sh license-audit --concurrency read --depends-on build
+> bin/check-custom-skill.sh .nanostack/skills/license-audit
+> ```
+>
+> The first command scaffolds a working skill from the bundled template, registers it as a custom phase in `.nanostack/config.json`, and rewrites every helper path to be self-contained. The second runs an 11-point check: frontmatter shape, `agents/openai.yaml` parses, `bash -n` on helpers, registration in config, save-and-read smoke through the artifact store. Restart your agent and `/license-audit` is live.
+>
+> The contract those tools enforce lives in [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). The 12-cell end-to-end harness that proves the journey works is at [`ci/e2e-custom-stack-flows.sh`](ci/e2e-custom-stack-flows.sh).
+>
+> Prefer copying by hand? The template still lives at `examples/custom-skill-template/audit-licenses/` and its README walks through the structure.
 
 ## Configure your stack
 

--- a/README.es.md
+++ b/README.es.md
@@ -227,6 +227,30 @@ Si querés enforcement duro, usá Claude Code. Si aceptás disciplina a nivel ag
 
 Para la guía completa de problemas en español (slash commands, jq, phase gate, puerto en uso, Windows, sprints atascados, conflictos de nombres), ver [TROUBLESHOOTING.es.md](TROUBLESHOOTING.es.md). Para temas avanzados (proxy corporativo, doble ejecución en autopilot, telemetría) consultá la versión canónica en inglés: [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
+## Construí tu propio skill
+
+Nanostack es un framework de workflow, no solo un set fijo de skills. Podés crear tus propios skills, registrarlos como fases, y reutilizar el mismo artifact store, resolver, sprint journal, analytics, conductor y vault local que usan los skills built-in.
+
+Generá un skill desde el template, validalo, reiniciá tu agente:
+
+```bash
+bin/create-skill.sh license-audit --concurrency read --depends-on build
+bin/check-custom-skill.sh .nanostack/skills/license-audit
+```
+
+Lo que ese skill hereda automáticamente, todo cubierto por `ci/e2e-custom-stack-flows.sh`:
+
+- `save-artifact.sh license-audit` y `find-artifact.sh license-audit` aceptan la fase custom igual que una core.
+- `resolve.sh license-audit` devuelve `phase_kind: "custom"` con `upstream_artifacts` derivados del `depends_on` del skill.
+- `sprint-journal.sh` emite una sección `## /license-audit` con status, headline y artifact path.
+- `analytics.sh --json` cuenta el skill en `sprints.custom.license-audit` y lo suma a `sprints.total`.
+- `discard-sprint.sh --dry-run` lista los artefactos del skill junto con los core.
+- `conductor/bin/sprint.sh start --phases <json>` acepta un grafo que incluye la fase custom; `batch` lee la `concurrency:` desde el `SKILL.md` del skill.
+
+Un equipo de marketing arma `/audience` y `/campaign`. Un equipo de datos arma `/explore` y `/model`. Un equipo de compliance arma `/license-audit` y `/privacy`. Todos componen con `/think` para ideas, `/review` para calidad y `/ship` para entrega.
+
+El contrato del framework está en [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). Walkthrough completo: [`EXTENDING.md`](EXTENDING.md).
+
 ## Privacidad
 
 Nanostack no tiene un servicio cloud propio. Guarda planes, artefactos, journals y know-how localmente en `.nanostack/`. No envía tu código, prompts, nombres de proyecto ni rutas de archivo a servidores de Nanostack. Tu proveedor de agente de IA puede procesar el contexto que le des; usá las opciones de privacidad de tu proveedor y tus propias políticas de datos para trabajo sensible.
@@ -237,11 +261,10 @@ Niveles: `off` (default), `anonymous`, `community`. Las instalaciones desde v0.4
 
 ## Más documentación
 
-Esta es una traducción de las secciones críticas. Para los temas avanzados (know-how, compounding, conductor, build on nanostack, analytics) consultá el [README en inglés](README.md):
+Esta es una traducción de las secciones críticas. Para los temas avanzados (know-how, compounding, conductor, analytics) consultá el [README en inglés](README.md):
 
 - [Know-how y memoria entre sprints](README.md#know-how)
 - [Sprints en paralelo (`/conductor`)](README.md#parallel-sprints)
-- [Build on nanostack: extender con tus propias skills](README.md#build-on-nanostack)
 - [Privacidad](README.md#privacy)
 
 ## Contribuir

--- a/README.md
+++ b/README.md
@@ -763,19 +763,27 @@ Open `.nanostack/know-how/` in Obsidian. Sprint journals link to conflict preced
 
 ## Build on nanostack
 
-Nanostack is a platform. Build your own skill set on top of it for any domain.
+Nanostack is a workflow framework, not just a fixed skill bundle. Create your own skills, register them as phases, and reuse the same artifact store, resolver, sprint journal, analytics, conductor, and local vault that the built-in skills run on.
 
-Register custom phases in `.nanostack/config.json`:
+Scaffold a skill from the template, validate it, restart your agent:
 
-```json
-{ "custom_phases": ["audience", "campaign", "measure"] }
+```bash
+bin/create-skill.sh license-audit --concurrency read --depends-on build
+bin/check-custom-skill.sh .nanostack/skills/license-audit
 ```
 
-Your skills use the same infrastructure: `save-artifact.sh` persists artifacts, `find-artifact.sh` reads them, skills cross-reference each other. The sprint journal, analytics and Obsidian vault work with custom phases.
+What that gets you, all proven by `ci/e2e-custom-stack-flows.sh`:
 
-A marketing team builds `/audience` and `/campaign`. A data team builds `/explore` and `/model`. A design team builds `/wireframe` and `/usability`. All compose with nanostack's `/think` for ideation, `/review` for quality and `/ship` for delivery.
+- `save-artifact.sh license-audit` and `find-artifact.sh license-audit` accept the custom phase the same way they accept a core phase.
+- `resolve.sh license-audit` returns `phase_kind: "custom"` with `upstream_artifacts` driven by the skill's `depends_on` (or by `phase_graph` in `.nanostack/config.json`).
+- `sprint-journal.sh` emits a `## /license-audit` section with the skill's status, headline, and artifact path.
+- `analytics.sh --json` adds the skill to `sprints.custom.license-audit` and counts it in `sprints.total`.
+- `discard-sprint.sh --dry-run` lists the skill's artifacts alongside the core ones.
+- `conductor/bin/sprint.sh start --phases <json>` accepts a graph that includes the custom phase; `conductor/bin/sprint.sh batch` reads its `concurrency:` from `SKILL.md`.
 
-Full guide: [`EXTENDING.md`](EXTENDING.md). Working starting point: [`examples/custom-skill-template/`](examples/custom-skill-template/) is a `/audit-licenses` skill you can copy and adapt.
+A marketing team builds `/audience` and `/campaign`. A data team builds `/explore` and `/model`. A design team builds `/wireframe` and `/usability`. A compliance team builds `/license-audit`, `/privacy`, and `/release-readiness`. All compose with nanostack's `/think` for ideation, `/review` for quality, and `/ship` for delivery.
+
+The framework contract is in [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). Full walkthrough: [`EXTENDING.md`](EXTENDING.md). Starting point you can copy: [`examples/custom-skill-template/`](examples/custom-skill-template/).
 
 ## Privacy
 

--- a/bin/check-custom-skill.sh
+++ b/bin/check-custom-skill.sh
@@ -63,8 +63,18 @@ else
   report OK "SKILL.md exists"
   # Extract frontmatter region (between first two --- markers).
   fm=$(awk '/^---[[:space:]]*$/{f++; next} f==1' "$SKILL_MD")
-  if echo "$fm" | grep -qE '^name:[[:space:]]'; then
+  fm_name=$(echo "$fm" | grep -E '^name:[[:space:]]' | head -1 | sed 's/^name:[[:space:]]*//')
+  if [ -n "$fm_name" ]; then
     report OK "frontmatter has 'name:'"
+    # The name an agent reads as the slash command must equal the
+    # directory basename. A copied template that still says
+    # `name: audit-licenses` inside .nanostack/skills/license-audit/
+    # would expose /audit-licenses to the agent, not /license-audit.
+    if [ "$fm_name" = "$NAME" ]; then
+      report OK "frontmatter name matches directory ($fm_name)"
+    else
+      report FAIL "frontmatter name '$fm_name' does not match directory '$NAME'"
+    fi
   else
     report FAIL "frontmatter has 'name:'"
   fi
@@ -84,14 +94,36 @@ else
   esac
 fi
 
-# 2. agents/openai.yaml exists and parses
+# 2. agents/openai.yaml exists, has the required keys, and does not
+#    embed an old template name. Avoid PyYAML — it is not in the
+#    Python stdlib and the install footprint pushes against the
+#    "low-friction tooling" claim. The narrow checks below are
+#    sufficient for the keys nanostack actually consumes.
 OPENAI_YAML="$SKILL_DIR/agents/openai.yaml"
 if [ ! -f "$OPENAI_YAML" ]; then
   report FAIL "agents/openai.yaml exists"
-elif ! python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$OPENAI_YAML" 2>/dev/null; then
-  report FAIL "agents/openai.yaml parses as YAML"
 else
-  report OK "agents/openai.yaml exists and parses"
+  report OK "agents/openai.yaml exists"
+  oy_fail=0
+  for key in display_name short_description default_prompt; do
+    if ! grep -qE "^[[:space:]]+${key}:" "$OPENAI_YAML"; then
+      report FAIL "agents/openai.yaml has '$key' under interface"
+      oy_fail=1
+    fi
+  done
+  [ "$oy_fail" -eq 0 ] && report OK "agents/openai.yaml has display_name + short_description + default_prompt"
+  # display_name is the discovery surface for the slash command. It
+  # must reference the new skill name; a copied skill that still says
+  # display_name: "audit-licenses" inside license-audit/ would expose
+  # the wrong command to OpenAI-compatible agents.
+  display_name=$(grep -E '^[[:space:]]+display_name:' "$OPENAI_YAML" | head -1 | sed -E 's/^[[:space:]]+display_name:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  if [ -n "$display_name" ]; then
+    if [ "$display_name" = "$NAME" ] || printf '%s' "$display_name" | grep -qF "$NAME"; then
+      report OK "openai.yaml display_name references '$NAME'"
+    else
+      report FAIL "openai.yaml display_name '$display_name' does not reference '$NAME'"
+    fi
+  fi
 fi
 
 # 3. bin/*.sh passes bash -n

--- a/bin/check-custom-skill.sh
+++ b/bin/check-custom-skill.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# check-custom-skill.sh — Validate a copied or scaffolded custom skill.
+#
+# Usage: bin/check-custom-skill.sh <skill-dir>
+#
+# Checks that the spec's PR 6 contract holds for one custom skill:
+#   1. SKILL.md exists with required frontmatter (name, description,
+#      concurrency in {read, write, exclusive}).
+#   2. agents/openai.yaml exists and parses as YAML.
+#   3. bin/*.sh passes bash -n.
+#   4. The skill name matches the directory name and the registry's
+#      phase-name regex.
+#   5. The phase is registered in .nanostack/config.json:custom_phases
+#      so save-artifact.sh / resolve.sh accept it.
+#   6. SKILL.md does not embed ./examples/custom-skill-template/...
+#      paths (would break after copy).
+#   7. The skill can save an artifact and find-artifact.sh can read it
+#      back. Smoke artifact is removed after the check.
+#
+# Output: one OK or FAIL line per check. Exit 0 if all pass, 1 if any
+# fail. The output is plain text by design — this is a CLI tool,
+# Professional voice, no profile-aware skeleton.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve NANOSTACK_STORE the same way lifecycle scripts do, so that
+# the registry sees the project's .custom_phases without forcing the
+# user to export the env var manually.
+. "$SCRIPT_DIR/lib/store-path.sh"
+. "$SCRIPT_DIR/lib/phases.sh"
+
+SKILL_DIR="${1:-}"
+if [ -z "$SKILL_DIR" ]; then
+  echo "Usage: bin/check-custom-skill.sh <skill-dir>" >&2
+  exit 2
+fi
+if [ ! -d "$SKILL_DIR" ]; then
+  echo "ERROR: $SKILL_DIR is not a directory" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+report() {
+  local status="$1" name="$2"
+  if [ "$status" = "OK" ]; then
+    printf '  OK    %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  %s\n' "$name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+NAME=$(basename "$SKILL_DIR")
+
+# 1. SKILL.md + frontmatter
+SKILL_MD="$SKILL_DIR/SKILL.md"
+if [ ! -f "$SKILL_MD" ]; then
+  report FAIL "SKILL.md exists at $SKILL_MD"
+else
+  report OK "SKILL.md exists"
+  # Extract frontmatter region (between first two --- markers).
+  fm=$(awk '/^---[[:space:]]*$/{f++; next} f==1' "$SKILL_MD")
+  if echo "$fm" | grep -qE '^name:[[:space:]]'; then
+    report OK "frontmatter has 'name:'"
+  else
+    report FAIL "frontmatter has 'name:'"
+  fi
+  if echo "$fm" | grep -qE '^description:[[:space:]]'; then
+    report OK "frontmatter has 'description:'"
+  else
+    report FAIL "frontmatter has 'description:'"
+  fi
+  conc=$(echo "$fm" | grep -E '^concurrency:[[:space:]]' | head -1 | sed 's/^concurrency:[[:space:]]*//')
+  case "$conc" in
+    read|write|exclusive)
+      report OK "concurrency is $conc"
+      ;;
+    *)
+      report FAIL "concurrency is one of read|write|exclusive (found: '$conc')"
+      ;;
+  esac
+fi
+
+# 2. agents/openai.yaml exists and parses
+OPENAI_YAML="$SKILL_DIR/agents/openai.yaml"
+if [ ! -f "$OPENAI_YAML" ]; then
+  report FAIL "agents/openai.yaml exists"
+elif ! python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$OPENAI_YAML" 2>/dev/null; then
+  report FAIL "agents/openai.yaml parses as YAML"
+else
+  report OK "agents/openai.yaml exists and parses"
+fi
+
+# 3. bin/*.sh passes bash -n
+if [ -d "$SKILL_DIR/bin" ]; then
+  bin_fail=0
+  for s in "$SKILL_DIR/bin"/*.sh; do
+    [ -f "$s" ] || continue
+    if ! bash -n "$s" 2>/dev/null; then
+      bin_fail=1
+      report FAIL "bash -n $(basename "$s")"
+    fi
+  done
+  [ "$bin_fail" -eq 0 ] && report OK "bin/*.sh syntax check"
+else
+  report OK "no bin/ to check"
+fi
+
+# 4. Skill directory name matches the registry regex.
+if printf '%s' "$NAME" | grep -qE "$NANO_PHASE_NAME_RE"; then
+  report OK "skill name '$NAME' matches phase regex"
+else
+  report FAIL "skill name '$NAME' matches phase regex (^[a-z][a-z0-9-]*$)"
+fi
+
+# 5. Phase is registered.
+if nano_phase_exists "$NAME" 2>/dev/null; then
+  report OK "phase '$NAME' is registered in .nanostack/config.json"
+else
+  report FAIL "phase '$NAME' is registered in .nanostack/config.json (use bin/create-skill.sh --register or edit config.custom_phases)"
+fi
+
+# 6. No repo-relative example paths leaked into SKILL.md.
+if [ -f "$SKILL_MD" ]; then
+  if grep -qE '\./examples/custom-skill-template/' "$SKILL_MD"; then
+    report FAIL "SKILL.md does not reference ./examples/custom-skill-template/"
+  else
+    report OK "SKILL.md has no repo-relative example paths"
+  fi
+fi
+
+# 7. Save + read smoke artifact (only if registered, otherwise the save
+#    will rightfully fail and we already reported the registration FAIL
+#    above).
+if nano_phase_exists "$NAME" 2>/dev/null; then
+  store="${NANOSTACK_STORE:-$PWD/.nanostack}"
+  export NANOSTACK_STORE="$store"
+  smoke_dir="$store/$NAME"
+  smoke_before=$(ls "$smoke_dir" 2>/dev/null | wc -l | tr -d ' ')
+  if "$NANOSTACK_ROOT/bin/save-artifact.sh" "$NAME" \
+    "{\"phase\":\"$NAME\",\"summary\":{\"status\":\"OK\",\"headline\":\"check-custom-skill smoke\"},\"context_checkpoint\":{\"summary\":\"smoke save\"}}" \
+    >/dev/null 2>&1; then
+    report OK "save-artifact accepts the skill name"
+  else
+    report FAIL "save-artifact accepts the skill name"
+  fi
+  found=$("$NANOSTACK_ROOT/bin/find-artifact.sh" "$NAME" 1 2>/dev/null) || found=""
+  if [ -n "$found" ] && [ -f "$found" ]; then
+    report OK "find-artifact returns the saved smoke artifact"
+    # Clean up: remove only the smoke file we just wrote.
+    rm -f "$found"
+  else
+    report FAIL "find-artifact returns the saved smoke artifact"
+  fi
+fi
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "OK: $NAME passed $PASS checks."
+else
+  echo "FAIL: $FAIL of $((PASS + FAIL)) checks failed for $NAME."
+fi
+exit $FAIL

--- a/bin/create-skill.sh
+++ b/bin/create-skill.sh
@@ -25,6 +25,10 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve NANOSTACK_STORE the same way lifecycle scripts do, so a
+# skill scaffolded from a git subdirectory or a no-git project lands
+# where save-artifact / resolve / conductor will look for it.
+. "$SCRIPT_DIR/lib/store-path.sh"
 . "$SCRIPT_DIR/lib/phases.sh"
 
 NAME="${1:-}"
@@ -88,9 +92,11 @@ if [ ! -f "$TEMPLATE/SKILL.md" ]; then
   exit 2
 fi
 
-# Project-local skills root. Conductor's nano_phase_skill_path walks
-# this first, so a skill written here is picked up automatically.
-DEST_ROOT=".nanostack/skills"
+# Skills root inside the resolved store. Conductor's
+# nano_phase_skill_path walks <store>/skills first, so a skill written
+# here is picked up automatically by the same scripts that read it
+# (save-artifact, resolve, conductor) regardless of cwd.
+DEST_ROOT="$NANOSTACK_STORE/skills"
 DEST="$DEST_ROOT/$NAME"
 if [ -e "$DEST" ]; then
   echo "ERROR: $DEST already exists; remove it or pick a different name" >&2
@@ -126,21 +132,24 @@ if [ -n "$DEPS" ]; then
     && mv "$DEST/SKILL.md.tmp" "$DEST/SKILL.md"
 fi
 
-# Registration in .nanostack/config.json (idempotent).
+# Registration in <store>/config.json (idempotent). Same path
+# lifecycle scripts read from, so a registration here is visible to
+# every consumer (save-artifact, resolve, analytics, conductor).
+CONFIG="$NANOSTACK_STORE/config.json"
 if [ "$REGISTER" = true ]; then
-  mkdir -p .nanostack
-  if [ -f .nanostack/config.json ]; then
+  mkdir -p "$NANOSTACK_STORE"
+  if [ -f "$CONFIG" ]; then
     jq --arg n "$NAME" '.custom_phases = ((.custom_phases // []) + [$n] | unique)' \
-      .nanostack/config.json > .nanostack/config.json.tmp \
-      && mv .nanostack/config.json.tmp .nanostack/config.json
+      "$CONFIG" > "$CONFIG.tmp" \
+      && mv "$CONFIG.tmp" "$CONFIG"
   else
-    jq -n --arg n "$NAME" '{custom_phases: [$n]}' > .nanostack/config.json
+    jq -n --arg n "$NAME" '{custom_phases: [$n]}' > "$CONFIG"
   fi
 fi
 
 echo "Created skill at $DEST"
 if [ "$REGISTER" = true ]; then
-  echo "Registered phase '$NAME' in .nanostack/config.json"
+  echo "Registered phase '$NAME' in $CONFIG"
 fi
 echo
 echo "Next:"

--- a/bin/create-skill.sh
+++ b/bin/create-skill.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# create-skill.sh — Scaffold a custom nanostack skill.
+#
+# Usage:
+#   bin/create-skill.sh <name> \
+#     [--from <template-dir>] \
+#     [--concurrency <read|write|exclusive>] \
+#     [--depends-on <phase>]... \
+#     [--register | --no-register]
+#
+# Defaults:
+#   --from        examples/custom-skill-template/audit-licenses
+#   --concurrency keeps the template's frontmatter value
+#   --depends-on  empty list
+#   --register    true (omits the registration step with --no-register)
+#
+# Output:
+#   Creates .nanostack/skills/<name>/ with SKILL.md, agents/openai.yaml,
+#   and the template's bin/ helpers. Substitutes the source skill name
+#   with <name> inside SKILL.md and agents/openai.yaml. Adds <name> to
+#   .custom_phases in .nanostack/config.json unless --no-register.
+#
+# Prints one next-step line on success.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$SCRIPT_DIR/lib/phases.sh"
+
+NAME="${1:-}"
+if [ -z "$NAME" ] || [ "${NAME#--}" != "$NAME" ]; then
+  echo "Usage: bin/create-skill.sh <name> [--from <dir>] [--concurrency <read|write|exclusive>] [--depends-on <phase>]... [--register | --no-register]" >&2
+  exit 2
+fi
+shift
+
+if ! printf '%s' "$NAME" | grep -qE "$NANO_PHASE_NAME_RE"; then
+  echo "ERROR: skill name '$NAME' must match ^[a-z][a-z0-9-]*$" >&2
+  exit 2
+fi
+
+# Reserved: cannot reuse a core phase name.
+case " $NANO_CORE_PHASES_LIST " in
+  *" $NAME "*)
+    echo "ERROR: '$NAME' is a core phase; choose a different skill name" >&2
+    exit 2
+    ;;
+esac
+
+TEMPLATE="$NANOSTACK_ROOT/examples/custom-skill-template/audit-licenses"
+CONCURRENCY=""
+DEPS=""
+REGISTER=true
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --from)
+      TEMPLATE="$2"
+      shift 2
+      ;;
+    --concurrency)
+      case "$2" in
+        read|write|exclusive) CONCURRENCY="$2" ;;
+        *) echo "ERROR: --concurrency must be read|write|exclusive" >&2; exit 2 ;;
+      esac
+      shift 2
+      ;;
+    --depends-on)
+      if ! printf '%s' "$2" | grep -qE "$NANO_PHASE_NAME_RE"; then
+        echo "ERROR: --depends-on '$2' must match ^[a-z][a-z0-9-]*$" >&2
+        exit 2
+      fi
+      DEPS="${DEPS:+$DEPS }$2"
+      shift 2
+      ;;
+    --register)    REGISTER=true; shift ;;
+    --no-register) REGISTER=false; shift ;;
+    *) echo "ERROR: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -d "$TEMPLATE" ]; then
+  echo "ERROR: template directory '$TEMPLATE' does not exist" >&2
+  exit 2
+fi
+if [ ! -f "$TEMPLATE/SKILL.md" ]; then
+  echo "ERROR: template '$TEMPLATE' has no SKILL.md" >&2
+  exit 2
+fi
+
+# Project-local skills root. Conductor's nano_phase_skill_path walks
+# this first, so a skill written here is picked up automatically.
+DEST_ROOT=".nanostack/skills"
+DEST="$DEST_ROOT/$NAME"
+if [ -e "$DEST" ]; then
+  echo "ERROR: $DEST already exists; remove it or pick a different name" >&2
+  exit 2
+fi
+mkdir -p "$DEST_ROOT"
+cp -R "$TEMPLATE" "$DEST"
+
+# Substitute the template's source name with the new one wherever the
+# source name appears as a literal token. The template is curated to
+# only use the name in safe locations (frontmatter `name:`, code
+# fences, /commands), so a global replacement is safe.
+TEMPLATE_NAME=$(basename "$TEMPLATE")
+if [ "$TEMPLATE_NAME" != "$NAME" ]; then
+  for f in "$DEST/SKILL.md" "$DEST/agents/openai.yaml" "$DEST/README.md"; do
+    [ -f "$f" ] || continue
+    # Use a temp file to keep the rename atomic and avoid in-place
+    # editing differences between BSD and GNU sed.
+    sed "s|$TEMPLATE_NAME|$NAME|g" "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  done
+fi
+
+# Optional frontmatter overrides. Both updates target lines that begin
+# with `concurrency:` or `depends_on:` in the SKILL.md frontmatter.
+if [ -n "$CONCURRENCY" ]; then
+  sed "s|^concurrency:.*|concurrency: $CONCURRENCY|" "$DEST/SKILL.md" > "$DEST/SKILL.md.tmp" \
+    && mv "$DEST/SKILL.md.tmp" "$DEST/SKILL.md"
+fi
+if [ -n "$DEPS" ]; then
+  # Build inline list form: depends_on: [a, b, c]
+  DEPS_INLINE=$(echo "$DEPS" | tr ' ' ',' | sed 's/,/, /g')
+  sed "s|^depends_on:.*|depends_on: [$DEPS_INLINE]|" "$DEST/SKILL.md" > "$DEST/SKILL.md.tmp" \
+    && mv "$DEST/SKILL.md.tmp" "$DEST/SKILL.md"
+fi
+
+# Registration in .nanostack/config.json (idempotent).
+if [ "$REGISTER" = true ]; then
+  mkdir -p .nanostack
+  if [ -f .nanostack/config.json ]; then
+    jq --arg n "$NAME" '.custom_phases = ((.custom_phases // []) + [$n] | unique)' \
+      .nanostack/config.json > .nanostack/config.json.tmp \
+      && mv .nanostack/config.json.tmp .nanostack/config.json
+  else
+    jq -n --arg n "$NAME" '{custom_phases: [$n]}' > .nanostack/config.json
+  fi
+fi
+
+echo "Created skill at $DEST"
+if [ "$REGISTER" = true ]; then
+  echo "Registered phase '$NAME' in .nanostack/config.json"
+fi
+echo
+echo "Next:"
+echo "  bin/check-custom-skill.sh $DEST"
+echo "  Then restart your agent so it picks up the new skill."

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -289,7 +289,29 @@ nano_phase_skill_path() {
   if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
     roots=$(jq -r '.skill_roots // [] | .[]' "$config" 2>/dev/null)
   fi
-  local default_roots=".nanostack/skills $HOME/.claude/skills $HOME/.agents/skills"
+  # Build the search order from most-specific to least:
+  #   1. configured skill_roots (user override)
+  #   2. <store>/skills — the resolved store, same path bin/create-skill.sh
+  #      writes to. This is the load-bearing one: a scaffold from a git
+  #      subdir or a no-git project lives here, not under cwd/.nanostack.
+  #   3. <config-dir>/skills — covers a global config under $HOME/.nanostack
+  #      that the resolver picked up via _nano_phases_resolve_config.
+  #   4. cwd-relative .nanostack/skills (legacy, retained for back-compat).
+  #   5. $HOME/.claude/skills + $HOME/.agents/skills (agent install
+  #      locations for skills shipped outside .nanostack).
+  local default_roots=""
+  if [ -n "${NANOSTACK_STORE:-}" ]; then
+    default_roots="$NANOSTACK_STORE/skills"
+  fi
+  if [ -n "$config" ]; then
+    local config_dir
+    config_dir=$(dirname "$config")
+    case " $default_roots " in
+      *" $config_dir/skills "*) ;;
+      *) default_roots="${default_roots:+$default_roots }$config_dir/skills" ;;
+    esac
+  fi
+  default_roots="${default_roots:+$default_roots }.nanostack/skills $HOME/.claude/skills $HOME/.agents/skills"
   for root in $roots $default_roots; do
     case "$root" in
       "~/"*) root="$HOME/${root#~/}" ;;

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -43,6 +43,18 @@ assert_true() {
   fi
 }
 
+assert_false() {
+  local name="$1"; shift
+  if ! "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
+  fi
+}
+
 assert_eq() {
   local name="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -144,17 +156,82 @@ batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
 assert_true "license-audit appears in a type=read batch" \
   bash -c "echo '$batch_out' | grep -qE '\"phases\":\\[[^]]*\"license-audit\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"license-audit\"'"
 
-# Cell 11: agents/openai.yaml is present and parses.
-echo "[11] agents/openai.yaml present and parses"
+# Cell 11: agents/openai.yaml is present with the three discovery keys.
+# Narrow grep beats PyYAML here — keep the harness portable on any
+# machine with bash + jq + node.
+echo "[11] agents/openai.yaml present with required keys"
+SKILLS_ROOT_FOR_CHECK="${NANOSTACK_STORE:-$PROJ/.nanostack}/skills"
+[ -d "$SKILLS_ROOT_FOR_CHECK/license-audit/agents" ] || \
+  SKILLS_ROOT_FOR_CHECK="$PROJ/.nanostack/skills"
 assert_true "openai.yaml exists" \
-  test -f ".nanostack/skills/license-audit/agents/openai.yaml"
-assert_true "openai.yaml parses as YAML" \
-  python3 -c "import yaml; yaml.safe_load(open('.nanostack/skills/license-audit/agents/openai.yaml'))"
+  test -f "$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml"
+assert_true "openai.yaml has display_name + short_description + default_prompt" \
+  bash -c "grep -qE '^[[:space:]]+display_name:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+short_description:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+default_prompt:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml'"
 
 # Cell 12: copied skill has no repo-relative example paths.
 echo "[12] copied skill has no repo-relative example paths"
 assert_true "SKILL.md has no ./examples/custom-skill-template/ leak" \
   bash -c "! grep -qE '\\./examples/custom-skill-template/' .nanostack/skills/license-audit/SKILL.md"
+
+# Cell 13: scaffolding from a git subdirectory must land in the repo
+# root's .nanostack, not the subdir's. Codex caught a regression here:
+# create-skill.sh used cwd-relative paths so a user invoking the tool
+# from src/ wrote .nanostack/ inside src/, then check-custom-skill.sh
+# (which resolves the store via store-path.sh -> repo root) failed
+# the registration check.
+echo "[13] create-skill resolves the store from a subdirectory"
+SUB_PROJ="$TMP_ROOT/subdir-project"
+mkdir -p "$SUB_PROJ/src/feature"
+cd "$SUB_PROJ"
+git init -q
+cd "$SUB_PROJ/src/feature"
+"$REPO/bin/create-skill.sh" subdir-skill --concurrency read >/dev/null
+assert_true "skill landed in repo root, not in src/feature" \
+  test -f "$SUB_PROJ/.nanostack/skills/subdir-skill/SKILL.md"
+assert_true "no rogue .nanostack inside src/feature" \
+  bash -c "! test -d '$SUB_PROJ/src/feature/.nanostack'"
+out=$( "$REPO/bin/check-custom-skill.sh" "$SUB_PROJ/.nanostack/skills/subdir-skill" 2>&1 )
+assert_true "check-custom-skill passes from a subdir scaffold" \
+  bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+
+# Cell 14: scaffolding outside any git repo. lib/store-path.sh falls
+# back to $HOME/.nanostack, so create-skill must too. Use a fake HOME
+# inside TMP_ROOT so the test does not touch the real ~/.nanostack.
+echo "[14] create-skill resolves the store outside git (fake HOME)"
+NOGIT_HOME="$TMP_ROOT/nogit-home"
+NOGIT_PROJ="$TMP_ROOT/nogit-project"
+mkdir -p "$NOGIT_HOME" "$NOGIT_PROJ"
+cd "$NOGIT_PROJ"
+HOME="$NOGIT_HOME" "$REPO/bin/create-skill.sh" nogit-skill >/dev/null
+assert_true "skill landed in fake-HOME store, not cwd" \
+  test -f "$NOGIT_HOME/.nanostack/skills/nogit-skill/SKILL.md"
+assert_true "no rogue .nanostack inside the cwd" \
+  bash -c "! test -d '$NOGIT_PROJ/.nanostack'"
+out=$( HOME="$NOGIT_HOME" "$REPO/bin/check-custom-skill.sh" "$NOGIT_HOME/.nanostack/skills/nogit-skill" 2>&1 )
+assert_true "check-custom-skill passes outside git" \
+  bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+
+# Cell 15: validator catches a frontmatter name that does not match
+# the directory basename. Codex hit a false-positive OK after a
+# manual copy that left `name: audit-licenses` inside a
+# license-audit/ folder; the agent would have exposed the wrong
+# slash command.
+echo "[15] validator rejects mismatched frontmatter name"
+DRIFT_HOME="$TMP_ROOT/drift-home"
+DRIFT_PROJ="$TMP_ROOT/drift-project"
+mkdir -p "$DRIFT_HOME" "$DRIFT_PROJ"
+cd "$DRIFT_PROJ"
+HOME="$DRIFT_HOME" "$REPO/bin/create-skill.sh" license-audit >/dev/null
+# Sabotage the SKILL.md so the frontmatter still says the source
+# template name. This is the "user copied by hand and forgot to
+# rename" path.
+DRIFT_SKILL="$DRIFT_HOME/.nanostack/skills/license-audit"
+sed 's/^name:.*/name: audit-licenses/' "$DRIFT_SKILL/SKILL.md" > "$DRIFT_SKILL/SKILL.md.tmp"
+mv "$DRIFT_SKILL/SKILL.md.tmp" "$DRIFT_SKILL/SKILL.md"
+assert_false "check-custom-skill rejects mismatched frontmatter name" \
+  bash -c "HOME='$DRIFT_HOME' '$REPO/bin/check-custom-skill.sh' '$DRIFT_SKILL'"
+
+cd "$PROJ"
 
 echo
 echo "============================="

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# e2e-custom-stack-flows.sh — Custom Stack Framework v1, end-to-end.
+#
+# Runs the full new-user journey on a real /tmp project:
+#   1. Scaffold a custom skill with bin/create-skill.sh.
+#   2. Validate it with bin/check-custom-skill.sh.
+#   3. Run its helper script.
+#   4. Save and find an artifact.
+#   5. Resolve the custom phase (phase_kind=custom).
+#   6. Generate a sprint journal (custom phase appears).
+#   7. Run analytics --json (custom phase counted).
+#   8. Default discard --dry-run (custom artifact listed).
+#   9. Start a conductor sprint with --phases that includes the custom phase.
+#  10. Conductor batch reads concurrency=read from the custom skill.
+#  11. agents/openai.yaml is present and parses.
+#  12. The copied skill has no repo-relative example paths.
+#
+# This harness is the contract Codex's spec calls for in PR 6: a clean
+# sandbox user can complete the entire workflow without reading source.
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT=$(mktemp -d /tmp/nanostack-cs-flows.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}expected: %s${NC}\n" "$expected"
+    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
+  fi
+}
+
+echo "Custom Stack Framework v1 E2E"
+echo "============================="
+echo "Tmp root: $TMP_ROOT"
+echo
+
+PROJ="$TMP_ROOT/project"
+mkdir -p "$PROJ"
+cd "$PROJ"
+git init -q
+
+# Cell 1: scaffold a new custom skill via bin/create-skill.sh.
+echo "[1] scaffold custom skill"
+"$REPO/bin/create-skill.sh" license-audit --concurrency read --depends-on build >/dev/null
+assert_true "skill directory exists" \
+  test -d ".nanostack/skills/license-audit"
+assert_true "phase registered in config" \
+  bash -c 'jq -e ".custom_phases | index(\"license-audit\")" .nanostack/config.json >/dev/null'
+
+# Cell 2: bin/check-custom-skill.sh passes on the scaffolded skill.
+echo "[2] check-custom-skill validates the scaffolded skill"
+out=$( "$REPO/bin/check-custom-skill.sh" .nanostack/skills/license-audit 2>&1 )
+last_line=$(echo "$out" | tail -1)
+assert_true "check-custom-skill ends with OK summary" \
+  bash -c "echo '$last_line' | grep -qE '^OK:'"
+
+# Cell 3: helper script runs from its copied location.
+echo "[3] helper runs from copied location"
+printf '%s\n' '{"name":"e2e","dependencies":{"lodash":"4.17.21"}}' > package.json
+audit_json=$( ".nanostack/skills/license-audit/bin/audit.sh" node 2>/dev/null )
+assert_true "helper emits .counts" \
+  bash -c "echo '$audit_json' | jq -e '.counts' >/dev/null"
+
+# Cell 4: save + find artifact.
+echo "[4] save and find an artifact"
+"$REPO/bin/save-artifact.sh" license-audit \
+  '{"phase":"license-audit","summary":{"status":"OK","headline":"e2e smoke"},"context_checkpoint":{"summary":"saved"}}' \
+  >/dev/null
+found=$( "$REPO/bin/find-artifact.sh" license-audit 30 2>/dev/null )
+assert_true "find-artifact returns a file" test -f "$found"
+assert_true "saved artifact has phase=license-audit" \
+  bash -c "jq -e '.phase == \"license-audit\"' '$found' >/dev/null"
+
+# Cell 5: resolver classifies the phase as custom.
+echo "[5] resolver returns phase_kind=custom"
+resolved=$( "$REPO/bin/resolve.sh" license-audit 2>/dev/null )
+kind=$( echo "$resolved" | jq -r '.phase_kind' )
+assert_eq "phase_kind == custom" "custom" "$kind"
+
+# Cell 6: sprint journal includes a /<phase> section.
+echo "[6] sprint-journal emits /license-audit section"
+journal=$( "$REPO/bin/sprint-journal.sh" )
+assert_true "journal file exists" test -f "$journal"
+assert_true "journal includes /license-audit" \
+  bash -c "grep -qF '## /license-audit' '$journal'"
+assert_true "journal mentions e2e smoke headline" \
+  bash -c "grep -qF 'e2e smoke' '$journal'"
+
+# Cell 7: analytics --json includes the custom count.
+echo "[7] analytics --json includes custom count"
+analytics=$( "$REPO/bin/analytics.sh" --json )
+assert_true "analytics.sprints.custom.license-audit >= 1" \
+  bash -c "echo '$analytics' | jq -e '.sprints.\"custom\".\"license-audit\" >= 1' >/dev/null"
+assert_true "analytics.sprints.total >= 1" \
+  bash -c "echo '$analytics' | jq -e '.sprints.total >= 1' >/dev/null"
+
+# Cell 8: default discard --dry-run lists the custom artifact.
+echo "[8] default discard --dry-run lists the custom artifact"
+discard_out=$( "$REPO/bin/discard-sprint.sh" --dry-run )
+assert_true "dry-run includes license-audit" \
+  bash -c "echo '$discard_out' | grep -qF 'license-audit'"
+
+# Cell 9: conductor sprint includes the custom phase via --phases.
+echo "[9] conductor sprint includes the custom phase"
+"$REPO/conductor/bin/sprint.sh" start \
+  --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"license-audit","depends_on":["build"]},{"name":"ship","depends_on":["license-audit"]}]' \
+  >/dev/null
+sprint_status=$( "$REPO/conductor/bin/sprint.sh" status )
+assert_true "conductor.phases has license-audit" \
+  bash -c "echo '$sprint_status' | jq -e '.phases | has(\"license-audit\")' >/dev/null"
+assert_true "conductor sprint has 5 phases" \
+  bash -c "echo '$sprint_status' | jq -e '.phases | length == 5' >/dev/null"
+
+# Cell 10: cmd_batch reads the custom skill's concurrency.
+echo "[10] conductor batch reads custom skill concurrency=read"
+batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+assert_true "license-audit appears in a type=read batch" \
+  bash -c "echo '$batch_out' | grep -qE '\"phases\":\\[[^]]*\"license-audit\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"license-audit\"'"
+
+# Cell 11: agents/openai.yaml is present and parses.
+echo "[11] agents/openai.yaml present and parses"
+assert_true "openai.yaml exists" \
+  test -f ".nanostack/skills/license-audit/agents/openai.yaml"
+assert_true "openai.yaml parses as YAML" \
+  python3 -c "import yaml; yaml.safe_load(open('.nanostack/skills/license-audit/agents/openai.yaml'))"
+
+# Cell 12: copied skill has no repo-relative example paths.
+echo "[12] copied skill has no repo-relative example paths"
+assert_true "SKILL.md has no ./examples/custom-skill-template/ leak" \
+  bash -c "! grep -qE '\\./examples/custom-skill-template/' .nanostack/skills/license-audit/SKILL.md"
+
+echo
+echo "============================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf "${GREEN}Custom Stack E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
+  exit 0
+else
+  printf "${RED}Custom Stack E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -193,6 +193,18 @@ assert_true "no rogue .nanostack inside src/feature" \
 out=$( "$REPO/bin/check-custom-skill.sh" "$SUB_PROJ/.nanostack/skills/subdir-skill" 2>&1 )
 assert_true "check-custom-skill passes from a subdir scaffold" \
   bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+# Conductor invoked from the subdir must still read the scaffolded
+# SKILL.md from the resolved store. Without the lookup-roots fix, batch
+# silently defaults to concurrency=write because nano_phase_skill_path
+# only searched .nanostack/skills relative to cwd.
+"$REPO/conductor/bin/sprint.sh" start \
+  --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"subdir-skill","depends_on":["build"]},{"name":"ship","depends_on":["subdir-skill"]}]' \
+  >/dev/null
+sub_batch=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+assert_true "subdir conductor reads SKILL.md (no 'no SKILL.md' warning)" \
+  bash -c "! echo '$sub_batch' | grep -qF 'no SKILL.md found'"
+assert_true "subdir conductor schedules subdir-skill as type=read" \
+  bash -c "echo '$sub_batch' | grep -qE '\"phases\":\\[[^]]*\"subdir-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"subdir-skill\"'"
 
 # Cell 14: scaffolding outside any git repo. lib/store-path.sh falls
 # back to $HOME/.nanostack, so create-skill must too. Use a fake HOME
@@ -202,7 +214,7 @@ NOGIT_HOME="$TMP_ROOT/nogit-home"
 NOGIT_PROJ="$TMP_ROOT/nogit-project"
 mkdir -p "$NOGIT_HOME" "$NOGIT_PROJ"
 cd "$NOGIT_PROJ"
-HOME="$NOGIT_HOME" "$REPO/bin/create-skill.sh" nogit-skill >/dev/null
+HOME="$NOGIT_HOME" "$REPO/bin/create-skill.sh" nogit-skill --concurrency read >/dev/null
 assert_true "skill landed in fake-HOME store, not cwd" \
   test -f "$NOGIT_HOME/.nanostack/skills/nogit-skill/SKILL.md"
 assert_true "no rogue .nanostack inside the cwd" \
@@ -210,6 +222,17 @@ assert_true "no rogue .nanostack inside the cwd" \
 out=$( HOME="$NOGIT_HOME" "$REPO/bin/check-custom-skill.sh" "$NOGIT_HOME/.nanostack/skills/nogit-skill" 2>&1 )
 assert_true "check-custom-skill passes outside git" \
   bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+# Conductor outside git must read the scaffolded SKILL.md from
+# $HOME/.nanostack/skills, not fall through to ~/.claude/skills or
+# the cwd-relative legacy root.
+HOME="$NOGIT_HOME" "$REPO/conductor/bin/sprint.sh" start \
+  --phases '[{"name":"think","depends_on":[]},{"name":"build","depends_on":["think"]},{"name":"nogit-skill","depends_on":["build"]},{"name":"ship","depends_on":["nogit-skill"]}]' \
+  >/dev/null
+nogit_batch=$( HOME="$NOGIT_HOME" "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+assert_true "no-git conductor reads SKILL.md (no 'no SKILL.md' warning)" \
+  bash -c "! echo '$nogit_batch' | grep -qF 'no SKILL.md found'"
+assert_true "no-git conductor schedules nogit-skill as type=read" \
+  bash -c "echo '$nogit_batch' | grep -qE '\"phases\":\\[[^]]*\"nogit-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"nogit-skill\"'"
 
 # Cell 15: validator catches a frontmatter name that does not match
 # the directory basename. Codex hit a false-positive OK after a

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -168,7 +168,7 @@ A failed validation aborts with exit `2` and the message `ERROR: invalid phase g
 `cmd_batch`'s `get_concurrency` reads the `concurrency:` frontmatter field from a phase's `SKILL.md`. Lookup order:
 
 1. Built-in core skill at `<nanostack_root>/<phase>/SKILL.md`.
-2. Custom skill resolved via `nano_phase_skill_path` — walks `.nanostack/skills/`, `~/.claude/skills/`, `~/.agents/skills/`, plus any `skill_roots` configured in `.nanostack/config.json`.
+2. Custom skill resolved via `nano_phase_skill_path`. Search order, most-specific to least: configured `skill_roots` from `.nanostack/config.json`, then `<store>/skills/` (where `<store>` comes from `bin/lib/store-path.sh` — the same path `bin/create-skill.sh` writes to), then `<config-dir>/skills/` (covers a global config under `$HOME/.nanostack/`), then the legacy cwd-relative `.nanostack/skills/`, then `$HOME/.claude/skills/` and `$HOME/.agents/skills/` for skills installed outside `.nanostack/`. The store-path-relative entries are the load-bearing ones: a scaffold from a git subdirectory or a no-git project lives in the resolved store, not under cwd.
 3. Conductor-only `build` stage returns `write` (no SKILL.md).
 4. Unknown phase falls back to `write` and emits a stderr warning. The conservative default avoids accidentally scheduling a custom write-phase as parallel-read.
 
@@ -215,7 +215,7 @@ Output is one `OK` or `FAIL` line per check, ending in `OK: <name> passed N chec
 
 ## End-to-end coverage
 
-`ci/e2e-custom-stack-flows.sh` runs the full new-user journey on a real `/tmp` project: scaffold → check → run helper → save → find → resolve → journal → analytics → discard → conductor start → conductor batch → openai.yaml present → no example-path leak. Twelve cells, nineteen assertions. The `e2e-custom-stack` GitHub Actions job runs it on every PR (`workflow_dispatch` for full e2e suite). When the harness is green, the framework claims in `README.md` and `EXTENDING.md` are grounded in working code.
+`ci/e2e-custom-stack-flows.sh` runs the full new-user journey on a real `/tmp` project: scaffold → check → run helper → save → find → resolve → journal → analytics → discard → conductor start → conductor batch → openai.yaml present → no example-path leak → subdirectory scaffold → no-git scaffold → frontmatter-name drift rejected. Fifteen cells, thirty assertions. The `e2e-custom-stack` GitHub Actions job runs it on `workflow_dispatch`. When the harness is green, the framework claims in `README.md` and `EXTENDING.md` are grounded in working code.
 
 ## Stability
 

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -176,6 +176,44 @@ A failed validation aborts with exit `2` and the message `ERROR: invalid phase g
 
 The output of `sprint.sh status` is keyed on phase names from the chosen graph. A custom graph that includes `audit-licenses` produces an `audit-licenses` entry under `.phases`, exactly as if it were a core phase. `sprint.sh batch` emits the same `{batch, type, phases}` JSON objects whether the phases are core, custom, or a mix.
 
+## Tooling
+
+`bin/create-skill.sh` scaffolds a custom skill and (by default) registers it as a custom phase in one shot.
+
+```bash
+bin/create-skill.sh license-audit --concurrency read --depends-on build
+```
+
+What it does:
+
+- Validates the skill name against the registry's regex (`^[a-z][a-z0-9-]*$`) and rejects any name that collides with a core phase.
+- Copies the bundled template (`examples/custom-skill-template/audit-licenses` by default; override with `--from <dir>`) into `.nanostack/skills/<name>/`.
+- Substitutes the source skill name with `<name>` in `SKILL.md`, `agents/openai.yaml`, and `README.md`.
+- Optionally rewrites the frontmatter `concurrency:` field (`--concurrency read|write|exclusive`) and `depends_on:` field (`--depends-on <phase>`, repeatable).
+- Adds `<name>` to `.custom_phases` in `.nanostack/config.json`. Idempotent — already-present names are not duplicated. `--no-register` skips this step.
+
+`bin/check-custom-skill.sh` validates a copied or scaffolded skill against the framework contract.
+
+```bash
+bin/check-custom-skill.sh .nanostack/skills/license-audit
+```
+
+What it checks:
+
+- `SKILL.md` exists with a `name:`, `description:`, and `concurrency:` frontmatter (`concurrency` must be `read`, `write`, or `exclusive`).
+- `agents/openai.yaml` exists and parses as YAML.
+- Every `bin/*.sh` passes `bash -n`.
+- The skill directory name matches the phase regex.
+- The phase is registered in `.nanostack/config.json:custom_phases` so `save-artifact.sh` and `resolve.sh` accept it.
+- `SKILL.md` does not embed `./examples/custom-skill-template/...` paths (would break after copy).
+- `save-artifact.sh` round-trips a smoke artifact and `find-artifact.sh` reads it back. The smoke artifact is removed after the check.
+
+Output is one `OK` or `FAIL` line per check, ending in `OK: <name> passed N checks.` or `FAIL: <K> of <N> checks failed for <name>.`. Exit `0` on full pass, `1` on any failure.
+
+## End-to-end coverage
+
+`ci/e2e-custom-stack-flows.sh` runs the full new-user journey on a real `/tmp` project: scaffold → check → run helper → save → find → resolve → journal → analytics → discard → conductor start → conductor batch → openai.yaml present → no example-path leak. Twelve cells, nineteen assertions. The `e2e-custom-stack` GitHub Actions job runs it on every PR (`workflow_dispatch` for full e2e suite). When the harness is green, the framework claims in `README.md` and `EXTENDING.md` are grounded in working code.
+
 ## Stability
 
 `phase_kind` is the load-bearing addition. Once shipped, downstream skills can branch on it. Future PRs may add new fields to the resolver output, but the existing shape stays — consumers should keep using `jq` field access rather than positional or shape-strict parsing.

--- a/reference/custom-stack-contract.md
+++ b/reference/custom-stack-contract.md
@@ -187,10 +187,11 @@ bin/create-skill.sh license-audit --concurrency read --depends-on build
 What it does:
 
 - Validates the skill name against the registry's regex (`^[a-z][a-z0-9-]*$`) and rejects any name that collides with a core phase.
-- Copies the bundled template (`examples/custom-skill-template/audit-licenses` by default; override with `--from <dir>`) into `.nanostack/skills/<name>/`.
+- Resolves the store path the same way every lifecycle script does (via `bin/lib/store-path.sh`): `$NANOSTACK_STORE` if set, otherwise the git repo root's `.nanostack/`, otherwise `$HOME/.nanostack/`. The skill lands at `<store>/skills/<name>/` and the registration is written to `<store>/config.json`. Same path that `save-artifact`, `resolve`, `analytics`, and `conductor` read from. A user invoking the tool from a git subdirectory writes to the repo root (not the subdir); a user without git writes to `$HOME/.nanostack/` (not the cwd).
+- Copies the bundled template (`examples/custom-skill-template/audit-licenses` by default; override with `--from <dir>`).
 - Substitutes the source skill name with `<name>` in `SKILL.md`, `agents/openai.yaml`, and `README.md`.
 - Optionally rewrites the frontmatter `concurrency:` field (`--concurrency read|write|exclusive`) and `depends_on:` field (`--depends-on <phase>`, repeatable).
-- Adds `<name>` to `.custom_phases` in `.nanostack/config.json`. Idempotent — already-present names are not duplicated. `--no-register` skips this step.
+- Adds `<name>` to `.custom_phases` in `<store>/config.json`. Idempotent — already-present names are not duplicated. `--no-register` skips this step.
 
 `bin/check-custom-skill.sh` validates a copied or scaffolded skill against the framework contract.
 
@@ -200,11 +201,13 @@ bin/check-custom-skill.sh .nanostack/skills/license-audit
 
 What it checks:
 
-- `SKILL.md` exists with a `name:`, `description:`, and `concurrency:` frontmatter (`concurrency` must be `read`, `write`, or `exclusive`).
-- `agents/openai.yaml` exists and parses as YAML.
+- `SKILL.md` exists with `name:`, `description:`, and `concurrency:` frontmatter (`concurrency` must be `read`, `write`, or `exclusive`).
+- The frontmatter `name:` matches the directory basename. A copied template that still says `name: audit-licenses` inside `license-audit/` would expose `/audit-licenses` to the agent — not what the user intended.
+- `agents/openai.yaml` exists and contains `display_name`, `short_description`, `default_prompt` under `interface:`. The validator uses narrow grep checks instead of a YAML library so it stays portable on any machine with bash + jq + standard tools (no PyYAML or external runtime needed).
+- The `display_name` references the new skill name, catching the same kind of drift in the OpenAI-discovery surface.
 - Every `bin/*.sh` passes `bash -n`.
 - The skill directory name matches the phase regex.
-- The phase is registered in `.nanostack/config.json:custom_phases` so `save-artifact.sh` and `resolve.sh` accept it.
+- The phase is registered in `<store>/config.json:custom_phases` so `save-artifact.sh` and `resolve.sh` accept it. `<store>` is resolved via `bin/lib/store-path.sh` — same path the scaffolder writes to.
 - `SKILL.md` does not embed `./examples/custom-skill-template/...` paths (would break after copy).
 - `save-artifact.sh` round-trips a smoke artifact and `find-artifact.sh` reads it back. The smoke artifact is removed after the check.
 


### PR DESCRIPTION
## Summary

Final PR of the Custom Stack Framework v1 round. Closes the spec's "Done Definition" — a clean sandbox user can complete the entire custom-skill workflow (scaffold, validate, run, save, read, journal, analytics, discard, conductor) without reading source.

## Changes

**Tooling**
- **`bin/create-skill.sh`** scaffolds a custom skill, rewrites paths to be self-contained, and registers the phase. Resolves the store via `bin/lib/store-path.sh` (git repo root or `$HOME/.nanostack/`), so a scaffold from a git subdir or a no-git project lands where every lifecycle script reads from. Validates the skill name against the registry regex and rejects collisions with core phase names. Flags: `--from <dir>`, `--concurrency <read|write|exclusive>`, `--depends-on <phase>` (repeatable), `--register` (default) / `--no-register`.
- **`bin/check-custom-skill.sh`** validates a copied or scaffolded skill against the framework contract: SKILL.md frontmatter (`name`, `description`, `concurrency` in `{read|write|exclusive}`), the frontmatter `name:` matches the directory basename, `agents/openai.yaml` has the three discovery keys (narrow grep — no PyYAML dependency), `display_name` references the skill, every `bin/*.sh` passes `bash -n`, name matches the phase regex, phase is registered in the resolved store's `config.json`, no repo-relative example paths leaked, `save-artifact` + `find-artifact` round-trip on a smoke artifact. Exits `0` on full pass, `1` on any failure.
- **`bin/lib/phases.sh`** `nano_phase_skill_path` now searches `$NANOSTACK_STORE/skills` and `<config-dir>/skills` before the cwd-relative legacy root. Conductor invoked from any cwd reads the scaffolded `SKILL.md` and honors its declared `concurrency`.

**End-to-end harness**
- **`ci/e2e-custom-stack-flows.sh`** runs the full new-user journey on a real `/tmp` project: **15 cells, 30 assertions**. Includes scaffold-from-subdir and scaffold-no-git cells that exercise conductor batch reading the SKILL.md from the resolved store, plus a frontmatter-name-drift rejection cell. New `e2e-custom-stack` GitHub Actions job runs it on `workflow_dispatch`.

**Docs**
- **`README.md` "Build on nanostack"** rewritten to claim only the guarantees the harness proves: `save`/`find`/`resolve` accept the phase, `phase_kind="custom"` in resolver output, sprint journal emits a section, analytics counts the phase, default discard includes it, conductor accepts a `--phases` graph, `cmd_batch` reads `concurrency` from `SKILL.md`.
- **`README.es.md`** gains a new "Construí tu propio skill" section with the same shape (Spanish first-class — Rule from PR #160).
- **`EXTENDING.md`**'s "Quickest way to start" block points at the new tooling, describes what the validator now checks, and documents the cwd-independent store resolution.
- **`reference/custom-stack-contract.md`** grows "Tooling" + "End-to-end coverage" sections; lookup-order paragraph reflects the new search path.

**CI lock**
- **`custom-stack-tooling`** round-trips `create-skill` + `check-custom-skill` on a `/tmp` project, asserts both helpers reject invalid skill names (uppercase, core-phase collision), and verifies `README.md` + `README.es.md` + `EXTENDING.md` all mention `bin/create-skill.sh` and `bin/check-custom-skill.sh`. Plus a token check on `README.md`'s Build-on-nanostack section so the public copy stays grounded in the harness.

## Test plan

- [x] tests/run.sh: 83/83
- [x] ci/e2e-user-flows.sh: 100/100
- [x] **ci/e2e-custom-stack-flows.sh: 30/30** (15 cells)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] Both YAML files parse
- [x] Manual: `bin/create-skill.sh license-audit --concurrency read --depends-on build` from project root, from a git subdirectory, and from a no-git tmp dir — all three cases scaffold to the resolved store and pass `bin/check-custom-skill.sh`.

## Round closure

After this lands, Custom Stack Framework v1 is complete:
- **PR 1 #196** phase registry library
- **PR 2 #197** resolver custom-phase support
- **PR 3 #198** + **#199** follow-up: copy-paste runnable template + fresh-shell safety
- **PR 4 #200** lifecycle outputs surface custom phases
- **PR 5 #201** conductor parses `--phases` and reads `phase_graph`
- **PR 6 (this)** tooling + docs + 15-cell E2E

The public phrasing rule from the spec relaxes: README and `EXTENDING.md` can now claim what the framework actually does.