### PR TITLE
custom-stack examples PR 1: compliance-release manifest + static contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3014,6 +3014,30 @@ jobs:
           done
           exit $fail
 
+  custom-stack-examples-contract:
+    name: Custom Stack Examples static contract
+    runs-on: ubuntu-latest
+    # PR 1 of the Custom Stack Examples v1 round. Validates every
+    # stack under examples/custom-stack-template/<name>/: manifest
+    # schema (kind=custom_stack_example, schema_version=1, name
+    # regex), skills[] structure (path exists, basename matches
+    # manifest, frontmatter name + concurrency match, openai.yaml
+    # has the three discovery keys, bin/smoke.sh is executable, at
+    # least one work-helper besides smoke, bash -n on every
+    # bin/*.sh), phase_graph membership (core ∪ build ∪ skills),
+    # ship depends on release-readiness when the stack ships one,
+    # README has the six required H2 sections and four required
+    # tokens, and no committed runtime artifacts (.nanostack,
+    # node_modules, .env, credential JSON, logs).
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run static contract
+        run: |
+          chmod +x ci/check-custom-stack-examples.sh
+          ci/check-custom-stack-examples.sh
+
   guard-rule-ids-unique:
     name: Guard rule ids are unique
     runs-on: ubuntu-latest

--- a/ci/check-custom-stack-examples.sh
+++ b/ci/check-custom-stack-examples.sh
@@ -196,6 +196,52 @@ for stack_dir in "${stack_dirs[@]}"; do
     fail "$stack_name phase_graph contains unknown names:$bad_graph"
   fi
 
+  # 10a. Every phase_graph[].depends_on[] target references a name that
+  #      exists in the same phase_graph. A misspelled dep would make the
+  #      conductor schedule run against a missing node, only surfacing
+  #      under runtime E2E. Catch it structurally.
+  bad_deps=""
+  while IFS=$'\t' read -r owner dep; do
+    [ -z "$dep" ] && continue
+    if ! printf '%s\n' "$graph_names" | grep -qFx "$dep"; then
+      bad_deps="$bad_deps $owner->$dep"
+    fi
+  done < <(jq -r '.phase_graph[]? | .name as $n | (.depends_on[]? | "\($n)\t\(.)")' "$stack_dir/stack.json")
+  if [ -z "$bad_deps" ]; then
+    ok "$stack_name phase_graph depends_on targets all resolve"
+  else
+    fail "$stack_name phase_graph has dangling depends_on:$bad_deps"
+  fi
+
+  # 10b. No duplicate phase_graph[].name. Two entries with the same
+  #      name would make depends_on ambiguous; the registry's runtime
+  #      validator already rejects this for config.phase_graph, so
+  #      catching it here in a static stack manifest stops the round
+  #      from shipping a contradictory shape.
+  graph_dupes=$(printf '%s\n' "$graph_names" | sort | uniq -d)
+  if [ -z "$graph_dupes" ]; then
+    ok "$stack_name phase_graph names are unique"
+  else
+    fail "$stack_name phase_graph contains duplicate names: $(echo "$graph_dupes" | tr '\n' ' ')"
+  fi
+
+  # 10c. Every declared skill appears in phase_graph. A stack that
+  #      ships a skill but never schedules it means the manifest and
+  #      the runtime contract drifted. The reverse (graph names not in
+  #      skills[]) is already covered by check 10.
+  missing_in_graph=""
+  while IFS= read -r s; do
+    [ -z "$s" ] && continue
+    if ! printf '%s\n' "$graph_names" | grep -qFx "$s"; then
+      missing_in_graph="$missing_in_graph $s"
+    fi
+  done <<< "$skill_names"
+  if [ -z "$missing_in_graph" ]; then
+    ok "$stack_name every declared skill appears in phase_graph"
+  else
+    fail "$stack_name skills declared but not in phase_graph:$missing_in_graph"
+  fi
+
   # 11. ship depends on the stack's composer (if there is a release-readiness
   #     skill, ship must depend on it, not directly on the review/security/qa
   #     trio). Spec rule for this stack; future stacks may declare a

--- a/ci/check-custom-stack-examples.sh
+++ b/ci/check-custom-stack-examples.sh
@@ -242,6 +242,36 @@ for stack_dir in "${stack_dirs[@]}"; do
     fail "$stack_name skills declared but not in phase_graph:$missing_in_graph"
   fi
 
+  # 10d. phase_graph is acyclic. Conductor's runtime validator will
+  #      reject a cyclic graph at sprint start, but a stack that ships
+  #      with a cycle would only fail under PR 3 runtime E2E. Catch it
+  #      here statically using the same Kahn's-algorithm reduction the
+  #      registry uses (bin/lib/phases.sh _nano_phase_graph_is_valid).
+  if jq -e '
+    .phase_graph as $g |
+    def acyclic:
+      reduce range(0; ($g | length) + 1) as $_ (
+        $g;
+        if length == 0 then .
+        else
+          ([.[] | select(.depends_on | length == 0) | .name]) as $leaves |
+          if ($leaves | length) == 0 then null
+          else
+            [.[]
+              | select(.name as $n | ($leaves | index($n)) | not)
+              | .depends_on |= map(select(. as $d | ($leaves | index($d)) | not))
+            ]
+          end
+        end
+      ) |
+      . != null and length == 0;
+    acyclic
+  ' "$stack_dir/stack.json" >/dev/null 2>&1; then
+    ok "$stack_name phase_graph is acyclic"
+  else
+    fail "$stack_name phase_graph contains a cycle"
+  fi
+
   # 11. ship depends on the stack's composer (if there is a release-readiness
   #     skill, ship must depend on it, not directly on the review/security/qa
   #     trio). Spec rule for this stack; future stacks may declare a

