### PR TITLE
custom-stack-examples PR 3: 15-cell runtime E2E for compliance-release

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,31 @@ jobs:
           chmod +x ci/e2e-think-archetypes.sh
           ci/e2e-think-archetypes.sh
 
+  e2e-custom-stack-examples:
+    name: E2E Custom Stack Examples v1 (compliance-release runtime)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Custom Stack Examples v1 PR 3. Walks the full new-user journey
+    # for the compliance-release stack on a real /tmp project: scaffold
+    # via bin/create-skill.sh --from, validate via
+    # bin/check-custom-skill.sh, save fake core artifacts, run each
+    # custom skill's helper, save its artifact, resolve via
+    # bin/resolve.sh release-readiness (assert all five upstream
+    # keys), compose via release-readiness/bin/summarize.sh, generate
+    # journal + analytics + discard, run conductor with the stack's
+    # phase_graph, exercise subdir + no-git scaffold paths.
+    # 15 cells, 51 assertions.
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq + node available
+        run: |
+          jq --version
+          node --version
+      - name: Run custom-stack-examples runtime E2E
+        run: |
+          chmod +x ci/e2e-custom-stack-examples.sh
+          ci/e2e-custom-stack-examples.sh
+
   e2e-custom-stack:
     name: E2E Custom Stack Framework v1 (15-cell journey)
     runs-on: ubuntu-latest

