### PR TITLE
README claim locks: lock the new narrative against drift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1993,6 +1993,112 @@ jobs:
           done
           exit $fail
 
+  readme-narrative-locks:
+    name: README narrative claim locks
+    runs-on: ubuntu-latest
+    # Spec readme-product-narrative-refresh-2026-04-26. PR 1 of the
+    # round rewrote the README around "default sprint + framework
+    # for workflow stacks". This job locks the new claim surface so
+    # later edits do not silently drift back to the older wording or
+    # reintroduce the disallowed phrases the spec called out (Amp,
+    # Cline, Antigravity, "4 commands", "every workflow run", etc.).
+    # The existing readme-public-copy job above already locks an
+    # earlier round's required + stale set; this job is additive.
+    steps:
+      - uses: actions/checkout@v4
+      - name: New required tokens in README.md
+        run: |
+          set -e
+          fail=0
+          # Five-adapter set + opt-in E2E framing must appear by name
+          # so the public claim cannot quietly degrade to "and more"
+          # or "always-on" again.
+          for tok in \
+            'opt-in E2E workflow' \
+            'Verified adapters' \
+            'OpenAI Codex' \
+            'OpenCode' \
+            'Gemini CLI'; do
+            if ! grep -qF "$tok" README.md; then
+              echo "FAIL: README.md missing required token: $tok"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Spanish README declares the same E2E opt-in framing
+        run: |
+          set -e
+          # Spec accepts either "E2E opt-in" or "workflow E2E opt-in"
+          # as long as the opt-in nature of the runtime harness is
+          # spelled out in Spanish too.
+          if ! grep -qE 'E2E opt-in|workflow E2E opt-in' README.es.md; then
+            echo "FAIL: README.es.md does not declare E2E opt-in framing"
+            exit 1
+          fi
+      - name: Forbidden phrases must NOT appear in README.md or README.es.md
+        run: |
+          set -e
+          fail=0
+          # Literal substrings handled with grep -F. Includes both
+          # Spanish and English variants and tightens the existing
+          # stale-strings list with phrases that have been seen in
+          # drafts but did not yet have a hard lock.
+          for bad in \
+            'npx create-nanostack install' \
+            'on every workflow run' \
+            'every workflow run' \
+            '4 commands' \
+            'Cuatro comandos' \
+            'zero dependencies' \
+            'Zero dependencies' \
+            'cero dependencias' \
+            'Cero dependencias' \
+            'marketplace' \
+            'plugin ecosystem' \
+            'GDPR ready' \
+            'SOC2 ready' \
+            'compliance certified' \
+            'works in every agent identically' \
+            'full engineering team'; do
+            hits=$(grep -nF "$bad" README.md README.es.md 2>/dev/null || true)
+            if [ -n "$hits" ]; then
+              echo "FAIL: forbidden phrase '$bad' present:"
+              echo "$hits"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Forbidden agent names (bare-word boundary) must NOT appear
+        run: |
+          set -e
+          fail=0
+          # Use word boundaries so legitimate uses like "amplifier",
+          # "decline", or "incline" do not trip the lock. The spec
+          # set blocks bare references to Amp, Cline, and Antigravity
+          # because Nanostack does not have verified adapters for
+          # them today; the README must claim only the five verified
+          # hosts.
+          for name in 'Amp' 'Cline' 'Antigravity'; do
+            hits=$(grep -nE "\\b${name}\\b" README.md README.es.md 2>/dev/null || true)
+            if [ -n "$hits" ]; then
+              echo "FAIL: forbidden agent name '$name' (bare word) present:"
+              echo "$hits"
+              fail=1
+            fi
+          done
+          exit $fail
+      - name: Sprint-order arrow MUST NOT show /qa before /security
+        run: |
+          set -e
+          # The canonical sprint order is /review -> /security -> /qa
+          # -> /ship. Any arrow form (-> or →) that shows /qa
+          # immediately before /security is a regression on the
+          # spec's "do not show /qa before /security" rule.
+          if grep -nE '/qa[[:space:]]*(->|→)[[:space:]]*/security' README.md README.es.md; then
+            echo "FAIL: README contains /qa -> /security arrow form (canonical order is /security -> /qa)"
+            exit 1
+          fi
+
   examples-library:
     name: Examples library contract
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2010,12 +2010,17 @@ jobs:
         run: |
           set -e
           fail=0