--- a/ci/check-custom-stack-examples.sh
+++ b/ci/check-custom-stack-examples.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# check-custom-stack-examples.sh — Static contract for stack examples
+# under examples/custom-stack-template/. Validates the manifest
+# schema, the README structure, the skill folder layout, and the
+# absence of committed runtime artifacts. Run on every PR via the
+# custom-stack-examples-contract lint job.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE_ROOT="$REPO_ROOT/examples/custom-stack-template"
+
+PASS=0
+FAIL=0
+
+ok()    { printf '  ok    %s\n' "$1"; PASS=$((PASS + 1)); }
+fail()  { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# 1. Top-level README exists.
+if [ -f "$TEMPLATE_ROOT/README.md" ]; then
+  ok "examples/custom-stack-template/README.md exists"
+else
+  fail "examples/custom-stack-template/README.md missing"
+fi
+
+# 2. At least one stack folder exists. Validate every stack found.
+shopt -s nullglob 2>/dev/null || true
+stack_dirs=()
+for d in "$TEMPLATE_ROOT"/*/; do
+  [ -f "$d/stack.json" ] || continue
+  stack_dirs+=("${d%/}")
+done
+
+if [ "${#stack_dirs[@]}" -eq 0 ]; then
+  fail "no stack found under examples/custom-stack-template/<name>/stack.json"
+  exit 1
+fi
+
+for stack_dir in "${stack_dirs[@]}"; do
+  stack_name=$(basename "$stack_dir")
+  printf '\n[stack: %s]\n' "$stack_name"
+
+  # 3. Stack README exists.
+  if [ -f "$stack_dir/README.md" ]; then
+    ok "$stack_name/README.md exists"
+  else
+    fail "$stack_name/README.md missing"
+    continue
+  fi
+
+  # 4. stack.json parses.
+  if ! jq . "$stack_dir/stack.json" >/dev/null 2>&1; then
+    fail "$stack_name/stack.json does not parse"
+    continue
+  fi
+  ok "$stack_name/stack.json parses"
+
+  # 5. kind == custom_stack_example.
+  kind=$(jq -r '.kind // "missing"' "$stack_dir/stack.json")
+  if [ "$kind" = "custom_stack_example" ]; then
+    ok "$stack_name kind is custom_stack_example"
+  else
+    fail "$stack_name kind is '$kind', expected custom_stack_example"
+  fi
+
+  # 6. schema_version == "1".
+  sv=$(jq -r '.schema_version // "missing"' "$stack_dir/stack.json")
+  if [ "$sv" = "1" ]; then
+    ok "$stack_name schema_version is 1"
+  else
+    fail "$stack_name schema_version is '$sv', expected 1"
+  fi
+
+  # 7. name matches phase regex.
+  manifest_name=$(jq -r '.name // ""' "$stack_dir/stack.json")
+  if printf '%s' "$manifest_name" | grep -qE '^[a-z][a-z0-9-]*$'; then
+    ok "$stack_name manifest .name '$manifest_name' matches phase regex"
+  else
+    fail "$stack_name manifest .name '$manifest_name' does not match phase regex"
+  fi
+
+  # 8. Each skills[].name is unique and matches the phase regex.
+  skill_names=$(jq -r '.skills[]?.name' "$stack_dir/stack.json")
+  if [ -z "$skill_names" ]; then
+    fail "$stack_name has no skills[]"
+    continue
+  fi
+  dupes=$(printf '%s\n' "$skill_names" | sort | uniq -d)
+  if [ -n "$dupes" ]; then
+    fail "$stack_name skills[].name contains duplicates: $(echo "$dupes" | tr '\n' ' ')"
+  else
+    ok "$stack_name skills[].name are unique"
+  fi
+  bad_skill_names=""
+  while IFS= read -r n; do
+    [ -z "$n" ] && continue
+    if ! printf '%s' "$n" | grep -qE '^[a-z][a-z0-9-]*$'; then
+      bad_skill_names="$bad_skill_names $n"
+    fi
+  done <<< "$skill_names"
+  if [ -z "$bad_skill_names" ]; then
+    ok "$stack_name all skills[].name match phase regex"
+  else
+    fail "$stack_name skills[].name fail phase regex:$bad_skill_names"
+  fi
+
+  # 9. Each skills[].path exists and contains SKILL.md.
+  while IFS=$'\t' read -r skill_name skill_path concurrency; do
+    [ -z "$skill_name" ] && continue
+    full_path="$stack_dir/$skill_path"
+    if [ ! -d "$full_path" ]; then
+      fail "$stack_name/$skill_name path '$skill_path' does not exist"
+      continue
+    fi
+    if [ ! -f "$full_path/SKILL.md" ]; then
+      fail "$stack_name/$skill_name $skill_path/SKILL.md missing"
+      continue
+    fi
+    # Skill directory basename matches manifest name.
+    if [ "$(basename "$full_path")" != "$skill_name" ]; then
+      fail "$stack_name/$skill_name path basename '$(basename "$full_path")' != manifest name '$skill_name'"
+    else
+      ok "$stack_name/$skill_name path basename matches manifest name"
+    fi
+    # SKILL.md frontmatter name matches.
+    fm_name=$(awk '/^---[[:space:]]*$/{f++; next} f==1' "$full_path/SKILL.md" \
+      | grep -E '^name:[[:space:]]' | head -1 | sed 's/^name:[[:space:]]*//')
+    if [ "$fm_name" = "$skill_name" ]; then
+      ok "$stack_name/$skill_name SKILL.md frontmatter name matches"
+    else
+      fail "$stack_name/$skill_name SKILL.md frontmatter name is '$fm_name', expected '$skill_name'"
+    fi
+    # SKILL.md frontmatter concurrency matches manifest.
+    fm_conc=$(awk '/^---[[:space:]]*$/{f++; next} f==1' "$full_path/SKILL.md" \
+      | grep -E '^concurrency:[[:space:]]' | head -1 | sed 's/^concurrency:[[:space:]]*//')
+    if [ "$fm_conc" = "$concurrency" ]; then
+      ok "$stack_name/$skill_name concurrency matches manifest"
+    else
+      fail "$stack_name/$skill_name concurrency '$fm_conc' does not match manifest '$concurrency'"
+    fi
+    # agents/openai.yaml exists with the three discovery keys.
+    oy="$full_path/agents/openai.yaml"
+    if [ ! -f "$oy" ]; then
+      fail "$stack_name/$skill_name agents/openai.yaml missing"
+    else
+      ok "$stack_name/$skill_name agents/openai.yaml exists"
+      oy_fail=0
+      for k in display_name short_description default_prompt; do
+        grep -qE "^[[:space:]]+${k}:" "$oy" || { oy_fail=1; fail "$stack_name/$skill_name openai.yaml missing key '$k'"; }
+      done
+      [ "$oy_fail" -eq 0 ] && ok "$stack_name/$skill_name openai.yaml has display_name + short_description + default_prompt"
+    fi
+    # bin/smoke.sh exists and is executable.
+    smoke="$full_path/bin/smoke.sh"
+    if [ -x "$smoke" ]; then
+      ok "$stack_name/$skill_name bin/smoke.sh is executable"
+    else
+      fail "$stack_name/$skill_name bin/smoke.sh missing or not executable"
+    fi
+    # At least one bin/*.sh besides smoke.sh exists.
+    other_helpers=0
+    for s in "$full_path/bin"/*.sh; do
+      [ -f "$s" ] || continue
+      [ "$(basename "$s")" = "smoke.sh" ] && continue
+      other_helpers=$((other_helpers + 1))
+    done
+    if [ "$other_helpers" -ge 1 ]; then
+      ok "$stack_name/$skill_name has at least one work-helper besides smoke.sh"
+    else
+      fail "$stack_name/$skill_name has no work-helper script besides smoke.sh"
+    fi
+    # Every bin/*.sh passes bash -n.
+    bin_n_fail=0
+    for s in "$full_path/bin"/*.sh; do
+      [ -f "$s" ] || continue
+      bash -n "$s" 2>/dev/null || { bin_n_fail=1; fail "$stack_name/$skill_name bash -n fails on $(basename "$s")"; }
+    done
+    [ "$bin_n_fail" -eq 0 ] && ok "$stack_name/$skill_name bash -n passes on every bin/*.sh"
+  done < <(jq -r '.skills[]? | "\(.name)\t\(.path)\t\(.concurrency)"' "$stack_dir/stack.json")
+
+  # 10. phase_graph membership: every phase_graph[].name is core ∪ build ∪ skills.
+  core_phases="think plan review qa security ship"
+  graph_names=$(jq -r '.phase_graph[]?.name' "$stack_dir/stack.json")
+  bad_graph=""
+  while IFS= read -r g; do
+    [ -z "$g" ] && continue
+    case " $core_phases build " in
+      *" $g "*) continue ;;
+    esac
+    if ! printf '%s\n' "$skill_names" | grep -qFx "$g"; then
+      bad_graph="$bad_graph $g"
+    fi
+  done <<< "$graph_names"
+  if [ -z "$bad_graph" ]; then
+    ok "$stack_name phase_graph names are all core/build/skill"
+  else
+    fail "$stack_name phase_graph contains unknown names:$bad_graph"
+  fi
+
+  # 11. ship depends on the stack's composer (if there is a release-readiness
+  #     skill, ship must depend on it, not directly on the review/security/qa
+  #     trio). Spec rule for this stack; future stacks may declare a
+  #     different composer in stack.json — for now the rule applies when the
+  #     skill is named release-readiness.
+  if printf '%s\n' "$skill_names" | grep -qFx "release-readiness"; then
+    ship_deps=$(jq -r '.phase_graph[]? | select(.name == "ship") | .depends_on[]?' "$stack_dir/stack.json")
+    if [ -n "$ship_deps" ] && printf '%s\n' "$ship_deps" | grep -qFx "release-readiness"; then
+      ok "$stack_name ship depends on release-readiness"
+    else
+      fail "$stack_name ship does not depend on release-readiness (got: $ship_deps)"
+    fi
+  fi
+
+  # 12. README has the six required H2 sections.
+  for h in "Who this stack is for" "What it adds" "Install in a sandbox" \
+           "Run the workflow" "Expected evidence" "Reset"; do
+    if grep -qE "^##[[:space:]]+${h}\$" "$stack_dir/README.md"; then
+      ok "$stack_name README has '## $h' section"
+    else
+      fail "$stack_name README missing '## $h' section"
+    fi
+  done
+
+  # 13. README mentions the four required tokens.
+  for tok in "bin/create-skill.sh" "bin/check-custom-skill.sh" \
+             "conductor/bin/sprint.sh" "release-readiness"; do
+    if grep -qF "$tok" "$stack_dir/README.md"; then
+      ok "$stack_name README mentions '$tok'"
+    else
+      fail "$stack_name README missing token '$tok'"
+    fi
+  done
+
+  # 14. No committed runtime artifacts under the stack tree.
+  rogue_paths=()
+  for unsafe in ".nanostack" "node_modules" ".env" ".env.local" \
+                ".env.production" ".env.staging" "*.log"; do
+    while IFS= read -r m; do
+      [ -n "$m" ] && rogue_paths+=("$m")
+    done < <(find "$stack_dir" -name "$unsafe" -not -path "*/.git/*" 2>/dev/null)
+  done
+  # Also detect credential JSON basenames that the bash guard blocks.
+  while IFS= read -r m; do
+    [ -n "$m" ] && rogue_paths+=("$m")
+  done < <(find "$stack_dir" -type f \( \
+    -iname "credentials.json" -o -iname "secrets.json" -o \
+    -iname "secret.json"      -o -iname "credential.json" -o \
+    -iname "service-account.json" -o -iname "service_account.json" -o \
+    -iname "firebase-adminsdk.json" -o \
+    -iname "google-credentials.json" -o -iname "gcp-credentials.json" -o \
+    -iname "aws-credentials.json"   -o -iname "supabase-service-role.json" -o \
+    -iname "client_secret.json"     -o -iname "client-secret.json" -o \
+    -iname "client-secrets.json" \
+  \) -not -path "*/.git/*" 2>/dev/null)
+  if [ "${#rogue_paths[@]}" -eq 0 ]; then
+    ok "$stack_name has no committed runtime artifacts"
+  else
+    fail "$stack_name has committed runtime artifacts: ${rogue_paths[*]}"
+  fi
+done
+
+printf '\n=========================\n'
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf 'Custom Stack Examples contract: %d checks passed, 0 failed\n' "$PASS"
+  exit 0
+fi
+printf 'Custom Stack Examples contract: %d failed of %d total\n' "$FAIL" "$TOTAL"
+exit 1

--- a/examples/custom-stack-template/README.md
+++ b/examples/custom-stack-template/README.md
@@ -1,0 +1,49 @@
+# Custom Stack Templates
+
+Working examples of multi-skill stacks you can copy and adapt. Sister to `examples/custom-skill-template/`, which shows a single skill in isolation; this folder shows how multiple skills compose into a domain workflow.
+
+A stack is a set of custom skills plus a `phase_graph` that wires them into the rest of the sprint. Each skill saves artifacts, reads upstream artifacts, and lets `conductor/bin/sprint.sh` schedule it. The framework contract those skills inherit lives in [`reference/custom-stack-contract.md`](../../reference/custom-stack-contract.md). The spec for this round of examples lives in [`reference/custom-stack-examples-technical-spec.md`](../../reference/custom-stack-examples-technical-spec.md).
+
+## Available stacks
+
+| Stack | What it does | When to copy |
+|---|---|---|
+| [`compliance-release/`](compliance-release/) | License audit + privacy hygiene + release-readiness composer that gates `/ship` | You ship code that may include third-party licenses or collect personal data, and you want a deterministic release-decision step before `/ship`. |
+
+More stacks land here as they prove out the framework. The first one (`compliance-release/`) is the reference shape — match its `stack.json` schema and README structure when adding new stacks.
+
+## How a stack is structured
+
+```
+<stack-name>/
+  README.md      # who this stack is for, install steps, expected evidence
+  stack.json     # manifest with kind: "custom_stack_example"
+  skills/
+    <skill-1>/
+      SKILL.md
+      agents/openai.yaml
+      bin/<work>.sh
+      bin/smoke.sh
+    <skill-2>/...
+    <skill-3>/...
+```
+
+The `stack.json` is an **example manifest**, not a project-level Nanostack stack-preferences file. The `kind: "custom_stack_example"` field makes the distinction explicit so tooling can validate.
+
+## Contract for a new stack
+
+Before opening a PR with a new stack, run:
+
+```bash
+ci/check-custom-stack-examples.sh
+```
+
+It validates the manifest schema, the README structure, the skill folder shape, the absence of committed runtime artifacts, and `bash -n` on every helper. Once PR 3 of this round lands, `ci/e2e-custom-stack-examples.sh` will additionally exercise the runtime contract on a real `/tmp` project.
+
+## What's covered today
+
+- **Manifest + structural lint** — every stack file shape and skill folder layout (this PR).
+- **Skill behavior** — license audit, privacy hygiene, release-readiness composer (next PR).
+- **Runtime install + journey** — scaffold the stack, save artifacts, resolve, journal, analytics, discard, conductor scheduling (PR 3 of the round).
+
+Until PR 3 ships, the stacks here are wired and lint-checked but not yet end-to-end runnable as a workflow. The status of each stack is on its own README.

--- a/examples/custom-stack-template/README.md
+++ b/examples/custom-stack-template/README.md
@@ -10,7 +10,7 @@ A stack is a set of custom skills plus a `phase_graph` that wires them into the 
 |---|---|---|
 | [`compliance-release/`](compliance-release/) | License audit + privacy hygiene + release-readiness composer that gates `/ship` | You ship code that may include third-party licenses or collect personal data, and you want a deterministic release-decision step before `/ship`. |
 
-More stacks land here as they prove out the framework. The first one (`compliance-release/`) is the reference shape — match its `stack.json` schema and README structure when adding new stacks.
+More stacks land here as they prove out the framework. The first one (`compliance-release/`) is the reference shape: match its `stack.json` schema and README structure when adding new stacks.
 
 ## How a stack is structured
 
@@ -42,8 +42,8 @@ It validates the manifest schema, the README structure, the skill folder shape, 
 
 ## What's covered today
 
-- **Manifest + structural lint** — every stack file shape and skill folder layout (this PR).
-- **Skill behavior** — license audit, privacy hygiene, release-readiness composer (next PR).
-- **Runtime install + journey** — scaffold the stack, save artifacts, resolve, journal, analytics, discard, conductor scheduling (PR 3 of the round).
+- **Manifest + structural lint**: every stack file shape and skill folder layout (this PR).
+- **Skill behavior**: license audit, privacy hygiene, release-readiness composer (next PR).
+- **Runtime install + journey**: scaffold the stack, save artifacts, resolve, journal, analytics, discard, conductor scheduling (PR 3 of the round).
 
 Until PR 3 ships, the stacks here are wired and lint-checked but not yet end-to-end runnable as a workflow. The status of each stack is on its own README.

--- a/examples/custom-stack-template/compliance-release/README.md
+++ b/examples/custom-stack-template/compliance-release/README.md
@@ -1,0 +1,145 @@
+# Compliance Release Stack
+
+A three-skill stack that gates `/ship` on license, privacy, and release-readiness evidence. Read-only by design — no commits, no PRs, no deploys, no network calls.
+
+> Status: **PR 1 of the Custom Stack Examples v1 round.** The manifest, README, and skill folders are in place and the static contract (`ci/check-custom-stack-examples.sh`) passes. Skill behavior lands in PR 2; runtime end-to-end coverage lands in PR 3. The install commands below run once PR 3 ships; until then the skills are stubs that satisfy the structural contract.
+
+## Who this stack is for
+
+Teams that ship code with third-party dependencies and may collect personal data, and want a deterministic release-decision step before `/ship`. Concretely:
+
+- You want a release gate that fails closed when QA evidence is missing or a privacy signal has no documented mitigation.
+- You want license risk surfaced as part of the sprint, not as a separate manual step.
+- You want the gate's decision recorded as an artifact your sprint journal and analytics already understand.
+
+If you only need any one of those, copying a single skill from `examples/custom-skill-template/` is a smaller starting point. This stack is the integrated workflow.
+
+## What it adds
+
+Three custom phases, wired into the sprint via `phase_graph` so `conductor/bin/sprint.sh` knows the dependency order:
+
+- **`/license-audit`** — scans direct dependencies for GPL, AGPL, or unknown licenses. Output: per-family counts and a flagged list. Status `OK`, `WARN` (unknown licenses), or `BLOCKED` (GPL/AGPL).
+- **`/privacy-check`** — release-hygiene check. Surfaces personal-data collection signals (forms, API routes that take email/name/phone/address/payment), telemetry libraries, and whether a privacy note exists. **Not a legal review.**
+- **`/release-readiness`** — composer. Reads `review`, `qa`, `security`, `license-audit`, and `privacy-check` artifacts and emits a single status. `BLOCKED` if any upstream is `BLOCKED` or required evidence is missing; `WARN` if any upstream is `WARN`; `OK` otherwise. Sits between the rest of the sprint and `/ship`.
+
+The `phase_graph` in `stack.json` puts `release-readiness` directly upstream of `ship` so the conductor cannot schedule `/ship` before the gate has run.
+
+## Install in a sandbox
+
+> The install commands below assume Custom Stack Examples PR 2 has merged so each skill has real behavior. Until then, scaffolding works but the helpers print placeholder output. PR 3 wires the runtime end-to-end harness that proves this section.
+
+From a sandbox project with Nanostack on `PATH`:
+
+```bash
+bin/create-skill.sh license-audit \
+  --from examples/custom-stack-template/compliance-release/skills/license-audit \
+  --concurrency read \
+  --depends-on build
+
+bin/create-skill.sh privacy-check \
+  --from examples/custom-stack-template/compliance-release/skills/privacy-check \
+  --concurrency read \
+  --depends-on build
+
+bin/create-skill.sh release-readiness \
+  --from examples/custom-stack-template/compliance-release/skills/release-readiness \
+  --concurrency read \
+  --depends-on review \
+  --depends-on qa \
+  --depends-on security \
+  --depends-on license-audit \
+  --depends-on privacy-check
+```
+
+Then wire the `phase_graph` so the conductor knows the full topology:
+
+```bash
+jq '.phase_graph = [
+  {"name":"think","depends_on":[]},
+  {"name":"plan","depends_on":["think"]},
+  {"name":"build","depends_on":["plan"]},
+  {"name":"review","depends_on":["build"]},
+  {"name":"qa","depends_on":["build"]},
+  {"name":"security","depends_on":["build"]},
+  {"name":"license-audit","depends_on":["build"]},
+  {"name":"privacy-check","depends_on":["build"]},
+  {"name":"release-readiness","depends_on":["review","qa","security","license-audit","privacy-check"]},
+  {"name":"ship","depends_on":["release-readiness"]}
+]' .nanostack/config.json > .nanostack/config.json.tmp \
+  && mv .nanostack/config.json.tmp .nanostack/config.json
+```
+
+Validate each scaffolded skill:
+
+```bash
+bin/check-custom-skill.sh .nanostack/skills/license-audit
+bin/check-custom-skill.sh .nanostack/skills/privacy-check
+bin/check-custom-skill.sh .nanostack/skills/release-readiness
+```
+
+Restart your agent so it picks up the three new slash commands.
+
+## Run the workflow
+
+The skills are read-only and idempotent. Run them in any order; the conductor (and `release-readiness`) reads the latest artifact for each upstream.
+
+```bash
+# License + privacy can run in parallel — both are concurrency=read.
+.nanostack/skills/license-audit/bin/audit.sh
+.nanostack/skills/privacy-check/bin/check.sh
+
+# release-readiness composes the upstream artifacts into a status.
+.nanostack/skills/release-readiness/bin/summarize.sh
+```
+
+Each helper saves an artifact via `bin/save-artifact.sh`. The full schedule, including parallelism, comes from the conductor:
+
+```bash
+conductor/bin/sprint.sh start
+conductor/bin/sprint.sh batch
+```
+
+`batch` returns the parallel groups in topological order. `license-audit` and `privacy-check` schedule together as `concurrency: read` after `build`; `release-readiness` waits for those plus the core review/qa/security artifacts; `ship` waits for `release-readiness`.
+
+## Expected evidence
+
+After running the workflow once, these are the artifacts and outputs you should see — every line is something Codex's spec or PR 3's harness asserts.
+
+- `.nanostack/license-audit/<timestamp>.json` exists with `summary.status`, `summary.counts`, `summary.flagged`.
+- `.nanostack/privacy-check/<timestamp>.json` exists with `summary.status`, `summary.signals`, `summary.missing`.
+- `.nanostack/release-readiness/<timestamp>.json` exists with `summary.status`, `summary.checks` (one entry per upstream), and `summary.next_action`.
+- `bin/resolve.sh release-readiness` returns `phase_kind: "custom"` with `upstream_artifacts` keys for all five upstreams.
+- `bin/sprint-journal.sh` emits `## /license-audit`, `## /privacy-check`, and `## /release-readiness` sections.
+- `bin/analytics.sh --json` includes all three phases under `sprints.custom`, with `sprints.total` summing core + custom.
+- `bin/discard-sprint.sh --dry-run` lists the three custom artifacts alongside the core ones.
+- `conductor/bin/sprint.sh batch` schedules `license-audit` and `privacy-check` as `type=read` after `build`, then `release-readiness` after the five upstreams complete, then `ship` after `release-readiness`.
+
+If any of these fails, `release-readiness` is supposed to surface it — that's the entire point of the gate.
+
+## Reset
+
+To remove the stack from a sandbox project:
+
+```bash
+rm -rf .nanostack/skills/license-audit \
+       .nanostack/skills/privacy-check \
+       .nanostack/skills/release-readiness
+
+jq '.custom_phases -= ["license-audit","privacy-check","release-readiness"]' \
+  .nanostack/config.json > .nanostack/config.json.tmp \
+  && mv .nanostack/config.json.tmp .nanostack/config.json
+
+# Optional: drop the saved artifacts too.
+rm -rf .nanostack/license-audit \
+       .nanostack/privacy-check \
+       .nanostack/release-readiness
+```
+
+If you also wired `phase_graph` and want to revert to the canonical default sprint, remove the field:
+
+```bash
+jq 'del(.phase_graph)' .nanostack/config.json > .nanostack/config.json.tmp \
+  && mv .nanostack/config.json.tmp .nanostack/config.json
+```
+
+Restart your agent so it stops surfacing the slash commands.

--- a/examples/custom-stack-template/compliance-release/README.md
+++ b/examples/custom-stack-template/compliance-release/README.md
@@ -1,6 +1,6 @@
 # Compliance Release Stack
 
-A three-skill stack that gates `/ship` on license, privacy, and release-readiness evidence. Read-only by design — no commits, no PRs, no deploys, no network calls.
+A three-skill stack that gates `/ship` on license, privacy, and release-readiness evidence. Read-only by design: no commits, no PRs, no deploys, no network calls.
 
 > Status: **PR 1 of the Custom Stack Examples v1 round.** The manifest, README, and skill folders are in place and the static contract (`ci/check-custom-stack-examples.sh`) passes. Skill behavior lands in PR 2; runtime end-to-end coverage lands in PR 3. The install commands below run once PR 3 ships; until then the skills are stubs that satisfy the structural contract.
 
@@ -18,9 +18,9 @@ If you only need any one of those, copying a single skill from `examples/custom-
 
 Three custom phases, wired into the sprint via `phase_graph` so `conductor/bin/sprint.sh` knows the dependency order:
 
-- **`/license-audit`** — scans direct dependencies for GPL, AGPL, or unknown licenses. Output: per-family counts and a flagged list. Status `OK`, `WARN` (unknown licenses), or `BLOCKED` (GPL/AGPL).
-- **`/privacy-check`** — release-hygiene check. Surfaces personal-data collection signals (forms, API routes that take email/name/phone/address/payment), telemetry libraries, and whether a privacy note exists. **Not a legal review.**
-- **`/release-readiness`** — composer. Reads `review`, `qa`, `security`, `license-audit`, and `privacy-check` artifacts and emits a single status. `BLOCKED` if any upstream is `BLOCKED` or required evidence is missing; `WARN` if any upstream is `WARN`; `OK` otherwise. Sits between the rest of the sprint and `/ship`.
+- **`/license-audit`**: scans direct dependencies for GPL, AGPL, or unknown licenses. Output: per-family counts and a flagged list. Status `OK`, `WARN` (unknown licenses), or `BLOCKED` (GPL/AGPL).
+- **`/privacy-check`**: release-hygiene check. Surfaces personal-data collection signals (forms, API routes that take email/name/phone/address/payment), telemetry libraries, and whether a privacy note exists. **Not a legal review.**
+- **`/release-readiness`**: composer. Reads `review`, `qa`, `security`, `license-audit`, and `privacy-check` artifacts and emits a single status. `BLOCKED` if any upstream is `BLOCKED` or required evidence is missing; `WARN` if any upstream is `WARN`; `OK` otherwise. Sits between the rest of the sprint and `/ship`.
 
 The `phase_graph` in `stack.json` puts `release-readiness` directly upstream of `ship` so the conductor cannot schedule `/ship` before the gate has run.
 
@@ -28,21 +28,32 @@ The `phase_graph` in `stack.json` puts `release-readiness` directly upstream of 
 
 > The install commands below assume Custom Stack Examples PR 2 has merged so each skill has real behavior. Until then, scaffolding works but the helpers print placeholder output. PR 3 wires the runtime end-to-end harness that proves this section.
 
-From a sandbox project with Nanostack on `PATH`:
+The Nanostack scaffolder (`bin/create-skill.sh`) reads the source skill via `--from`. Setting an absolute path makes the install work regardless of the sandbox project's cwd. Point `NANOSTACK_ROOT` at your local Nanostack checkout (the directory that contains `bin/create-skill.sh`):
 
 ```bash
-bin/create-skill.sh license-audit \
-  --from examples/custom-stack-template/compliance-release/skills/license-audit \
+# Substitute the path to your Nanostack checkout.
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+STACK_DIR="$NANOSTACK_ROOT/examples/custom-stack-template/compliance-release"
+```
+
+Scaffold the three skills from the absolute stack path:
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+STACK_DIR="$NANOSTACK_ROOT/examples/custom-stack-template/compliance-release"
+
+"$NANOSTACK_ROOT/bin/create-skill.sh" license-audit \
+  --from "$STACK_DIR/skills/license-audit" \
   --concurrency read \
   --depends-on build
 
-bin/create-skill.sh privacy-check \
-  --from examples/custom-stack-template/compliance-release/skills/privacy-check \
+"$NANOSTACK_ROOT/bin/create-skill.sh" privacy-check \
+  --from "$STACK_DIR/skills/privacy-check" \
   --concurrency read \
   --depends-on build
 
-bin/create-skill.sh release-readiness \
-  --from examples/custom-stack-template/compliance-release/skills/release-readiness \
+"$NANOSTACK_ROOT/bin/create-skill.sh" release-readiness \
+  --from "$STACK_DIR/skills/release-readiness" \
   --concurrency read \
   --depends-on review \
   --depends-on qa \
@@ -51,9 +62,12 @@ bin/create-skill.sh release-readiness \
   --depends-on privacy-check
 ```
 
-Then wire the `phase_graph` so the conductor knows the full topology:
+`bin/create-skill.sh` resolves the install destination via `bin/lib/store-path.sh` (your repo root's `.nanostack/`, or `$HOME/.nanostack/` outside git), so the skills land where every lifecycle script reads from regardless of which subdirectory you ran the command from.
+
+Then wire the `phase_graph` so the conductor knows the full topology. Resolve the store path the same way the scaffolder did:
 
 ```bash
+STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
 jq '.phase_graph = [
   {"name":"think","depends_on":[]},
   {"name":"plan","depends_on":["think"]},
@@ -65,17 +79,20 @@ jq '.phase_graph = [
   {"name":"privacy-check","depends_on":["build"]},
   {"name":"release-readiness","depends_on":["review","qa","security","license-audit","privacy-check"]},
   {"name":"ship","depends_on":["release-readiness"]}
-]' .nanostack/config.json > .nanostack/config.json.tmp \
-  && mv .nanostack/config.json.tmp .nanostack/config.json
+]' "$STORE/config.json" > "$STORE/config.json.tmp" \
+  && mv "$STORE/config.json.tmp" "$STORE/config.json"
 ```
 
-Validate each scaffolded skill:
+Validate each scaffolded skill against the framework contract:
 
 ```bash
-bin/check-custom-skill.sh .nanostack/skills/license-audit
-bin/check-custom-skill.sh .nanostack/skills/privacy-check
-bin/check-custom-skill.sh .nanostack/skills/release-readiness
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/license-audit"
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/privacy-check"
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/release-readiness"
 ```
+
+Each invocation should end with `OK: <name> passed N checks.`. The path expression resolves the same store `bin/create-skill.sh` wrote to (your repo root's `.nanostack/skills/` inside git, or `$HOME/.nanostack/skills/` outside git).
 
 Restart your agent so it picks up the three new slash commands.
 
@@ -84,26 +101,30 @@ Restart your agent so it picks up the three new slash commands.
 The skills are read-only and idempotent. Run them in any order; the conductor (and `release-readiness`) reads the latest artifact for each upstream.
 
 ```bash
-# License + privacy can run in parallel — both are concurrency=read.
-.nanostack/skills/license-audit/bin/audit.sh
-.nanostack/skills/privacy-check/bin/check.sh
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+SKILLS_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills"
+
+# License + privacy can run in parallel (both are concurrency=read).
+"$SKILLS_ROOT/license-audit/bin/audit.sh"
+"$SKILLS_ROOT/privacy-check/bin/check.sh"
 
 # release-readiness composes the upstream artifacts into a status.
-.nanostack/skills/release-readiness/bin/summarize.sh
+"$SKILLS_ROOT/release-readiness/bin/summarize.sh"
 ```
 
 Each helper saves an artifact via `bin/save-artifact.sh`. The full schedule, including parallelism, comes from the conductor:
 
 ```bash
-conductor/bin/sprint.sh start
-conductor/bin/sprint.sh batch
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/conductor/bin/sprint.sh" start
+"$NANOSTACK_ROOT/conductor/bin/sprint.sh" batch
 ```
 
 `batch` returns the parallel groups in topological order. `license-audit` and `privacy-check` schedule together as `concurrency: read` after `build`; `release-readiness` waits for those plus the core review/qa/security artifacts; `ship` waits for `release-readiness`.
 
 ## Expected evidence
 
-After running the workflow once, these are the artifacts and outputs you should see — every line is something Codex's spec or PR 3's harness asserts.
+After running the workflow once, these are the artifacts and outputs you should see; every line is something Codex's spec or PR 3's harness asserts.
 
 - `.nanostack/license-audit/<timestamp>.json` exists with `summary.status`, `summary.counts`, `summary.flagged`.
 - `.nanostack/privacy-check/<timestamp>.json` exists with `summary.status`, `summary.signals`, `summary.missing`.
@@ -114,32 +135,35 @@ After running the workflow once, these are the artifacts and outputs you should 
 - `bin/discard-sprint.sh --dry-run` lists the three custom artifacts alongside the core ones.
 - `conductor/bin/sprint.sh batch` schedules `license-audit` and `privacy-check` as `type=read` after `build`, then `release-readiness` after the five upstreams complete, then `ship` after `release-readiness`.
 
-If any of these fails, `release-readiness` is supposed to surface it — that's the entire point of the gate.
+If any of these fails, `release-readiness` is supposed to surface it. That's the entire point of the gate.
 
 ## Reset
 
-To remove the stack from a sandbox project:
+To remove the stack from a sandbox project (resolves the same store the scaffolder wrote to: repo root inside git, `$HOME/.nanostack/` outside):
 
 ```bash
-rm -rf .nanostack/skills/license-audit \
-       .nanostack/skills/privacy-check \
-       .nanostack/skills/release-readiness
+STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
+
+rm -rf "$STORE/skills/license-audit" \
+       "$STORE/skills/privacy-check" \
+       "$STORE/skills/release-readiness"
 
 jq '.custom_phases -= ["license-audit","privacy-check","release-readiness"]' \
-  .nanostack/config.json > .nanostack/config.json.tmp \
-  && mv .nanostack/config.json.tmp .nanostack/config.json
+  "$STORE/config.json" > "$STORE/config.json.tmp" \
+  && mv "$STORE/config.json.tmp" "$STORE/config.json"
 
 # Optional: drop the saved artifacts too.
-rm -rf .nanostack/license-audit \
-       .nanostack/privacy-check \
-       .nanostack/release-readiness
+rm -rf "$STORE/license-audit" \
+       "$STORE/privacy-check" \
+       "$STORE/release-readiness"
 ```
 
 If you also wired `phase_graph` and want to revert to the canonical default sprint, remove the field:
 
 ```bash
-jq 'del(.phase_graph)' .nanostack/config.json > .nanostack/config.json.tmp \
-  && mv .nanostack/config.json.tmp .nanostack/config.json
+STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
+jq 'del(.phase_graph)' "$STORE/config.json" > "$STORE/config.json.tmp" \
+  && mv "$STORE/config.json.tmp" "$STORE/config.json"
 ```
 
 Restart your agent so it stops surfacing the slash commands.

--- a/examples/custom-stack-template/compliance-release/README.md
+++ b/examples/custom-stack-template/compliance-release/README.md
@@ -64,10 +64,12 @@ STACK_DIR="$NANOSTACK_ROOT/examples/custom-stack-template/compliance-release"
 
 `bin/create-skill.sh` resolves the install destination via `bin/lib/store-path.sh` (your repo root's `.nanostack/`, or `$HOME/.nanostack/` outside git), so the skills land where every lifecycle script reads from regardless of which subdirectory you ran the command from.
 
-Then wire the `phase_graph` so the conductor knows the full topology. Resolve the store path the same way the scaffolder did:
+Then wire the `phase_graph` so the conductor knows the full topology. Resolve the store path the same way the scaffolder did, by sourcing `bin/lib/store-path.sh`. That gives `$NANOSTACK_STORE` with the same priority order lifecycle scripts use: an explicit `NANOSTACK_STORE` env var first, then the git repo root, then `$HOME/.nanostack/`. Skipping this step would split the install across two stores when a user or harness has `NANOSTACK_STORE` exported.
 
 ```bash
-STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+. "$NANOSTACK_ROOT/bin/lib/store-path.sh"
+
 jq '.phase_graph = [
   {"name":"think","depends_on":[]},
   {"name":"plan","depends_on":["think"]},
@@ -79,20 +81,22 @@ jq '.phase_graph = [
   {"name":"privacy-check","depends_on":["build"]},
   {"name":"release-readiness","depends_on":["review","qa","security","license-audit","privacy-check"]},
   {"name":"ship","depends_on":["release-readiness"]}
-]' "$STORE/config.json" > "$STORE/config.json.tmp" \
-  && mv "$STORE/config.json.tmp" "$STORE/config.json"
+]' "$NANOSTACK_STORE/config.json" > "$NANOSTACK_STORE/config.json.tmp" \
+  && mv "$NANOSTACK_STORE/config.json.tmp" "$NANOSTACK_STORE/config.json"
 ```
 
 Validate each scaffolded skill against the framework contract:
 
 ```bash
 NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
-"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/license-audit"
-"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/privacy-check"
-"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills/release-readiness"
+. "$NANOSTACK_ROOT/bin/lib/store-path.sh"
+
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$NANOSTACK_STORE/skills/license-audit"
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$NANOSTACK_STORE/skills/privacy-check"
+"$NANOSTACK_ROOT/bin/check-custom-skill.sh" "$NANOSTACK_STORE/skills/release-readiness"
 ```
 
-Each invocation should end with `OK: <name> passed N checks.`. The path expression resolves the same store `bin/create-skill.sh` wrote to (your repo root's `.nanostack/skills/` inside git, or `$HOME/.nanostack/skills/` outside git).
+Each invocation should end with `OK: <name> passed N checks.`. The path resolves through `bin/lib/store-path.sh`, the exact same priority order `bin/create-skill.sh` used to install the skill: explicit `NANOSTACK_STORE` env var, then git repo root's `.nanostack/`, then `$HOME/.nanostack/`.
 
 Restart your agent so it picks up the three new slash commands.
 
@@ -102,14 +106,14 @@ The skills are read-only and idempotent. Run them in any order; the conductor (a
 
 ```bash
 NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
-SKILLS_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack/skills"
+. "$NANOSTACK_ROOT/bin/lib/store-path.sh"
 
 # License + privacy can run in parallel (both are concurrency=read).
-"$SKILLS_ROOT/license-audit/bin/audit.sh"
-"$SKILLS_ROOT/privacy-check/bin/check.sh"
+"$NANOSTACK_STORE/skills/license-audit/bin/audit.sh"
+"$NANOSTACK_STORE/skills/privacy-check/bin/check.sh"
 
 # release-readiness composes the upstream artifacts into a status.
-"$SKILLS_ROOT/release-readiness/bin/summarize.sh"
+"$NANOSTACK_STORE/skills/release-readiness/bin/summarize.sh"
 ```
 
 Each helper saves an artifact via `bin/save-artifact.sh`. The full schedule, including parallelism, comes from the conductor:
@@ -139,31 +143,33 @@ If any of these fails, `release-readiness` is supposed to surface it. That's the
 
 ## Reset
 
-To remove the stack from a sandbox project (resolves the same store the scaffolder wrote to: repo root inside git, `$HOME/.nanostack/` outside):
+To remove the stack from a sandbox project (resolves the same store the scaffolder wrote to: explicit `NANOSTACK_STORE` env var, then git repo root, then `$HOME/.nanostack/`):
 
 ```bash
-STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+. "$NANOSTACK_ROOT/bin/lib/store-path.sh"
 
-rm -rf "$STORE/skills/license-audit" \
-       "$STORE/skills/privacy-check" \
-       "$STORE/skills/release-readiness"
+rm -rf "$NANOSTACK_STORE/skills/license-audit" \
+       "$NANOSTACK_STORE/skills/privacy-check" \
+       "$NANOSTACK_STORE/skills/release-readiness"
 
 jq '.custom_phases -= ["license-audit","privacy-check","release-readiness"]' \
-  "$STORE/config.json" > "$STORE/config.json.tmp" \
-  && mv "$STORE/config.json.tmp" "$STORE/config.json"
+  "$NANOSTACK_STORE/config.json" > "$NANOSTACK_STORE/config.json.tmp" \
+  && mv "$NANOSTACK_STORE/config.json.tmp" "$NANOSTACK_STORE/config.json"
 
 # Optional: drop the saved artifacts too.
-rm -rf "$STORE/license-audit" \
-       "$STORE/privacy-check" \
-       "$STORE/release-readiness"
+rm -rf "$NANOSTACK_STORE/license-audit" \
+       "$NANOSTACK_STORE/privacy-check" \
+       "$NANOSTACK_STORE/release-readiness"
 ```
 
 If you also wired `phase_graph` and want to revert to the canonical default sprint, remove the field:
 
 ```bash
-STORE="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")/.nanostack"
-jq 'del(.phase_graph)' "$STORE/config.json" > "$STORE/config.json.tmp" \
-  && mv "$STORE/config.json.tmp" "$STORE/config.json"
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+. "$NANOSTACK_ROOT/bin/lib/store-path.sh"
+jq 'del(.phase_graph)' "$NANOSTACK_STORE/config.json" > "$NANOSTACK_STORE/config.json.tmp" \
+  && mv "$NANOSTACK_STORE/config.json.tmp" "$NANOSTACK_STORE/config.json"
 ```
 
 Restart your agent so it stops surfacing the slash commands.

--- a/examples/custom-stack-template/compliance-release/skills/license-audit/SKILL.md
+++ b/examples/custom-stack-template/compliance-release/skills/license-audit/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: license-audit
+description: Use to audit the open-source licenses of every direct dependency in this project before shipping. Flags GPL/AGPL as BLOCKED, unknown as WARN. Triggers on /license-audit.
+concurrency: read
+depends_on: [build]
+summary: "License compliance check across npm/pip/go dependencies, part of the compliance-release stack."
+estimated_tokens: 200
+---
+
+# /license-audit — Dependency License Audit
+
+You audit the open-source licenses of this project's dependencies. The point is compliance: some licenses (GPL, AGPL) force the project that uses them to be open-source under the same terms. This skill runs before `/release-readiness` so the gate has license evidence to compose.
+
+This is the `license-audit` skill from the compliance-release stack. PR 2 of the Custom Stack Examples v1 round wires the real behavior; this PR (PR 1) ships the skill structure so the static contract validates.
+
+## Process
+
+### 0. Resolve paths (host-agnostic)
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/license-audit}"
+```
+
+Some agents (including Claude Code) execute each tool call in a fresh bash process, so each snippet redefines the env vars it uses.
+
+### 1. Run the audit
+
+```bash
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/license-audit}"
+"$SKILL_DIR/bin/audit.sh"
+```
+
+The helper detects the project stack (npm, pip, go) from manifest files, classifies each direct dependency's license into a family (permissive, weak copyleft, strong copyleft, unknown), and prints a JSON object with counts and a `flagged` list.
+
+### 2. Save the artifact
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/bin/save-artifact.sh" license-audit \
+  '{"phase":"license-audit","summary":{"status":"OK","headline":"...","counts":{...},"flagged":[]},"context_checkpoint":{"summary":"License audit completed.","key_files":["package.json"]}}'
+```
+
+Status rules:
+- `OK` — every direct dependency has a known permissive or weak-copyleft license.
+- `WARN` — at least one license is `unknown`. The composer in `/release-readiness` rolls this up.
+- `BLOCKED` — at least one direct dependency is GPL or AGPL.
+
+### 3. Headline
+
+```
+[license-audit] OK: 12 deps scanned, 0 GPL/AGPL flagged.
+```
+
+Use `WARN` or `BLOCKED` instead of `OK` when the status field above is not OK.
+
+## Gotchas
+
+- This skill walks **direct dependencies only**. Transitive dependencies are out of scope; pair with a deep auditor if your compliance bar requires that.
+- "Unknown license" means the manifest declares the package but no license metadata is parseable from the manifest itself. Unknown is treated as `WARN`, not `OK`. The user decides whether to upgrade or replace.
+- This skill never rewrites your code, edits package.json, or runs `npm install`. It is read-only.

--- a/examples/custom-stack-template/compliance-release/skills/license-audit/agents/openai.yaml
+++ b/examples/custom-stack-template/compliance-release/skills/license-audit/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "license-audit"
+  short_description: "Audits direct-dependency licenses before /release-readiness. Flags GPL/AGPL as BLOCKED, unknown as WARN."
+  default_prompt: "Use license-audit before /ship to surface license risk in this sprint's release decision."
+policy:
+  allow_implicit_invocation: true

--- a/examples/custom-stack-template/compliance-release/skills/license-audit/bin/audit.sh
+++ b/examples/custom-stack-template/compliance-release/skills/license-audit/bin/audit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# audit.sh — license-audit skill (placeholder for PR 1 of CSE v1).
+#
+# PR 2 of the Custom Stack Examples v1 round replaces this body with
+# real license classification across npm/pip/go manifests. PR 1 ships
+# only the scaffolding so the static contract validates.
+#
+# When PR 2 lands, the helper must:
+#   - Detect the project stack from package.json | requirements.txt |
+#     pyproject.toml | go.mod.
+#   - Classify each direct dependency's license into permissive,
+#     weak_copyleft, strong_copyleft, or unknown.
+#   - Print a JSON object on stdout: { counts, flagged }.
+#   - Exit 0 always; the artifact's summary.status carries OK/WARN/BLOCKED.
+set -e
+
+cat <<'JSON'
+{
+  "counts": { "total": 0, "permissive": 0, "weak_copyleft": 0, "strong_copyleft": 0, "unknown": 0 },
+  "flagged": [],
+  "_placeholder": "license-audit/bin/audit.sh — PR 1 stub. Real behavior lands in PR 2."
+}
+JSON

--- a/examples/custom-stack-template/compliance-release/skills/license-audit/bin/smoke.sh
+++ b/examples/custom-stack-template/compliance-release/skills/license-audit/bin/smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# smoke.sh — license-audit smoke check (placeholder for PR 1).
+#
+# PR 2 replaces this with a real /tmp project + manifests check.
+# PR 1 ships only the file so the static contract validates that
+# every skill folder has a smoke.sh.
+set -e
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AUDIT="$SKILL_DIR/bin/audit.sh"
+
+if [ ! -x "$AUDIT" ]; then
+  echo "FAIL: $AUDIT is not executable" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required for the smoke check" >&2
+  exit 1
+fi
+
+out=$( "$AUDIT" 2>/dev/null )
+if ! printf '%s' "$out" | jq -e '.counts' >/dev/null 2>&1; then
+  echo "FAIL: audit.sh did not emit a JSON object with .counts" >&2
+  echo "$out" >&2
+  exit 1
+fi
+
+echo "OK: license-audit placeholder smoke passed (PR 2 wires the real behavior)"

--- a/examples/custom-stack-template/compliance-release/skills/privacy-check/SKILL.md
+++ b/examples/custom-stack-template/compliance-release/skills/privacy-check/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: privacy-check
+description: Use to detect personal-data collection signals (email forms, payment fields, telemetry libraries) before shipping. Surfaces missing privacy notes. Not a legal review. Triggers on /privacy-check.
+concurrency: read
+depends_on: [build]
+summary: "Release hygiene check for personal-data collection and privacy notes, part of the compliance-release stack."
+estimated_tokens: 220
+---
+
+# /privacy-check — Release Privacy Hygiene
+
+You scan the release for obvious personal-data collection signals (email/name/phone/address/payment fields, telemetry libraries) and surface whether a privacy note exists when collection is detected. The output feeds `/release-readiness`, which gates `/ship`.
+
+**This is not a legal review.** It does not certify GDPR or CCPA compliance. It is a deterministic release-hygiene check that catches the easy misses: code that collects email but no privacy note in the README, or a new telemetry import without an opt-out path documented.
+
+This is the `privacy-check` skill from the compliance-release stack. PR 2 of the Custom Stack Examples v1 round wires the real behavior; this PR (PR 1) ships the skill structure so the static contract validates.
+
+## Process
+
+### 0. Resolve paths (host-agnostic)
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/privacy-check}"
+```
+
+### 1. Run the check
+
+```bash
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/privacy-check}"
+"$SKILL_DIR/bin/check.sh"
+```
+
+The helper scans the project's source for:
+- Personal-data fields: `email`, `name`, `phone`, `address`, `payment`, `token`, `api_key`, file uploads.
+- Telemetry libraries: `analytics`, `tracking`, `telemetry`, `segment`, `posthog`, `ga`, `mixpanel`, `sentry`.
+- A privacy note: `PRIVACY.md`, a "Privacy" or "Data" section in `README.md`, or `TELEMETRY.md` for telemetry-only cases.
+- Env templates: `.env.example`, `.env.sample`, `.env.template` (allowed by guard) for keys that hint at collection.
+
+The helper **does not read** `.env`, `.env.local`, `.env.production`, or any credential JSON. The bash guard already blocks those.
+
+### 2. Save the artifact
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/bin/save-artifact.sh" privacy-check \
+  '{"phase":"privacy-check","summary":{"status":"WARN","headline":"...","signals":[...],"missing":["privacy_note"],"next_action":"..."},"context_checkpoint":{"summary":"Privacy check completed."}}'
+```
+
+Status rules:
+- `OK` — no collection signals detected, or signals are documented in a privacy note.
+- `WARN` — collection signals detected but no privacy note found, or telemetry without an opt-out path documented.
+- `BLOCKED` — reserved for clearly unsafe patterns (e.g., a credential file added to source). The composer escalates this in `/release-readiness`.
+
+### 3. Headline
+
+```
+[privacy-check] WARN: email collection detected, no privacy note.
+```
+
+## Gotchas
+
+- This skill does not interpret intent. A test fixture that mentions `email` will be flagged the same way real code does. The user decides whether the signal is real.
+- "Privacy note" is a structural check, not a quality check. The skill confirms a note exists; it does not validate the note's content. That's a human review.
+- The helper never edits files, never writes to the network, never opens `.env` or credential files. Read-only by design.

--- a/examples/custom-stack-template/compliance-release/skills/privacy-check/agents/openai.yaml
+++ b/examples/custom-stack-template/compliance-release/skills/privacy-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "privacy-check"
+  short_description: "Release privacy hygiene. Surfaces personal-data collection signals and missing privacy notes. Not a legal review."
+  default_prompt: "Use privacy-check before /ship to catch collection signals without a privacy note."
+policy:
+  allow_implicit_invocation: true

--- a/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/check.sh
+++ b/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# check.sh — privacy-check skill (placeholder for PR 1 of CSE v1).
+#
+# PR 2 replaces this body with the real release-hygiene scan
+# (personal-data fields, telemetry imports, missing privacy note).
+# PR 1 ships only the scaffolding so the static contract validates.
+set -e
+
+cat <<'JSON'
+{
+  "signals": [],
+  "missing": [],
+  "_placeholder": "privacy-check/bin/check.sh — PR 1 stub. Real behavior lands in PR 2."
+}
+JSON

--- a/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/smoke.sh
+++ b/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# smoke.sh — privacy-check smoke check (placeholder for PR 1).
+set -e
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK="$SKILL_DIR/bin/check.sh"
+
+if [ ! -x "$CHECK" ]; then
+  echo "FAIL: $CHECK is not executable" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required for the smoke check" >&2
+  exit 1
+fi
+
+out=$( "$CHECK" 2>/dev/null )
+if ! printf '%s' "$out" | jq -e '.signals' >/dev/null 2>&1; then
+  echo "FAIL: check.sh did not emit a JSON object with .signals" >&2
+  echo "$out" >&2
+  exit 1
+fi
+
+echo "OK: privacy-check placeholder smoke passed (PR 2 wires the real behavior)"

--- a/examples/custom-stack-template/compliance-release/skills/release-readiness/SKILL.md
+++ b/examples/custom-stack-template/compliance-release/skills/release-readiness/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: release-readiness
+description: Use after review/qa/security/license-audit/privacy-check to compose a release decision before /ship. Returns OK only when all required upstream evidence is present and clean. Triggers on /release-readiness.
+concurrency: read
+depends_on: [review, qa, security, license-audit, privacy-check]
+summary: "Composes core + custom release evidence into a single gate before /ship, part of the compliance-release stack."
+estimated_tokens: 240
+---
+
+# /release-readiness — Release Decision Composer
+
+You compose the sprint's release evidence into a single decision. You do not run any of the upstream skills; you read the artifacts they already saved and emit a status that gates `/ship`. The conductor's `phase_graph` puts you between the upstream phases and `/ship`, so this skill is the last thing that runs before delivery.
+
+This is the `release-readiness` skill from the compliance-release stack. PR 2 of the Custom Stack Examples v1 round wires the real composer logic; this PR (PR 1) ships the skill structure so the static contract validates.
+
+## Process
+
+### 0. Resolve paths (host-agnostic)
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/release-readiness}"
+```
+
+### 1. Resolve upstream evidence
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/bin/resolve.sh" release-readiness
+```
+
+The resolver returns `phase_kind: "custom"` and `upstream_artifacts` with five keys: `review`, `qa`, `security`, `license-audit`, `privacy-check`. Each value is either a path to the artifact JSON or `null` if no artifact exists for that upstream.
+
+### 2. Compose the decision
+
+```bash
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/release-readiness}"
+"$SKILL_DIR/bin/summarize.sh"
+```
+
+The helper reads each upstream artifact (where present), maps each to a `check` entry, and computes a rolled-up status:
+
+- **`MISSING`** for any upstream whose artifact is absent.
+- **`BLOCKED`** for the rollup if any upstream is `BLOCKED`.
+- **`WARN`** for the rollup if any upstream is `WARN` (and none is `BLOCKED`).
+- **`OK`** only when all five upstreams are present and none is `WARN` or `BLOCKED`.
+
+### 3. Save the artifact
+
+```bash
+NANOSTACK_ROOT="${NANOSTACK_ROOT:-$HOME/.claude/skills/nanostack}"
+"$NANOSTACK_ROOT/bin/save-artifact.sh" release-readiness \
+  '{"phase":"release-readiness","summary":{"status":"...","headline":"...","checks":[...],"next_action":"..."},"context_checkpoint":{"summary":"Release readiness composed upstream evidence."}}'
+```
+
+### 4. Headline
+
+```
+[release-readiness] BLOCKED: privacy note missing and QA evidence absent.
+```
+
+Prefix the status (`OK`, `WARN`, `BLOCKED`) and surface the most actionable next step. The composer's job is to tell the user **what to do**, not just to print a verdict.
+
+## Gotchas
+
+- This skill **never runs `/ship`**, never opens a PR, never commits, never deploys. It only composes evidence into a decision.
+- Missing upstreams are explicit. If `qa` has no artifact, the rollup is `BLOCKED` for "QA evidence missing" — not `OK` with a quiet gap. The whole point of the gate is to surface that exactly.
+- The status rollup is monotonic: once any upstream is `BLOCKED`, the composer cannot soften the rollup to `WARN`. The user must explicitly resolve the blocker.
+- `WARN` rollups still allow `/ship` (the composer does not auto-block), but the artifact records the warning and the next-action so the team has a paper trail.

--- a/examples/custom-stack-template/compliance-release/skills/release-readiness/agents/openai.yaml
+++ b/examples/custom-stack-template/compliance-release/skills/release-readiness/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "release-readiness"
+  short_description: "Composes review/qa/security/license-audit/privacy-check artifacts into a single release decision before /ship."
+  default_prompt: "Use release-readiness to gate /ship on the compliance-release stack's upstream evidence."
+policy:
+  allow_implicit_invocation: true

--- a/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/smoke.sh
+++ b/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# smoke.sh — release-readiness smoke check (placeholder for PR 1).
+set -e
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SUMMARIZE="$SKILL_DIR/bin/summarize.sh"
+
+if [ ! -x "$SUMMARIZE" ]; then
+  echo "FAIL: $SUMMARIZE is not executable" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required for the smoke check" >&2
+  exit 1
+fi
+
+out=$( "$SUMMARIZE" 2>/dev/null )
+if ! printf '%s' "$out" | jq -e '.checks' >/dev/null 2>&1; then
+  echo "FAIL: summarize.sh did not emit a JSON object with .checks" >&2
+  echo "$out" >&2
+  exit 1
+fi
+
+echo "OK: release-readiness placeholder smoke passed (PR 2 wires the real behavior)"

--- a/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh
+++ b/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# summarize.sh — release-readiness skill (placeholder for PR 1 of CSE v1).
+#
+# PR 2 replaces this body with the real composer that walks the five
+# upstream artifacts (review, qa, security, license-audit,
+# privacy-check) and rolls them up into a status. PR 1 ships only
+# the scaffolding so the static contract validates.
+set -e
+
+cat <<'JSON'
+{
+  "checks": [],
+  "rollup_status": "OK",
+  "_placeholder": "release-readiness/bin/summarize.sh — PR 1 stub. Real behavior lands in PR 2."
+}
+JSON

--- a/examples/custom-stack-template/compliance-release/stack.json
+++ b/examples/custom-stack-template/compliance-release/stack.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1",
+  "kind": "custom_stack_example",
+  "name": "compliance-release",
+  "display_name": "Compliance Release Stack",
+  "description": "A read-only release compliance workflow that checks licenses, privacy signals, and release readiness before /ship.",
+  "skills": [
+    {
+      "name": "license-audit",
+      "path": "skills/license-audit",
+      "concurrency": "read",
+      "depends_on": ["build"]
+    },
+    {
+      "name": "privacy-check",
+      "path": "skills/privacy-check",
+      "concurrency": "read",
+      "depends_on": ["build"]
+    },
+    {
+      "name": "release-readiness",
+      "path": "skills/release-readiness",
+      "concurrency": "read",
+      "depends_on": ["review", "qa", "security", "license-audit", "privacy-check"]
+    }
+  ],
+  "phase_graph": [
+    { "name": "think",             "depends_on": [] },
+    { "name": "plan",              "depends_on": ["think"] },
+    { "name": "build",             "depends_on": ["plan"] },
+    { "name": "review",            "depends_on": ["build"] },
+    { "name": "qa",                "depends_on": ["build"] },
+    { "name": "security",          "depends_on": ["build"] },
+    { "name": "license-audit",     "depends_on": ["build"] },
+    { "name": "privacy-check",     "depends_on": ["build"] },
+    { "name": "release-readiness", "depends_on": ["review", "qa", "security", "license-audit", "privacy-check"] },
+    { "name": "ship",              "depends_on": ["release-readiness"] }
+  ],
+  "expected_evidence": [
+    "resolve.sh release-readiness returns upstream_artifacts for review, qa, security, license-audit, and privacy-check",
+    "conductor batch schedules license-audit and privacy-check as read phases after build",
+    "sprint-journal.sh emits sections for all three custom phases",
+    "analytics.sh --json counts all three custom phases"
+  ]
+}

--- a/reference/custom-stack-examples-technical-spec.md
+++ b/reference/custom-stack-examples-technical-spec.md
@@ -1,0 +1,681 @@
+# Custom Stack Examples v1: Technical Spec
+
+## Status
+
+Draft for implementation planning.
+
+This spec is for the next round after Custom Stack Framework v1. The framework is now real: custom phases can be registered, resolved, saved, surfaced in lifecycle outputs, and scheduled by conductor. The next step is to prove that a user can build a domain workflow on top of it, not only a single custom skill.
+
+## Product Objective
+
+Show that Nanostack is a base framework for building your own agent workflow stack.
+
+The product promise for this round:
+
+> Nanostack gives you the delivery framework. You can bring your own domain workflow as custom skills, and those skills inherit artifacts, resolver context, journals, analytics, conductor scheduling, and local vault output.
+
+The proof must be executable, not copy only. A clean sandbox user should be able to copy or scaffold a stack, run its skills, save artifacts, resolve dependencies, generate journal/analytics, and see conductor schedule the custom graph correctly.
+
+## Why This Round Exists
+
+Custom Stack Framework v1 proved a single skill works:
+
+- `bin/create-skill.sh` can scaffold one custom skill.
+- `bin/check-custom-skill.sh` can validate it.
+- Lifecycle scripts accept custom phases.
+- Conductor reads `concurrency:` from custom `SKILL.md`.
+
+That is necessary but not enough for the product claim "build your own stack." A stack is a domain workflow with multiple phases that hand off context to each other. The next round should prove composition.
+
+## Scope Decision
+
+Start with one fully developed stack, not three.
+
+The first proof point should be:
+
+```text
+examples/custom-stack-template/compliance-release/
+```
+
+Reason:
+
+- It matches Nanostack's strengths: delivery, review, security, QA, and release evidence.
+- It is easy to test in CI without external APIs.
+- It demonstrates a real multi-skill graph:
+  - one skill scans licenses
+  - one skill checks privacy/release data handling
+  - one skill composes those results into a release decision
+- It avoids vague "marketing workflow" behavior that is harder to verify deterministically.
+
+Future stacks like marketing, data, or design should wait until the first stack exposes the right file shape and test contract.
+
+## Non-Goals
+
+- Do not build a new stack installer yet.
+- Do not introduce a daemon, package manager, or plugin registry.
+- Do not require Node, Python packages, Docker, network access, or external services.
+- Do not claim "one command installs a full stack" unless the command exists and is covered by E2E.
+- Do not move the README hero to "framework" before at least one real stack example lands and passes CI.
+- Do not create three shallow examples. One complete stack is more valuable than three brochure examples.
+
+## Directory Contract
+
+Add a new directory:
+
+```text
+examples/custom-stack-template/
+  README.md
+  compliance-release/
+    README.md
+    stack.json
+    skills/
+      license-audit/
+        SKILL.md
+        agents/openai.yaml
+        bin/audit.sh
+        bin/smoke.sh
+      privacy-check/
+        SKILL.md
+        agents/openai.yaml
+        bin/check.sh
+        bin/smoke.sh
+      release-readiness/
+        SKILL.md
+        agents/openai.yaml
+        bin/summarize.sh
+        bin/smoke.sh
+```
+
+### Why `stack.json`
+
+`stack.json` in this directory is an example manifest, not Nanostack's technology stack preferences file. It must not be read by `/nano` as project stack defaults.
+
+The file exists so docs, CI, and future tooling can agree on the stack composition without scraping prose.
+
+If this name is too ambiguous with existing `.nanostack/stack.json`, use `custom-stack.json` instead. Do not introduce both. The implementation PR should make one explicit choice and document it.
+
+Recommended decision: use `stack.json` inside `examples/custom-stack-template/<stack-name>/` because Opus already named that shape, but keep the schema field `kind: "custom_stack_example"` to prevent confusion.
+
+## Stack Manifest Schema
+
+`examples/custom-stack-template/compliance-release/stack.json`:
+
+```json
+{
+  "schema_version": "1",
+  "kind": "custom_stack_example",
+  "name": "compliance-release",
+  "display_name": "Compliance Release Stack",
+  "description": "A read-only release compliance workflow that checks licenses, privacy signals, and release readiness before /ship.",
+  "skills": [
+    {
+      "name": "license-audit",
+      "path": "skills/license-audit",
+      "concurrency": "read",
+      "depends_on": ["build"]
+    },
+    {
+      "name": "privacy-check",
+      "path": "skills/privacy-check",
+      "concurrency": "read",
+      "depends_on": ["build"]
+    },
+    {
+      "name": "release-readiness",
+      "path": "skills/release-readiness",
+      "concurrency": "read",
+      "depends_on": ["review", "qa", "security", "license-audit", "privacy-check"]
+    }
+  ],
+  "phase_graph": [
+    { "name": "think", "depends_on": [] },
+    { "name": "plan", "depends_on": ["think"] },
+    { "name": "build", "depends_on": ["plan"] },
+    { "name": "review", "depends_on": ["build"] },
+    { "name": "qa", "depends_on": ["build"] },
+    { "name": "security", "depends_on": ["build"] },
+    { "name": "license-audit", "depends_on": ["build"] },
+    { "name": "privacy-check", "depends_on": ["build"] },
+    { "name": "release-readiness", "depends_on": ["review", "qa", "security", "license-audit", "privacy-check"] },
+    { "name": "ship", "depends_on": ["release-readiness"] }
+  ],
+  "expected_evidence": [
+    "resolve.sh release-readiness returns upstream_artifacts for review, qa, security, license-audit, and privacy-check",
+    "conductor batch schedules license-audit and privacy-check as read phases after build",
+    "sprint-journal.sh emits sections for all three custom phases",
+    "analytics.sh --json counts all three custom phases"
+  ]
+}
+```
+
+Validation rules:
+
+- `schema_version` must be `"1"`.
+- `kind` must be `"custom_stack_example"`.
+- `name` must match `^[a-z][a-z0-9-]*$`.
+- Each `skills[].name` must match the phase regex.
+- Each `skills[].path` must exist and contain `SKILL.md`.
+- Each skill must pass `bin/check-custom-skill.sh` after installation into a temp project.
+- Every `phase_graph[].name` must be either core, `build`, or listed in `skills[].name`.
+- Every custom skill listed in `phase_graph` must appear in `skills`.
+- `ship` must depend on `release-readiness`, not directly on the review/security/QA trio in this stack.
+
+## Stack Behavior
+
+### Skill 1: `/license-audit`
+
+Purpose:
+
+Read dependency manifests and identify license risk before release.
+
+Inputs:
+
+- `package.json`
+- `requirements.txt`
+- `pyproject.toml`
+- `go.mod`
+
+Output artifact:
+
+```json
+{
+  "phase": "license-audit",
+  "summary": {
+    "status": "OK",
+    "headline": "No GPL/AGPL licenses found in direct dependencies.",
+    "counts": {
+      "total": 12,
+      "permissive": 10,
+      "weak_copyleft": 1,
+      "strong_copyleft": 0,
+      "unknown": 1
+    },
+    "flagged": [],
+    "next_action": "None."
+  },
+  "context_checkpoint": {
+    "summary": "License audit completed.",
+    "key_files": ["package.json"],
+    "decisions_made": [],
+    "open_questions": []
+  }
+}
+```
+
+Rules:
+
+- Read-only.
+- No network.
+- Direct dependencies only unless a lockfile parser is already available without installing dependencies.
+- Unknown licenses produce `status: "WARN"`, not `OK`.
+- GPL or AGPL produces `status: "BLOCKED"`.
+
+### Skill 2: `/privacy-check`
+
+Purpose:
+
+Check whether the release introduces obvious privacy/data-handling risk before shipping.
+
+This is not a legal review. It is a deterministic release hygiene check.
+
+Inputs:
+
+- README files
+- `TELEMETRY.md` if present
+- `.env.example`, `.env.sample`, `.env.template`
+- app source files under common locations:
+  - `src/`
+  - `app/`
+  - `pages/`
+  - `server/`
+  - `api/`
+
+Checks:
+
+- Detects forms or API routes that collect email, name, phone, address, payment, token, API key, or uploaded files.
+- Detects telemetry words: analytics, tracking, telemetry, segment, posthog, ga, mixpanel, sentry.
+- Detects whether a privacy note exists in README or `PRIVACY.md` when collection signals exist.
+- Detects unsafe examples in env templates, but must not read real `.env` files.
+
+Output artifact:
+
+```json
+{
+  "phase": "privacy-check",
+  "summary": {
+    "status": "WARN",
+    "headline": "Email collection detected but no privacy note found.",
+    "signals": [
+      {
+        "kind": "personal_data",
+        "file": "src/signup.js",
+        "evidence": "email"
+      }
+    ],
+    "missing": ["privacy_note"],
+    "next_action": "Add a short privacy note before shipping."
+  },
+  "context_checkpoint": {
+    "summary": "Privacy check completed.",
+    "key_files": ["src/signup.js"],
+    "decisions_made": [],
+    "open_questions": ["Where should the privacy note live?"]
+  }
+}
+```
+
+Rules:
+
+- Read-only.
+- Must not read `.env`, `.env.local`, `.env.production`, secret JSON files, or private key files.
+- It may read env templates allowed by guard: `.env.example`, `.env.sample`, `.env.template`.
+- It must report "not a legal review" in the skill close, not in every artifact field.
+- It must never claim GDPR/CCPA compliance.
+
+### Skill 3: `/release-readiness`
+
+Purpose:
+
+Compose core and custom evidence into a release decision before `/ship`.
+
+Inputs:
+
+- `review`
+- `qa`
+- `security`
+- `license-audit`
+- `privacy-check`
+
+Resolver behavior:
+
+`bin/resolve.sh release-readiness` must return:
+
+```json
+{
+  "phase": "release-readiness",
+  "phase_kind": "custom",
+  "upstream_artifacts": {
+    "review": "/path/or/null",
+    "qa": "/path/or/null",
+    "security": "/path/or/null",
+    "license-audit": "/path/or/null",
+    "privacy-check": "/path/or/null"
+  }
+}
+```
+
+Output artifact:
+
+```json
+{
+  "phase": "release-readiness",
+  "summary": {
+    "status": "BLOCKED",
+    "headline": "Release blocked: privacy note missing and QA evidence absent.",
+    "checks": [
+      { "phase": "review", "status": "OK", "evidence": "artifact" },
+      { "phase": "qa", "status": "MISSING", "evidence": null },
+      { "phase": "security", "status": "OK", "evidence": "artifact" },
+      { "phase": "license-audit", "status": "OK", "evidence": "artifact" },
+      { "phase": "privacy-check", "status": "WARN", "evidence": "artifact" }
+    ],
+    "next_action": "Run /qa and add a privacy note before /ship."
+  },
+  "context_checkpoint": {
+    "summary": "Release readiness composed upstream evidence.",
+    "key_files": [],
+    "decisions_made": [],
+    "open_questions": []
+  }
+}
+```
+
+Rules:
+
+- Read-only.
+- Missing required upstreams are `MISSING`.
+- Any upstream `BLOCKED` makes release-readiness `BLOCKED`.
+- Any upstream `WARN` with no explicit mitigation makes release-readiness `WARN` at minimum.
+- `OK` only when all required upstreams are present and none is `WARN` or `BLOCKED`.
+- It does not create PRs, commit, deploy, or run `/ship`.
+
+## Installation Path For The Example
+
+The README should show only commands that work today.
+
+Recommended user flow:
+
+```bash
+# from a sandbox project where nanostack is available
+bin/create-skill.sh license-audit \
+  --from examples/custom-stack-template/compliance-release/skills/license-audit \
+  --concurrency read \
+  --depends-on build
+
+bin/create-skill.sh privacy-check \
+  --from examples/custom-stack-template/compliance-release/skills/privacy-check \
+  --concurrency read \
+  --depends-on build
+
+bin/create-skill.sh release-readiness \
+  --from examples/custom-stack-template/compliance-release/skills/release-readiness \
+  --concurrency read \
+  --depends-on review \
+  --depends-on qa \
+  --depends-on security \
+  --depends-on license-audit \
+  --depends-on privacy-check
+```
+
+Then configure the graph:
+
+```bash
+jq '.phase_graph = [
+  {"name":"think","depends_on":[]},
+  {"name":"plan","depends_on":["think"]},
+  {"name":"build","depends_on":["plan"]},
+  {"name":"review","depends_on":["build"]},
+  {"name":"qa","depends_on":["build"]},
+  {"name":"security","depends_on":["build"]},
+  {"name":"license-audit","depends_on":["build"]},
+  {"name":"privacy-check","depends_on":["build"]},
+  {"name":"release-readiness","depends_on":["review","qa","security","license-audit","privacy-check"]},
+  {"name":"ship","depends_on":["release-readiness"]}
+]' .nanostack/config.json > .nanostack/config.json.tmp &&
+mv .nanostack/config.json.tmp .nanostack/config.json
+```
+
+If this feels too long in docs, the implementation may add a tiny example-local helper:
+
+```text
+examples/custom-stack-template/compliance-release/bin/install.sh
+```
+
+But only if:
+
+- It is pure bash + jq.
+- It calls existing `bin/create-skill.sh`.
+- It is covered by E2E.
+- Public docs say "example helper", not "new framework installer".
+
+## E2E Contract
+
+Add:
+
+```text
+ci/check-custom-stack-examples.sh
+ci/e2e-custom-stack-examples.sh
+```
+
+### Static Contract: `ci/check-custom-stack-examples.sh`
+
+Validates:
+
+- `examples/custom-stack-template/README.md` exists.
+- `examples/custom-stack-template/compliance-release/README.md` exists.
+- `stack.json` parses with `jq`.
+- `stack.json.kind == "custom_stack_example"`.
+- All `skills[].path` exist.
+- All `skills[].name` match directory basenames.
+- Each skill has:
+  - `SKILL.md`
+  - `agents/openai.yaml`
+  - at least one `bin/*.sh`
+  - `bin/smoke.sh`
+- Every shell script passes `bash -n`.
+- No committed runtime artifacts:
+  - `.nanostack/`
+  - `node_modules/`
+  - `.env`
+  - real credential JSON
+  - logs
+- README has these sections:
+  - "Who this stack is for"
+  - "What it adds"
+  - "Install in a sandbox"
+  - "Run the workflow"
+  - "Expected evidence"
+  - "Reset"
+- README must mention `bin/create-skill.sh`, `bin/check-custom-skill.sh`, `conductor/bin/sprint.sh`, and `release-readiness`.
+
+### Runtime Contract: `ci/e2e-custom-stack-examples.sh`
+
+Runs in a temp project. No network.
+
+Cells:
+
+1. Create a fixture app with:
+   - `package.json`
+   - `README.md`
+   - `.env.example`
+   - one source file with an email field
+2. Install the three skills using the documented commands or the example helper.
+3. Validate each skill with `bin/check-custom-skill.sh`.
+4. Save minimal fake core artifacts for `review`, `qa`, and `security`.
+5. Run `license-audit/bin/audit.sh` and save a `license-audit` artifact.
+6. Run `privacy-check/bin/check.sh` and save a `privacy-check` artifact.
+7. Run `bin/resolve.sh release-readiness` and assert upstream keys include all five dependencies.
+8. Run `release-readiness/bin/summarize.sh` and save a `release-readiness` artifact.
+9. Run `bin/sprint-journal.sh` and assert sections exist:
+   - `## /license-audit`
+   - `## /privacy-check`
+   - `## /release-readiness`
+10. Run `bin/analytics.sh --json` and assert all three custom phases are counted under `sprints.custom`.
+11. Run `bin/discard-sprint.sh --dry-run` and assert custom artifacts are listed.
+12. Run `conductor/bin/sprint.sh start` with the stack's `phase_graph`.
+13. Run `conductor/bin/sprint.sh batch` and assert:
+   - `license-audit` and `privacy-check` are `type=read`
+   - both appear after `build`
+   - `release-readiness` appears after `license-audit`, `privacy-check`, `review`, `qa`, and `security`
+   - `ship` appears after `release-readiness`
+14. Run the same install from a git subdirectory and assert no rogue subdir `.nanostack/` is created.
+15. Run no-git install with fake `$HOME` and assert skills land in `$HOME/.nanostack/skills`.
+
+Acceptance target:
+
+- At least 35 assertions.
+- The harness output must include a final count, e.g.:
+
+```text
+Custom Stack Examples E2E: 42 checks passed, 0 failed
+```
+
+## CI Integration
+
+Add lint jobs:
+
+```text
+custom-stack-examples-contract
+```
+
+Optionally add workflow_dispatch job in `.github/workflows/e2e.yml`:
+
+```text
+e2e-custom-stack-examples
+```
+
+Do not run heavy E2E on every PR unless existing policy changes. Static checks can run in lint; runtime stack E2E may remain workflow_dispatch if consistent with current E2E policy.
+
+## Public Wording Contract
+
+Do not reposition the README hero until the first stack example is green.
+
+After the stack lands, README can add a short section near the top:
+
+```text
+Use Nanostack as-is, or build your own workflow stack on top.
+```
+
+Allowed claims after this round:
+
+- "Build your own workflow stack."
+- "Custom skills can compose into a domain workflow."
+- "The compliance-release example proves save, resolve, journal, analytics, discard, and conductor work together."
+- "No SaaS, no daemon, no build step."
+
+Disallowed claims:
+
+- "Install any stack with one command" unless a covered installer exists.
+- "Marketplace" or "plugin ecosystem".
+- "Compliance certified", "GDPR ready", "SOC2 ready", or legal compliance claims.
+- "Works in every agent identically." Adapter honesty still applies.
+
+## README Follow-Up Gates
+
+The README/landing repositioning becomes eligible only when all are true:
+
+- `examples/custom-stack-template/compliance-release/` exists.
+- Static and runtime stack example checks are green.
+- The stack README explains installation without requiring source reading.
+- `EXTENDING.md` links to the stack example.
+- `README.es.md` has equivalent first-class wording.
+
+Until then, framework wording should remain in the middle of the README, not the hero.
+
+## Suggested PR Split
+
+### PR 1: Stack Example Contract
+
+Files:
+
+- `reference/custom-stack-examples-technical-spec.md`
+- `examples/custom-stack-template/README.md`
+- `examples/custom-stack-template/compliance-release/README.md`
+- `examples/custom-stack-template/compliance-release/stack.json`
+- `ci/check-custom-stack-examples.sh`
+- `.github/workflows/lint.yml`
+
+Acceptance:
+
+- Static contract validates the manifest and README shape.
+- No skill behavior yet beyond placeholder folders if needed.
+- Public docs do not claim the stack is runnable until PR 3.
+
+### PR 2: Compliance Skills
+
+Files:
+
+- `examples/custom-stack-template/compliance-release/skills/license-audit/**`
+- `examples/custom-stack-template/compliance-release/skills/privacy-check/**`
+- `examples/custom-stack-template/compliance-release/skills/release-readiness/**`
+
+Acceptance:
+
+- Each skill passes `bin/check-custom-skill.sh` after install into a temp project.
+- Each `bin/smoke.sh` passes.
+- No external runtime dependencies.
+
+### PR 3: Runtime E2E
+
+Files:
+
+- `ci/e2e-custom-stack-examples.sh`
+- `.github/workflows/e2e.yml`
+- updates to `ci/check-custom-stack-examples.sh`
+
+Acceptance:
+
+- Full 15-cell runtime contract passes locally.
+- Conductor schedule proves custom phase ordering and concurrency.
+- Journal, analytics, discard, resolver all prove composition.
+
+### PR 4: Public Docs and Positioning
+
+Files:
+
+- `README.md`
+- `README.es.md`
+- `EXTENDING.md`
+- `examples/custom-stack-template/README.md`
+
+Acceptance:
+
+- Public copy uses "build your own workflow stack" only where the harness proves it.
+- Spanish docs are first-class.
+- No overclaims about compliance, marketplace, or cross-agent enforcement.
+
+## Manual Retest Script For Codex
+
+After PR 3 or PR 4, Codex should run:
+
+```bash
+ci/check-custom-stack-examples.sh
+ci/e2e-custom-stack-examples.sh
+```
+
+Then manually test one no-docs user path:
+
+```bash
+tmp=$(mktemp -d)
+cd "$tmp"
+git init
+cp -R /path/to/nanostack/examples/custom-stack-template/compliance-release ./compliance-release
+# follow the README only, no source reading
+```
+
+Pass condition:
+
+- The README commands are sufficient.
+- No hidden environment variable is required.
+- No real secrets are read.
+- `release-readiness` blocks when privacy or QA evidence is missing.
+- `release-readiness` passes when all upstream artifacts are `OK`.
+
+## Risks
+
+### Risk: Stack examples become marketing demos
+
+Mitigation:
+
+- Every stack claim must have a static or runtime assertion.
+- The first stack must be deterministic and local.
+
+### Risk: `stack.json` conflicts with existing stack preferences
+
+Mitigation:
+
+- Keep example manifest under `examples/custom-stack-template/<name>/stack.json`.
+- Add `kind: "custom_stack_example"`.
+- Do not teach users to copy it to `.nanostack/stack.json`.
+
+### Risk: Skills duplicate built-in `/security`
+
+Mitigation:
+
+- `privacy-check` checks release hygiene only.
+- It does not claim vulnerability coverage.
+- It never replaces `/security`.
+
+### Risk: Example helper becomes untested framework API
+
+Mitigation:
+
+- If an install helper exists, keep it under the example directory.
+- Call it "example helper".
+- Cover it with E2E.
+
+## Done Definition
+
+This round is done when:
+
+- One real custom stack exists under `examples/custom-stack-template/compliance-release/`.
+- The stack has 3 working custom skills.
+- The stack has a manifest and README.
+- Static checks validate the manifest, docs, scripts, and no-runtime-artifact policy.
+- Runtime E2E proves install, validate, run, save, resolve, journal, analytics, discard, and conductor scheduling.
+- `EXTENDING.md` points users to the stack as the next step after the single-skill template.
+- README/README.es may mention "build your own workflow stack" with no overclaims.
+
+## What Comes After
+
+After one stack proves the abstraction:
+
+1. Add a second stack only if the contract held without major refactors.
+2. Reposition README top copy around:
+
+   ```text
+   Use Nanostack's delivery workflow, or build your own workflow stack on top.
+   ```
+
+3. Create a 60-second sandbox demo using the smallest path from the first stack.
+


### PR DESCRIPTION
## Summary

First PR of the **Custom Stack Examples v1** round. The framework round (PRs #196-#202) proved a single skill works end-to-end. This round proves a stack — multiple custom skills composed into a domain workflow that gates `/ship`.

PR 1 lands the structural surface for the first stack (`compliance-release`: `license-audit` + `privacy-check` + `release-readiness` composer) plus the static contract that locks every stack to the same shape. The skill helpers in this PR are placeholders that emit valid JSON; **PR 2 replaces them with real behavior**, and **PR 3 adds the runtime end-to-end harness**. PR 4 updates the public README + `EXTENDING.md` once the harness proves the framework story.

## Layout

```
examples/custom-stack-template/
  README.md                     # overview, links per-stack readmes
  compliance-release/
    README.md                   # 6 required H2 sections, 4 required tokens
    stack.json                  # kind=custom_stack_example schema
    skills/
      license-audit/
        SKILL.md
        agents/openai.yaml
        bin/audit.sh            # placeholder; PR 2 wires real
        bin/smoke.sh
      privacy-check/...
      release-readiness/...
```

## Static contract — `ci/check-custom-stack-examples.sh`

Validates every stack folder it finds. Current run on `compliance-release/`: **49 checks pass**.

- **Manifest schema**: `kind == "custom_stack_example"`, `schema_version == "1"`, manifest `name` + every `skills[].name` match the phase regex, no duplicate skill names.
- **Skill folder shape**: `SKILL.md` + `agents/openai.yaml` + `bin/smoke.sh` + at least one work-helper besides `smoke.sh`. Directory basename matches the manifest's `skills[].name`. SKILL.md frontmatter `name:` and `concurrency:` match the manifest. `agents/openai.yaml` has `display_name` + `short_description` + `default_prompt`. `bash -n` passes on every `bin/*.sh`.
- **`phase_graph` integrity**:
  - every node is in `core ∪ build ∪ declared skills` (no orphans);
  - every `depends_on[]` target references a name that appears in the graph (no dangling deps);
  - `phase_graph[].name` are unique (no duplicates);
  - every declared skill appears in the graph (no shipped-but-unscheduled skill);
  - the graph is acyclic — Kahn's algorithm reduction (no cycles, including self-loops).
- **Composer-precedes-ship rule**: when a stack ships a `release-readiness` skill, `ship` must depend on it (not directly on the review/security/qa trio).
- **README structure**: the six required H2 sections (`Who this stack is for`, `What it adds`, `Install in a sandbox`, `Run the workflow`, `Expected evidence`, `Reset`) and four required tokens (`bin/create-skill.sh`, `bin/check-custom-skill.sh`, `conductor/bin/sprint.sh`, `release-readiness`).
- **No committed runtime artifacts**: `.nanostack/`, `node_modules/`, `.env*`, credential JSON basenames already blocked by the bash guard (G-035), logs.

The lint job `custom-stack-examples-contract` runs the checker on every PR.

## Stack README install hygiene

Every install / wire / validate / run / reset block sources `$NANOSTACK_ROOT/bin/lib/store-path.sh` and uses `$NANOSTACK_STORE`, matching the same priority order `bin/create-skill.sh` uses (explicit env var > git repo root > `$HOME/.nanostack/`). A user with `NANOSTACK_STORE` exported, or running from any cwd inside or outside git, never sees the install split across two stores.

The `--from` paths in `bin/create-skill.sh` invocations are anchored at `$NANOSTACK_ROOT/examples/custom-stack-template/compliance-release/skills/<name>` so the install runs from any sandbox project, not only from the Nanostack repo root.

## Test plan

- [x] tests/run.sh: 83/83
- [x] ci/e2e-user-flows.sh: 100/100
- [x] ci/e2e-custom-stack-flows.sh: 30/30
- [x] **ci/check-custom-stack-examples.sh: 49/49** (new)
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses
- [x] Each skill's placeholder smoke passes
- [x] Em-dash sweep on every public-copy file (top-level *.md and examples/**/README.md)
- [x] Sabotage tests for the new graph contract: dangling depends_on, duplicate phase_graph names, skill omitted from graph, 2-node cycle, self-loop, 3-node cycle — all caught

## Public claim discipline

The compliance-release `README.md` explicitly documents that the install commands run once PR 3 ships, so the public claim never runs ahead of the harness. The framework spec's "do not reposition the README hero before runtime E2E lands" rule is honored.

## Out of scope (PRs 2-4 of the round)

- PR 2: real skill behavior (`license-audit/bin/audit.sh` classifies dependency licenses; `privacy-check/bin/check.sh` scans for collection signals + missing privacy notes; `release-readiness/bin/summarize.sh` composes the upstream artifacts into a status).
- PR 3: `ci/e2e-custom-stack-examples.sh` — 15-cell runtime harness with ≥35 assertions, including subdir + no-git scaffold paths.
- PR 4: README + README.es + EXTENDING.md "build your own workflow stack" wording, only after the runtime harness proves it.