--- a/ci/e2e-custom-stack-examples.sh
+++ b/ci/e2e-custom-stack-examples.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# e2e-custom-stack-examples.sh — Custom Stack Examples v1 runtime contract.
+#
+# Walks the full new-user journey for the compliance-release stack on
+# a real /tmp project, no network, no installs. Proves that the stack
+# composes save / find / resolve / journal / analytics / discard /
+# conductor end-to-end, and that the install path resolves correctly
+# from a git subdirectory and from a no-git project.
+#
+# 15 cells, ≥35 assertions per the spec
+# (reference/custom-stack-examples-technical-spec.md).
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STACK_DIR="$REPO/examples/custom-stack-template/compliance-release"
+TMP_ROOT=$(mktemp -d /tmp/cse-runtime.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_false() {
+  local name="$1"; shift
+  if ! "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
+  fi
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}expected: %s${NC}\n" "$expected"
+    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
+  fi
+}
+
+echo "Custom Stack Examples v1 runtime E2E"
+echo "===================================="
+echo "Tmp root: $TMP_ROOT"
+echo
+
+# ─── Cell 1: fixture project ────────────────────────────────────────
+# Minimal Node app with one MIT dep installed under node_modules, a
+# README, an .env.example, and a source file with email + name fields.
+# License-audit + privacy-check both need real bytes to scan.
+echo "[1] fixture project"
+PROJ="$TMP_ROOT/main"
+mkdir -p "$PROJ/src" "$PROJ/node_modules/lodash"
+cd "$PROJ"
+git init -q
+cat > package.json <<'JSON'
+{ "name": "cse-fixture", "dependencies": { "lodash": "4.17.21" } }
+JSON
+cat > node_modules/lodash/package.json <<'JSON'
+{ "name": "lodash", "version": "4.17.21", "license": "MIT" }
+JSON
+cat > README.md <<'MD'
+# CSE Fixture
+A minimal app for the runtime stack harness.
+MD
+cat > src/signup.js <<'JS'
+const profile = { email: req.body.email, name: req.body.name };
+JS
+cat > .env.example <<'ENV'
+EMAIL_API_KEY=replace_me
+APP_NAME=demo
+ENV
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+assert_true "fixture has package.json + src + README + .env.example" \
+  bash -c "test -f package.json && test -f src/signup.js && test -f README.md && test -f .env.example"
+
+# ─── Cell 2: install via bin/create-skill.sh --from ────────────────
+# Mirrors the install commands documented in compliance-release/README.md.
+echo "[2] install three skills via bin/create-skill.sh --from"
+"$REPO/bin/create-skill.sh" license-audit \
+  --from "$STACK_DIR/skills/license-audit" \
+  --concurrency read --depends-on build >/dev/null
+"$REPO/bin/create-skill.sh" privacy-check \
+  --from "$STACK_DIR/skills/privacy-check" \
+  --concurrency read --depends-on build >/dev/null
+"$REPO/bin/create-skill.sh" release-readiness \
+  --from "$STACK_DIR/skills/release-readiness" \
+  --concurrency read \
+  --depends-on review --depends-on qa --depends-on security \
+  --depends-on license-audit --depends-on privacy-check >/dev/null
+assert_true "license-audit installed under store" \
+  test -f "$NANOSTACK_STORE/skills/license-audit/SKILL.md"
+assert_true "privacy-check installed under store" \
+  test -f "$NANOSTACK_STORE/skills/privacy-check/SKILL.md"
+assert_true "release-readiness installed under store" \
+  test -f "$NANOSTACK_STORE/skills/release-readiness/SKILL.md"
+assert_true "all three phases registered in config" \
+  bash -c '
+    cfg="$NANOSTACK_STORE/config.json"
+    jq -e ".custom_phases | (index(\"license-audit\") != null) and (index(\"privacy-check\") != null) and (index(\"release-readiness\") != null)" "$cfg" >/dev/null
+  '
+
+# ─── Cell 3: bin/check-custom-skill.sh validates each ──────────────
+echo "[3] bin/check-custom-skill.sh per skill"
+for s in license-audit privacy-check release-readiness; do
+  out=$( "$REPO/bin/check-custom-skill.sh" "$NANOSTACK_STORE/skills/$s" 2>&1 )
+  if echo "$out" | tail -1 | grep -qE "^OK:"; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    check-custom-skill: %s\n" "$s"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  check-custom-skill: %s\n" "$s"
+    echo "$out"
+  fi
+done
+
+# ─── Cell 4: save fake core artifacts (review, qa, security) ───────
+# Each is OK so the rollup later only depends on license-audit /
+# privacy-check / release-readiness.
+echo "[4] save core artifacts (review, qa, security) via save-artifact.sh"
+"$REPO/bin/save-artifact.sh" review \
+  '{"phase":"review","summary":{"status":"OK","blocking":0,"should_fix":0,"nitpicks":0,"positive":1},"context_checkpoint":{"summary":"reviewed"}}' \
+  >/dev/null
+"$REPO/bin/save-artifact.sh" qa \
+  '{"phase":"qa","summary":{"status":"OK","tests_run":1,"tests_passed":1,"tests_failed":0,"bugs_found":0,"bugs_fixed":0},"context_checkpoint":{"summary":"qa"}}' \
+  >/dev/null
+"$REPO/bin/save-artifact.sh" security \
+  '{"phase":"security","summary":{"status":"OK","critical":0,"high":0,"medium":0,"low":0,"total_findings":0},"context_checkpoint":{"summary":"clean"}}' \
+  >/dev/null
+assert_true "review artifact saved with .integrity" \
+  bash -c 'jq -e ".integrity != null" $(ls $NANOSTACK_STORE/review/*.json | head -1) >/dev/null'
+assert_true "qa artifact saved with .integrity" \
+  bash -c 'jq -e ".integrity != null" $(ls $NANOSTACK_STORE/qa/*.json | head -1) >/dev/null'
+assert_true "security artifact saved with .integrity" \
+  bash -c 'jq -e ".integrity != null" $(ls $NANOSTACK_STORE/security/*.json | head -1) >/dev/null'
+
+# ─── Cell 5: run license-audit and save its artifact ───────────────
+echo "[5] run license-audit/bin/audit.sh + save artifact"
+audit_out=$( "$NANOSTACK_STORE/skills/license-audit/bin/audit.sh" )
+assert_true "audit.sh emits .counts" \
+  bash -c "echo '$audit_out' | jq -e '.counts' >/dev/null"
+assert_true "audit detects MIT lodash as permissive" \
+  bash -c "echo '$audit_out' | jq -e '.counts.permissive == 1 and .counts.strong_copyleft == 0' >/dev/null"
+license_summary=$( jq -n \
+  --argjson counts "$(echo "$audit_out" | jq '.counts')" \
+  --argjson flagged "$(echo "$audit_out" | jq '.flagged')" \
+  '{
+    phase: "license-audit",
+    summary: { status: "OK", headline: "e2e: 1 MIT dep", counts: $counts, flagged: $flagged, next_action: "None." },
+    context_checkpoint: { summary: "license audit completed" }
+  }' )
+"$REPO/bin/save-artifact.sh" license-audit "$license_summary" >/dev/null
+assert_true "license-audit artifact saved" \
+  bash -c "ls $NANOSTACK_STORE/license-audit/*.json | head -1 | grep -q ."
+
+# ─── Cell 6: run privacy-check and save its artifact ───────────────
+echo "[6] run privacy-check/bin/check.sh + save artifact"
+priv_out=$( "$NANOSTACK_STORE/skills/privacy-check/bin/check.sh" )
+assert_true "privacy-check detects email signal" \
+  bash -c "echo '$priv_out' | jq -e '.signals | any(.kind == \"personal_data\" and .evidence == \"email\")' >/dev/null"
+assert_true "privacy-check detects name signal" \
+  bash -c "echo '$priv_out' | jq -e '.signals | any(.kind == \"personal_data\" and .evidence == \"name\")' >/dev/null"
+assert_true "privacy-check flags missing privacy_note (no PRIVACY.md, no Privacy section)" \
+  bash -c "echo '$priv_out' | jq -e '.missing | index(\"privacy_note\") != null' >/dev/null"
+privacy_summary=$( jq -n \
+  --argjson signals "$(echo "$priv_out" | jq '.signals')" \
+  --argjson missing "$(echo "$priv_out" | jq '.missing')" \
+  '{
+    phase: "privacy-check",
+    summary: { status: "WARN", headline: "Email + name without privacy note", signals: $signals, missing: $missing, next_action: "Add a privacy note before shipping." },
+    context_checkpoint: { summary: "privacy hygiene completed" }
+  }' )
+"$REPO/bin/save-artifact.sh" privacy-check "$privacy_summary" >/dev/null
+assert_true "privacy-check artifact saved" \
+  bash -c "ls $NANOSTACK_STORE/privacy-check/*.json | head -1 | grep -q ."
+
+# ─── Cell 7: bin/resolve.sh release-readiness ──────────────────────
+echo "[7] bin/resolve.sh release-readiness"
+resolved=$( "$REPO/bin/resolve.sh" release-readiness 2>/dev/null )
+assert_eq "resolver phase_kind == custom" "custom" \
+  "$( echo "$resolved" | jq -r '.phase_kind' )"
+for upstream in review qa security license-audit privacy-check; do
+  assert_true "upstream_artifacts has '$upstream' key" \
+    bash -c "echo '$resolved' | jq -e '.upstream_artifacts | has(\"$upstream\")' >/dev/null"
+done
+# Each declared upstream now has a saved artifact, so the resolver
+# returns a path (not null) for each.
+assert_true "every declared upstream resolves to a path (not null)" \
+  bash -c "echo '$resolved' | jq -e '.upstream_artifacts | to_entries | all(.value | type == \"string\")' >/dev/null"
+
+# ─── Cell 8: run release-readiness summarize + save ────────────────
+echo "[8] run release-readiness/bin/summarize.sh + save artifact"
+sum_out=$( NANOSTACK_ROOT="$REPO" "$NANOSTACK_STORE/skills/release-readiness/bin/summarize.sh" )
+rollup=$( echo "$sum_out" | jq -r '.rollup_status' )
+# privacy-check is WARN, others OK -> rollup WARN.
+assert_eq "rollup is WARN (privacy-check WARN, others OK)" "WARN" "$rollup"
+assert_true "checks include all five upstreams" \
+  bash -c "echo '$sum_out' | jq -e '.checks | length == 5' >/dev/null"
+release_summary=$( jq -n \
+  --argjson checks "$(echo "$sum_out" | jq '.checks')" \
+  --arg rollup "$rollup" \
+  '{
+    phase: "release-readiness",
+    summary: { status: $rollup, headline: ("Release readiness: " + $rollup), checks: $checks, next_action: "Add a privacy note and re-run /privacy-check." },
+    context_checkpoint: { summary: "release readiness composed" }
+  }' )
+"$REPO/bin/save-artifact.sh" release-readiness "$release_summary" >/dev/null
+assert_true "release-readiness artifact saved" \
+  bash -c "ls $NANOSTACK_STORE/release-readiness/*.json | head -1 | grep -q ."
+
+# ─── Cell 9: sprint-journal sections ───────────────────────────────
+echo "[9] sprint-journal includes the three custom phases"
+journal=$( "$REPO/bin/sprint-journal.sh" )
+for s in license-audit privacy-check release-readiness; do
+  assert_true "journal has '## /$s' section" \
+    bash -c "grep -qF '## /$s' '$journal'"
+done
+
+# ─── Cell 10: analytics --json includes custom counts ─────────────
+echo "[10] analytics --json counts the three custom phases"
+analytics=$( "$REPO/bin/analytics.sh" --json )
+for s in license-audit privacy-check release-readiness; do
+  assert_true "analytics.sprints.custom.\"$s\" >= 1" \
+    bash -c "echo '$analytics' | jq -e \".sprints.\\\"custom\\\".\\\"$s\\\" >= 1\" >/dev/null"
+done
+assert_true "analytics.sprints.custom_total >= 3" \
+  bash -c "echo '$analytics' | jq -e '.sprints.custom_total >= 3' >/dev/null"
+
+# ─── Cell 11: discard --dry-run lists custom artifacts ────────────
+echo "[11] discard-sprint --dry-run lists the three custom artifacts"
+discard=$( "$REPO/bin/discard-sprint.sh" --dry-run )
+for s in license-audit privacy-check release-readiness; do
+  assert_true "discard --dry-run mentions $s" \
+    bash -c "echo '$discard' | grep -qF '$s'"
+done
+
+# ─── Cell 12: conductor start with the stack's phase_graph ────────
+echo "[12] conductor sprint.sh start with stack.json phase_graph"
+phase_graph=$( jq '.phase_graph' "$STACK_DIR/stack.json" )
+jq --argjson g "$phase_graph" '.phase_graph = $g' "$NANOSTACK_STORE/config.json" \
+  > "$NANOSTACK_STORE/config.json.tmp" \
+  && mv "$NANOSTACK_STORE/config.json.tmp" "$NANOSTACK_STORE/config.json"
+"$REPO/conductor/bin/sprint.sh" start >/dev/null
+sprint_status=$( "$REPO/conductor/bin/sprint.sh" status )
+for p in license-audit privacy-check release-readiness; do
+  assert_true "sprint includes '$p'" \
+    bash -c "echo '$sprint_status' | jq -e '.phases | has(\"$p\")' >/dev/null"
+done
+assert_true "sprint has 10 nodes (think+plan+build+review+qa+security+3 custom+ship)" \
+  bash -c "echo '$sprint_status' | jq -e '.phases | length == 10' >/dev/null"
+
+# ─── Cell 13: conductor batch ordering and concurrency ────────────
+echo "[13] conductor sprint.sh batch — ordering + concurrency"
+batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+# license-audit + privacy-check both depend only on build; both are
+# concurrency=read; conductor should schedule them in the same
+# type=read batch after build completes.
+build_line=$( echo "$batch_out" | grep -nF '"build"' | head -1 | cut -d: -f1 )
+la_line=$( echo "$batch_out" | grep -nF '"license-audit"' | head -1 | cut -d: -f1 )
+pc_line=$( echo "$batch_out" | grep -nF '"privacy-check"' | head -1 | cut -d: -f1 )
+rr_line=$( echo "$batch_out" | grep -nF '"release-readiness"' | head -1 | cut -d: -f1 )
+ship_line=$( echo "$batch_out" | grep -nF '"ship"' | head -1 | cut -d: -f1 )
+assert_true "build appears before license-audit + privacy-check" \
+  bash -c "[ '$build_line' -lt '$la_line' ] && [ '$build_line' -lt '$pc_line' ]"
+assert_true "release-readiness appears after license-audit + privacy-check" \
+  bash -c "[ '$rr_line' -gt '$la_line' ] && [ '$rr_line' -gt '$pc_line' ]"
+assert_true "ship appears after release-readiness" \
+  bash -c "[ '$ship_line' -gt '$rr_line' ]"
+assert_true "license-audit scheduled as type=read" \
+  bash -c "echo '$batch_out' | grep -qE '\"type\":\"read\".*\"phases\":\\[[^]]*\"license-audit\"|\"phases\":\\[[^]]*\"license-audit\"[^]]*\\].*\"type\":\"read\"'"
+assert_true "privacy-check scheduled as type=read" \
+  bash -c "echo '$batch_out' | grep -qE '\"type\":\"read\".*\"phases\":\\[[^]]*\"privacy-check\"|\"phases\":\\[[^]]*\"privacy-check\"[^]]*\\].*\"type\":\"read\"'"
+
+# ─── Cell 14: subdir scaffold lands in repo root .nanostack ───────
+# Same install, run from a subdirectory. store-path.sh resolves to
+# the git repo root, so the skill must land there (not in subdir/.nanostack).
+echo "[14] scaffold from a git subdirectory"
+SUB_PROJ="$TMP_ROOT/subdir-project"
+mkdir -p "$SUB_PROJ/src/feature"
+cd "$SUB_PROJ"
+git init -q
+cd "$SUB_PROJ/src/feature"
+unset NANOSTACK_STORE
+"$REPO/bin/create-skill.sh" license-audit \
+  --from "$STACK_DIR/skills/license-audit" \
+  --concurrency read --depends-on build >/dev/null
+assert_true "subdir scaffold lands in repo root .nanostack/skills" \
+  test -f "$SUB_PROJ/.nanostack/skills/license-audit/SKILL.md"
+assert_false "no rogue .nanostack inside the subdir" \
+  test -d "$SUB_PROJ/src/feature/.nanostack"
+
+# ─── Cell 15: no-git scaffold lands in $HOME/.nanostack ───────────
+# No git init in this project; HOME points at a fresh tmp so the
+# real ~/.nanostack is untouched.
+echo "[15] scaffold without git (fake HOME)"
+NOGIT_HOME="$TMP_ROOT/nogit-home"
+NOGIT_PROJ="$TMP_ROOT/nogit-project"
+mkdir -p "$NOGIT_HOME" "$NOGIT_PROJ"
+cd "$NOGIT_PROJ"
+HOME="$NOGIT_HOME" "$REPO/bin/create-skill.sh" license-audit \
+  --from "$STACK_DIR/skills/license-audit" \
+  --concurrency read --depends-on build >/dev/null
+assert_true "no-git scaffold lands in fake \$HOME/.nanostack/skills" \
+  test -f "$NOGIT_HOME/.nanostack/skills/license-audit/SKILL.md"
+assert_false "no .nanostack inside the no-git project cwd" \
+  test -d "$NOGIT_PROJ/.nanostack"
+
+echo
+echo "===================================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf "${GREEN}Custom Stack Examples runtime E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
+  exit 0
+else
+  printf "${RED}Custom Stack Examples runtime E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/check.sh
+++ b/examples/custom-stack-template/compliance-release/skills/privacy-check/bin/check.sh
@@ -59,10 +59,14 @@ scan_personal_data() {
     [ -d "$root" ] || continue
     grep -rEn "$PERSONAL_RE" "$root" 2>/dev/null | head -20 | while IFS=: read -r file line evidence; do
       [ -z "$file" ] && continue
-      # Extract just the matching token for evidence.
-      token=$(printf '%s' "$evidence" | grep -oE "$PERSONAL_RE" | head -1)
-      [ -z "$token" ] && token="(field)"
-      printf 'personal_data\t%s\t%s\n' "$file" "$token"
+      # Emit one signal per UNIQUE matching token in the line. The
+      # earlier `head -1` form silently dropped the second token when
+      # a single line collected both, e.g. `{ email: ..., name: ... }`
+      # would only report email. Users expect both fields to surface.
+      printf '%s' "$evidence" | grep -oE "$PERSONAL_RE" | sort -u | while read -r token; do
+        [ -z "$token" ] && continue
+        printf 'personal_data\t%s\t%s\n' "$file" "$token"
+      done
     done
   done
 }