-          # Five-adapter set + opt-in E2E framing must appear by name
-          # so the public claim cannot quietly degrade to "and more"
-          # or "always-on" again.
+          # Every name in the verified-adapter set must appear by
+          # itself (not just under a generic "Verified adapters"
+          # heading), so a future edit cannot drop Claude Code or
+          # Cursor from the public claim while keeping the rest.
+          # The opt-in E2E framing is locked here too so the claim
+          # cannot quietly degrade to "always-on" again.
           for tok in \
             'opt-in E2E workflow' \
             'Verified adapters' \
+            'Claude Code' \
+            'Cursor' \
             'OpenAI Codex' \
             'OpenCode' \
             'Gemini CLI'; do
@@ -2039,20 +2044,21 @@ jobs:
         run: |
           set -e
           fail=0
-          # Literal substrings handled with grep -F. Includes both
-          # Spanish and English variants and tightens the existing
-          # stale-strings list with phrases that have been seen in
-          # drafts but did not yet have a hard lock.
+          # Case-insensitive literal-substring sweep. Earlier draft
+          # used grep -F (case-sensitive) which would have let trivial
+          # variants slip through (Marketplace, GDPR Ready, Every
+          # workflow run, Full engineering team, etc.). For a public-
+          # narrative lock the casing should not matter; -iF locks
+          # the claim regardless of how it is capitalized.
+          # Spanish forms collapse with -i (cero/Cero, cuatro/Cuatro).
           for bad in \
             'npx create-nanostack install' \
             'on every workflow run' \
             'every workflow run' \
             '4 commands' \
-            'Cuatro comandos' \
+            'cuatro comandos' \
             'zero dependencies' \
-            'Zero dependencies' \
             'cero dependencias' \
-            'Cero dependencias' \
             'marketplace' \
             'plugin ecosystem' \
             'GDPR ready' \
@@ -2060,9 +2066,9 @@ jobs:
             'compliance certified' \
             'works in every agent identically' \
             'full engineering team'; do
-            hits=$(grep -nF "$bad" README.md README.es.md 2>/dev/null || true)
+            hits=$(grep -niF "$bad" README.md README.es.md 2>/dev/null || true)
             if [ -n "$hits" ]; then
-              echo "FAIL: forbidden phrase '$bad' present:"
+              echo "FAIL: forbidden phrase '$bad' present (case-insensitive):"
               echo "$hits"
               fail=1
             fi
@@ -2072,16 +2078,16 @@ jobs:
         run: |
           set -e
           fail=0
-          # Use word boundaries so legitimate uses like "amplifier",
-          # "decline", or "incline" do not trip the lock. The spec
-          # set blocks bare references to Amp, Cline, and Antigravity
-          # because Nanostack does not have verified adapters for
-          # them today; the README must claim only the five verified
-          # hosts.
+          # Word-boundary regex so legitimate words like "amplifier",
+          # "decline", or "incline" do not trip the lock. Match is
+          # case-insensitive so trivial variants (AMP, amp, Cline,
+          # CLINE, ANTIGRAVITY) are caught the same way. Nanostack
+          # does not ship verified adapters for any of these hosts;
+          # the README must claim only the five verified ones.
           for name in 'Amp' 'Cline' 'Antigravity'; do
-            hits=$(grep -nE "\\b${name}\\b" README.md README.es.md 2>/dev/null || true)
+            hits=$(grep -niE "\\b${name}\\b" README.md README.es.md 2>/dev/null || true)
             if [ -n "$hits" ]; then
-              echo "FAIL: forbidden agent name '$name' (bare word) present:"
+              echo "FAIL: forbidden agent name '$name' (bare word, case-insensitive) present:"
               echo "$hits"
               fail=1
             fi


### PR DESCRIPTION
## Summary

PR 2 of the README narrative refresh round. PR 1 #207 rewrote the public copy; this PR adds the lint job (`readme-narrative-locks`) that prevents the new claims from drifting back to older wording or accepting the disallowed phrases Codex's spec called out. The existing `readme-public-copy` job is preserved untouched; this is additive.

## Five new check groups

### 1. Required English tokens

Five-adapter set + opt-in E2E framing must appear by name so the public claim cannot quietly degrade to "and more" or imply always-on coverage. Each adapter is required element-wise so dropping any one of them fires the lint.

- `opt-in E2E workflow`
- `Verified adapters`
- `Claude Code`
- `Cursor`
- `OpenAI Codex`
- `OpenCode`
- `Gemini CLI`

### 2. Required Spanish form

Either `E2E opt-in` or `workflow E2E opt-in` must appear in `README.es.md`. The Spanish surface stays honest about the runtime harness being `workflow_dispatch`.

### 3. Forbidden literal phrases (case-insensitive, both READMEs)

`grep -niF` sweep so trivial casing variants (`Marketplace`, `GDPR Ready`, `Every workflow run`, `Full engineering team`, etc.) are caught the same way as the canonical lowercase form. Spanish/English forms collapse under `-i` (`cero`/`Cero`, `cuatro`/`Cuatro`).

- `npx create-nanostack install` (specific bad install command)
- `on every workflow run` / `every workflow run`
- `4 commands` / `cuatro comandos`
- `zero dependencies` / `cero dependencias`
- `marketplace` / `plugin ecosystem`
- `GDPR ready` / `SOC2 ready` / `compliance certified`
- `works in every agent identically`
- `full engineering team`

### 4. Forbidden agent names (bare-word boundary, case-insensitive)

`grep -niE "\b<name>\b"`. Spec rejects bare references to Amp, Cline, and Antigravity because Nanostack does not ship verified adapters for them today. Word boundaries hold under `-i` so legitimate words like `amplifier`, `ramp`, `decline`, `incline` do not trip the lock; only standalone `Amp` / `AMP` / `amp`, `Cline` / `CLINE`, `Antigravity` / `ANTIGRAVITY` fire.

### 5. Sprint-order arrow check

Any arrow form (`->` or unicode `→`) placing `/qa` immediately before `/security` is a regression on the "do not show /qa before /security" rule.

## Sabotage-tested

Each rule fired correctly when the PR head was deliberately broken. Replay summary:

| Sabotage | Caught? |
|---|---|
| Drop `Claude Code` from README | Yes (required-token check) |
| Drop `Cursor` from README | Yes (required-token check) |
| Drop `OpenAI Codex` from README | Yes (required-token check) |
| Append `Marketplace` (case-flipped) | Yes (case-i literal sweep) |
| Append `GDPR Ready` (case-flipped) | Yes (case-i literal sweep) |
| Append `Full engineering team` (case-flipped) | Yes (case-i literal sweep) |
| Append `Zero Dependencies` / `Cuatro Comandos` (case-flipped) | Yes (case-i literal sweep) |
| Append `AMP` / `CLINE` / `antigravity` (case-flipped) | Yes (case-i bare-word check) |
| Append `Sprint: /qa -> /security -> /ship` | Yes (arrow-form check) |
| Strip `E2E opt-in` from `README.es.md` | Yes (Spanish required-form check) |

Happy path passes clean on current `main` content.

## Test plan

- [x] YAML parses
- [x] tests/run.sh: 83/83
- [x] ci/e2e-user-flows.sh: 100/100
- [x] ci/e2e-custom-stack-flows.sh: 30/30
- [x] ci/check-custom-stack-examples.sh: 49/49
- [x] ci/e2e-think-flows.sh: 32/32
- [x] ci/e2e-think-archetypes.sh: 25/25
- [x] ci/e2e-onboarding-flows.sh: 34/34
- [x] ci/e2e-delivery-matrix.sh: 17/17
- [x] ci/check-examples.sh: 32/32
- [x] All five new check groups pass against current `README.md` + `README.es.md`
- [x] Every sabotage case fires the matching lock

## Round closure

After this lands, the README narrative refresh round is complete:

- **PR 1 #207** — public copy rewritten, framework story first-class, sandbox table includes `compliance-release`, Spanish parity restored, existing required-strings lock updated to match the new pillars
- **PR 2 (this)** — additive `readme-narrative-locks` job protects the new claim surface from drift, including the full five-adapter set element-wise and case-insensitive forbidden-phrase + bare-agent-name sweeps

The README is now the canonical product page: clear for first-time users, precise for technical users, honest about enforcement, current with framework + workflow stack support, and protected from known stale claims.