@@ -72,9 +76,12 @@ scan_telemetry() {
     [ -d "$root" ] || continue
     grep -rEn "$TELEMETRY_RE" "$root" 2>/dev/null | head -20 | while IFS=: read -r file line evidence; do
       [ -z "$file" ] && continue
-      token=$(printf '%s' "$evidence" | grep -oiE "$TELEMETRY_RE" | head -1 | tr '[:upper:]' '[:lower:]')
-      [ -z "$token" ] && token="(library)"
-      printf 'telemetry\t%s\t%s\n' "$file" "$token"
+      # Same fix: emit one signal per unique library reference in the
+      # line so `import { posthog } from "sentry"` reports both.
+      printf '%s' "$evidence" | grep -oiE "$TELEMETRY_RE" | tr '[:upper:]' '[:lower:]' | sort -u | while read -r token; do
+        [ -z "$token" ] && continue
+        printf 'telemetry\t%s\t%s\n' "$file" "$token"
+      done
     done
   done
 }


### PR DESCRIPTION
## Summary

Third PR of the **Custom Stack Examples v1** round. PR 1 #203 landed the manifest + 49-check static contract. PR 2 #204 wired the real skill behavior with 21 case-level smoke assertions. This PR adds `ci/e2e-custom-stack-examples.sh` — the runtime contract that proves the `compliance-release` stack composes end-to-end on a real `/tmp` project.

**15 cells, 51 assertions, no network.** Spec asked for ≥35; the harness exceeds the floor because every upstream resolution and conductor batching condition is asserted explicitly.

## What the harness exercises

| Cell | What |
|---|---|
| 1 | Fixture project: Node app, README, `.env.example`, `src/signup.js` with email + name fields, MIT lodash installed under `node_modules`. |
| 2 | Install all three skills via `bin/create-skill.sh --from` with the documented `--concurrency` + `--depends-on` flags. Assert they land in `$NANOSTACK_STORE/skills` and the three phases register. |
| 3 | `bin/check-custom-skill.sh` validates each scaffolded skill (PR 6 of the framework round's contract). |
| 4 | Save fake `review` / `qa` / `security` artifacts via `save-artifact.sh` so the release composer has real upstream evidence with valid `.integrity` hashes. |
| 5 | Run `license-audit/bin/audit.sh`; assert MIT lodash classifies as permissive. Save artifact. |
| 6 | Run `privacy-check/bin/check.sh`; assert email AND name signals both surface, `missing` includes `privacy_note`. Save artifact. |
| 7 | `bin/resolve.sh release-readiness`; assert `phase_kind=custom` and all five declared upstream keys resolve to a path (not null). |
| 8 | Run `release-readiness/bin/summarize.sh`; assert rollup is `WARN` (privacy-check is WARN, others OK) and all five checks are recorded. Save artifact. |
| 9 | `bin/sprint-journal.sh` emits `## /<phase>` sections for all three custom phases. |
| 10 | `bin/analytics.sh --json` counts each phase under `sprints.custom` and reports `sprints.custom_total >= 3`. |
| 11 | `bin/discard-sprint.sh --dry-run` lists every custom artifact. |
| 12 | `conductor/bin/sprint.sh start` with the stack's `phase_graph`. Assert sprint has 10 nodes (think + plan + build + review + qa + security + 3 custom + ship). |
| 13 | `conductor/bin/sprint.sh batch` ordering and concurrency. Assert build precedes license-audit and privacy-check; both schedule as `type=read`; release-readiness follows after both; ship follows after release-readiness. |
| 14 | Scaffold from a git **subdirectory**. Assert skills land in repo root `.nanostack/skills` (not `subdir/.nanostack`). |
| 15 | Scaffold without git, fake `$HOME`. Assert skills land in `$HOME/.nanostack/skills` (not cwd). |

## Bug fix surfaced by the harness

Cell 6 asserts both `email` AND `name` signals surface from `src/signup.js`. The PR 2 smoke case 2 had the same fixture line but only asserted `signals | any(.kind == "personal_data")`, which was satisfied by `email` alone. The runtime harness asserting both exposed that `privacy-check`'s scanner used `head -1` on the per-line token extraction, silently dropping the second match.

Fixed in this PR: `scan_personal_data` and `scan_telemetry` now emit one signal per **unique** matching token in each line. The PR 2 smokes still pass (name-only and ga were already covered).

## CI

New `e2e-custom-stack-examples` job in `.github/workflows/e2e.yml` runs the harness on `workflow_dispatch`, alongside the existing `e2e-custom-stack` and other e2e jobs.

## Test plan

- [x] tests/run.sh: 83/83
- [x] ci/e2e-user-flows.sh: 100/100
- [x] ci/e2e-custom-stack-flows.sh: 30/30
- [x] **ci/e2e-custom-stack-examples.sh: 51/51** (new)
- [x] ci/check-custom-stack-examples.sh: 49/49
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] YAML parses
- [x] Smokes still pass: license-audit 6/6, privacy-check 8/8, release-readiness 7/7

## Out of scope (PR 4)

- README.md + README.es.md + EXTENDING.md "build your own workflow stack" repositioning, only after this harness lands. The framework spec's "do not reposition the README hero before runtime E2E lands" rule unblocks once PR 3 merges.