### PR TITLE
guard: custom-phase concurrency parity (PR 1 of architecture vNext)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           ci/e2e-custom-stack-examples.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (19-cell journey)
+    name: E2E Custom Stack Framework v1 (20-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           ci/e2e-custom-stack-examples.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (15-cell journey)
+    name: E2E Custom Stack Framework v1 (18-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           ci/e2e-custom-stack-examples.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (18-cell journey)
+    name: E2E Custom Stack Framework v1 (19-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           ci/e2e-custom-stack-examples.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (21-cell journey)
+    name: E2E Custom Stack Framework v1 (22-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           ci/e2e-custom-stack-examples.sh
 
   e2e-custom-stack:
-    name: E2E Custom Stack Framework v1 (20-cell journey)
+    name: E2E Custom Stack Framework v1 (21-cell journey)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Custom Stack Framework v1 PR 6. Runs the full new-user journey:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3322,3 +3322,37 @@ jobs:
           run_case 0 'cat wrangler.json'
           run_case 0 'jq . package.json'
           exit $fail
+
+  guard-uses-phase-registry:
+    name: Guard resolves current-phase SKILL.md via the phase registry
+    runs-on: ubuntu-latest
+    # Tier 2.5 concurrency enforcement must go through nano_phase_skill_path
+    # (bin/lib/phases.sh) so custom phases get the same write-block
+    # protection as built-in ones. The 2026-05-10 audit caught a raw
+    # $NANOSTACK_ROOT/$CURRENT_PHASE/SKILL.md lookup that silently no-oped
+    # for every custom skill (their SKILL.md lives under the store, not
+    # the repo). This lock blocks any reintroduction of the raw lookup.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: No raw repo-root SKILL.md lookup in guard
+        run: |
+          set -e
+          script=guard/bin/check-dangerous.sh
+          # Strip comment lines so the explanatory header (which quotes
+          # the forbidden pattern as context) does not trigger the lock.
+          code_only=$(grep -vE '^[[:space:]]*#' "$script")
+          if echo "$code_only" | grep -E '\$NANOSTACK_ROOT/\$[A-Z_]*PHASE[A-Z_]*/SKILL\.md'; then
+            echo "FAIL: $script contains a raw \$NANOSTACK_ROOT/<phase>/SKILL.md lookup."
+            echo "Use nano_phase_skill_path from bin/lib/phases.sh so custom phases"
+            echo "get the same concurrency protection as built-in ones."
+            exit 1
+          fi
+          if ! grep -qF 'nano_phase_skill_path' "$script"; then
+            echo "FAIL: $script does not reference nano_phase_skill_path."
+            echo "The concurrency tier must resolve SKILL.md through the phase"
+            echo "registry so custom skills under <store>/skills/ are honored."
+            exit 1
+          fi
+          echo "OK: guard concurrency tier uses the phase registry."

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -285,6 +285,34 @@ nano_phase_skill_path() {
       return 1
       ;;
   esac
+
+  # Membership in nano_custom_phases is the trust boundary: only an
+  # explicitly registered custom phase is allowed to search user-owned
+  # skill roots (skill_roots, store/skills, ~/.claude/skills, ~/.agents/
+  # skills). An unregistered phase that happens to share a name with an
+  # unrelated user-installed skill must NOT be silently shadowed,
+  # otherwise the bundled `feature`/`doctor` read-only behavior could
+  # be overridden by an arbitrary same-named directory. Codex flagged
+  # this on the PR 1 sixth pass.
+  local is_registered_custom=0
+  local _custom_list
+  _custom_list=$(nano_custom_phases "$config" 2>/dev/null)
+  case " $_custom_list " in
+    *" $phase "*) is_registered_custom=1 ;;
+  esac
+
+  if [ "$is_registered_custom" = "0" ]; then
+    # Not core, not registered as custom — fall back to repo-bundled
+    # non-core skills only. This preserves the old raw lookup behavior
+    # for feature/doctor/help/compound/start while preventing shadowing
+    # by unrelated user-installed skills with the same directory name.
+    if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ] && [ -f "$repo_root/$phase/SKILL.md" ]; then
+      printf '%s\n' "$repo_root/$phase"
+      return 0
+    fi
+    return 1
+  fi
+
   # Build a newline-delimited candidate list so paths with spaces (a
   # $HOME like "Hello World" or a store under "My Drive") survive
   # iteration. Previous form was a single space-separated string fed
@@ -352,19 +380,5 @@ nano_phase_skill_path() {
     fi
   done <<< "$candidates"
   unset -f _phases_append_root
-
-  # Repo-bundled non-core skills (feature, doctor, help, compound,
-  # start, ...) live at $NANOSTACK_ROOT/<phase>/SKILL.md. They are
-  # shipped with the repo and can be set as current_phase. The
-  # previous raw lookup in guard saw them directly; we preserve that
-  # behavior here as the LAST fallback so an explicitly registered
-  # custom skill with the same directory name wins (create-skill.sh
-  # does not reserve bundled names, so a user can legitimately
-  # register `feature` themselves). Codex flagged the original
-  # ordering on the PR 1 fifth pass.
-  if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ] && [ -f "$repo_root/$phase/SKILL.md" ]; then
-    printf '%s\n' "$repo_root/$phase"
-    return 0
-  fi
   return 1
 }

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -294,16 +294,23 @@ nano_phase_skill_path() {
   local candidates=""
   _phases_append_root() {
     local candidate="$1"
-    [ -z "$candidate" ] && return
+    # Both early returns are successful no-ops, not errors. A bare
+    # `return` would inherit the previous test's exit status (1 when
+    # the candidate is non-empty), and callers running under `set -e`
+    # would treat the helper as failed. Codex caught this on the
+    # PR 1 second pass with the standard $NANOSTACK_STORE == config_dir
+    # case where the dedup branch fires.
+    [ -z "$candidate" ] && return 0
     # Dedup: skip if the exact path is already on the list.
     case $'\n'"$candidates"$'\n' in
-      *$'\n'"$candidate"$'\n'*) return ;;
+      *$'\n'"$candidate"$'\n'*) return 0 ;;
     esac
     if [ -z "$candidates" ]; then
       candidates="$candidate"
     else
       candidates="$candidates"$'\n'"$candidate"
     fi
+    return 0
   }
 
   # 1. Configured skill_roots (user override), newline-separated from jq.

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -285,41 +285,65 @@ nano_phase_skill_path() {
       return 1
       ;;
   esac
-  local roots=""
+  # Build a newline-delimited candidate list so paths with spaces (a
+  # $HOME like "Hello World" or a store under "My Drive") survive
+  # iteration. Previous form was a single space-separated string fed
+  # into `for root in $list`, which silently dropped split halves and
+  # made guard concurrency a no-op for those users. Codex caught this
+  # while reviewing the registry-aware guard tier.
+  local candidates=""
+  _phases_append_root() {
+    local candidate="$1"
+    [ -z "$candidate" ] && return
+    # Dedup: skip if the exact path is already on the list.
+    case $'\n'"$candidates"$'\n' in
+      *$'\n'"$candidate"$'\n'*) return ;;
+    esac
+    if [ -z "$candidates" ]; then
+      candidates="$candidate"
+    else
+      candidates="$candidates"$'\n'"$candidate"
+    fi
+  }
+
+  # 1. Configured skill_roots (user override), newline-separated from jq.
   if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
-    roots=$(jq -r '.skill_roots // [] | .[]' "$config" 2>/dev/null)
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      _phases_append_root "$line"
+    done < <(jq -r '.skill_roots // [] | .[]' "$config" 2>/dev/null)
   fi
-  # Build the search order from most-specific to least:
-  #   1. configured skill_roots (user override)
-  #   2. <store>/skills — the resolved store, same path bin/create-skill.sh
-  #      writes to. This is the load-bearing one: a scaffold from a git
-  #      subdir or a no-git project lives here, not under cwd/.nanostack.
-  #   3. <config-dir>/skills — covers a global config under $HOME/.nanostack
-  #      that the resolver picked up via _nano_phases_resolve_config.
-  #   4. cwd-relative .nanostack/skills (legacy, retained for back-compat).
-  #   5. $HOME/.claude/skills + $HOME/.agents/skills (agent install
-  #      locations for skills shipped outside .nanostack).
-  local default_roots=""
+  # 2. <store>/skills — same path bin/create-skill.sh writes to. This is
+  #    the load-bearing one: a scaffold from a git subdir or a no-git
+  #    project lives here, not under cwd/.nanostack.
   if [ -n "${NANOSTACK_STORE:-}" ]; then
-    default_roots="$NANOSTACK_STORE/skills"
+    _phases_append_root "$NANOSTACK_STORE/skills"
   fi
+  # 3. <config-dir>/skills — covers a global config under $HOME/.nanostack
+  #    that the resolver picked up via _nano_phases_resolve_config.
   if [ -n "$config" ]; then
     local config_dir
     config_dir=$(dirname "$config")
-    case " $default_roots " in
-      *" $config_dir/skills "*) ;;
-      *) default_roots="${default_roots:+$default_roots }$config_dir/skills" ;;
-    esac
+    _phases_append_root "$config_dir/skills"
   fi
-  default_roots="${default_roots:+$default_roots }.nanostack/skills $HOME/.claude/skills $HOME/.agents/skills"
-  for root in $roots $default_roots; do
+  # 4. cwd-relative .nanostack/skills (legacy, retained for back-compat).
+  _phases_append_root ".nanostack/skills"
+  # 5. $HOME/.claude/skills + $HOME/.agents/skills (agent install
+  #    locations for skills shipped outside .nanostack).
+  _phases_append_root "$HOME/.claude/skills"
+  _phases_append_root "$HOME/.agents/skills"
+
+  while IFS= read -r root; do
+    [ -z "$root" ] && continue
     case "$root" in
       "~/"*) root="$HOME/${root#~/}" ;;
     esac
     if [ -d "$root/$phase" ] && [ -f "$root/$phase/SKILL.md" ]; then
+      unset -f _phases_append_root
       printf '%s\n' "$root/$phase"
       return 0
     fi
-  done
+  done <<< "$candidates"
+  unset -f _phases_append_root
   return 1
 }

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -285,6 +285,17 @@ nano_phase_skill_path() {
       return 1
       ;;
   esac
+  # Repo-bundled non-core skills live at $NANOSTACK_ROOT/<name>/SKILL.md
+  # (feature, doctor, help, compound, start, etc). They are shipped with
+  # the repo and can be set as current_phase, but they are not in the
+  # core list. The previous raw lookup in guard saw them directly; we
+  # preserve that behavior here so guard concurrency stays consistent
+  # whether the phase is core, repo-bundled, or registered custom.
+  # Codex caught this on the PR 1 fourth pass.
+  if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ] && [ -f "$repo_root/$phase/SKILL.md" ]; then
+    printf '%s\n' "$repo_root/$phase"
+    return 0
+  fi
   # Build a newline-delimited candidate list so paths with spaces (a
   # $HOME like "Hello World" or a store under "My Drive") survive
   # iteration. Previous form was a single space-separated string fed

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -285,17 +285,6 @@ nano_phase_skill_path() {
       return 1
       ;;
   esac
-  # Repo-bundled non-core skills live at $NANOSTACK_ROOT/<name>/SKILL.md
-  # (feature, doctor, help, compound, start, etc). They are shipped with
-  # the repo and can be set as current_phase, but they are not in the
-  # core list. The previous raw lookup in guard saw them directly; we
-  # preserve that behavior here so guard concurrency stays consistent
-  # whether the phase is core, repo-bundled, or registered custom.
-  # Codex caught this on the PR 1 fourth pass.
-  if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ] && [ -f "$repo_root/$phase/SKILL.md" ]; then
-    printf '%s\n' "$repo_root/$phase"
-    return 0
-  fi
   # Build a newline-delimited candidate list so paths with spaces (a
   # $HOME like "Hello World" or a store under "My Drive") survive
   # iteration. Previous form was a single space-separated string fed
@@ -363,5 +352,19 @@ nano_phase_skill_path() {
     fi
   done <<< "$candidates"
   unset -f _phases_append_root
+
+  # Repo-bundled non-core skills (feature, doctor, help, compound,
+  # start, ...) live at $NANOSTACK_ROOT/<phase>/SKILL.md. They are
+  # shipped with the repo and can be set as current_phase. The
+  # previous raw lookup in guard saw them directly; we preserve that
+  # behavior here as the LAST fallback so an explicitly registered
+  # custom skill with the same directory name wins (create-skill.sh
+  # does not reserve bundled names, so a user can legitimately
+  # register `feature` themselves). Codex flagged the original
+  # ordering on the PR 1 fifth pass.
+  if [ -n "$repo_root" ] && [ -d "$repo_root/$phase" ] && [ -f "$repo_root/$phase/SKILL.md" ]; then
+    printf '%s\n' "$repo_root/$phase"
+    return 0
+  fi
   return 1
 }

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -267,7 +267,10 @@ cd "$PROJ"
 # must block writes the same way a built-in read phase does. Without the
 # registry lookup, guard fell back to $NANOSTACK_ROOT/<phase>/SKILL.md
 # and silently no-oped for every custom skill (which lives under the
-# store's skills/, not the repo).
+# store's skills/, not the repo). Also exercises the in-project bypass
+# (./ prefix + absolute in-project path) that Codex flagged on the
+# PR 1 review — Tier 2.4 must run before the in-project fast-path or
+# `touch ./x` inside a git worktree slips through.
 echo "[16] guard blocks writes during a read-only custom phase"
 GUARD_HOME="$TMP_ROOT/guard-home"
 GUARD_PROJ="$TMP_ROOT/guard-project"
@@ -278,12 +281,14 @@ HOME="$GUARD_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read 
 GUARD_STORE="$GUARD_PROJ/.nanostack"
 [ -d "$GUARD_STORE/skills/license-audit" ] || GUARD_STORE="$GUARD_HOME/.nanostack"
 echo '{"current_phase":"license-audit"}' > "$GUARD_STORE/session.json"
-set +e
-NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
-guard_rc=$?
-set -e
-assert_eq "custom read phase blocks write (exit 1)" "1" "$guard_rc"
+for case_cmd in "touch should-not-pass" "touch ./should-not-pass" "touch $GUARD_PROJ/should-not-pass"; do
+  set +e
+  NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
+    "$REPO/guard/bin/check-dangerous.sh" "$case_cmd" >/dev/null 2>&1
+  guard_rc=$?
+  set -e
+  assert_eq "blocks: $case_cmd" "1" "$guard_rc"
+done
 
 # Cell 17: switching the same custom phase to concurrency: write lifts
 # the concurrency block. (Other guard tiers may still object to specific

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -14,6 +14,12 @@
 #  10. Conductor batch reads concurrency=read from the custom skill.
 #  11. agents/openai.yaml is present and parses.
 #  12. The copied skill has no repo-relative example paths.
+#  13. Scaffolding from a git subdirectory lands in the repo root store.
+#  14. Scaffolding outside any git repo lands in $HOME/.nanostack.
+#  15. Validator rejects mismatched frontmatter name.
+#  16. Guard blocks writes during a read-only custom phase.
+#  17. Custom write phase does not trigger the concurrency block.
+#  18. Built-in review phase still blocks (regression check).
 #
 # This harness is the contract Codex's spec calls for in PR 6: a clean
 # sandbox user can complete the entire workflow without reading source.
@@ -253,6 +259,59 @@ sed 's/^name:.*/name: audit-licenses/' "$DRIFT_SKILL/SKILL.md" > "$DRIFT_SKILL/S
 mv "$DRIFT_SKILL/SKILL.md.tmp" "$DRIFT_SKILL/SKILL.md"
 assert_false "check-custom-skill rejects mismatched frontmatter name" \
   bash -c "HOME='$DRIFT_HOME' '$REPO/bin/check-custom-skill.sh' '$DRIFT_SKILL'"
+
+cd "$PROJ"
+
+# Cell 16: guard concurrency is registry-aware. A read-only custom phase
+# must block writes the same way a built-in read phase does. Without the
+# registry lookup, guard fell back to $NANOSTACK_ROOT/<phase>/SKILL.md
+# and silently no-oped for every custom skill (which lives under the
+# store's skills/, not the repo).
+echo "[16] guard blocks writes during a read-only custom phase"
+GUARD_HOME="$TMP_ROOT/guard-home"
+GUARD_PROJ="$TMP_ROOT/guard-project"
+mkdir -p "$GUARD_HOME" "$GUARD_PROJ"
+cd "$GUARD_PROJ"
+git init -q
+HOME="$GUARD_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
+GUARD_STORE="$GUARD_PROJ/.nanostack"
+[ -d "$GUARD_STORE/skills/license-audit" ] || GUARD_STORE="$GUARD_HOME/.nanostack"
+echo '{"current_phase":"license-audit"}' > "$GUARD_STORE/session.json"
+set +e
+NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
+guard_rc=$?
+set -e
+assert_eq "custom read phase blocks write (exit 1)" "1" "$guard_rc"
+
+# Cell 17: switching the same custom phase to concurrency: write lifts
+# the concurrency block. (Other guard tiers may still object to specific
+# commands; here we use a path outside the project so Tier 2 in-project
+# fast-path does not auto-pass.)
+echo "[17] custom write phase does not trigger the concurrency block"
+sed_target="$GUARD_STORE/skills/license-audit/SKILL.md"
+sed 's/^concurrency: read$/concurrency: write/' "$sed_target" > "$sed_target.tmp"
+mv "$sed_target.tmp" "$sed_target"
+OUT_TMP=$(mktemp -d /tmp/guard-outside.XXXXXX)
+set +e
+NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch $OUT_TMP/x" >/dev/null 2>&1
+guard_rc=$?
+set -e
+rm -rf "$OUT_TMP"
+assert_eq "custom write phase does not block on concurrency (exit 0)" "0" "$guard_rc"
+
+# Cell 18: built-in read phases keep working unchanged. /review is the
+# canonical case: it must keep blocking touch even after the lookup
+# moved through the phase registry.
+echo "[18] built-in review phase still blocks writes"
+echo '{"current_phase":"review"}' > "$GUARD_STORE/session.json"
+set +e
+NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
+guard_rc=$?
+set -e
+assert_eq "built-in review phase blocks write (exit 1)" "1" "$guard_rc"
 
 cd "$PROJ"
 

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -20,7 +20,8 @@
 #  16. Guard blocks writes during a read-only custom phase.
 #  17. Custom write phase does not trigger the concurrency block.
 #  18. Built-in review phase still blocks (regression check).
-#  19. Guard still works when the store path contains a space.
+#  19. Guard finds repo-bundled non-core skills (feature, doctor).
+#  20. Guard still works when the store path contains a space.
 #
 # This harness is the contract Codex's spec calls for in PR 6: a clean
 # sandbox user can complete the entire workflow without reading source.
@@ -319,12 +320,35 @@ guard_rc=$?
 set -e
 assert_eq "built-in review phase blocks write (exit 1)" "1" "$guard_rc"
 
-# Cell 19: a HOME (or store) path that contains a space must not break
+# Cell 19: repo-bundled non-core skills (feature, doctor, help, ...)
+# also have concurrency: read frontmatter. The guard's previous raw
+# lookup at $NANOSTACK_ROOT/<phase>/SKILL.md saw them directly; the
+# registry-aware lookup must keep finding them. Codex caught the
+# regression on PR 1's fourth pass — without the repo-root fallback,
+# `current_phase=feature` left SKILL_CONC empty and the guard allowed
+# writes.
+echo "[19] guard finds repo-bundled non-core skills"
+BUNDLED_PROJ="$TMP_ROOT/bundled-project"
+mkdir -p "$BUNDLED_PROJ/.nanostack"
+cd "$BUNDLED_PROJ"
+git init -q
+for bundled in feature doctor; do
+  echo "{\"current_phase\":\"$bundled\"}" > "$BUNDLED_PROJ/.nanostack/session.json"
+  set +e
+  NANOSTACK_STORE="$BUNDLED_PROJ/.nanostack" \
+    "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
+  guard_rc=$?
+  set -e
+  assert_eq "bundled $bundled phase blocks write" "1" "$guard_rc"
+done
+cd "$PROJ"
+
+# Cell 20: a HOME (or store) path that contains a space must not break
 # the guard. The previous space-separated root iteration in
 # nano_phase_skill_path silently dropped path halves and made the
 # concurrency block a no-op for these users. Codex caught the
 # regression on PR 1 of the architecture round; this cell locks it.
-echo "[19] guard works when store path contains a space"
+echo "[20] guard works when store path contains a space"
 SPACE_TMP=$(mktemp -d /tmp/nanostack-space.XXXXXX)
 SPACE_HOME="$SPACE_TMP/home with space"
 SPACE_PROJ="$SPACE_TMP/nogit"

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -20,6 +20,7 @@
 #  16. Guard blocks writes during a read-only custom phase.
 #  17. Custom write phase does not trigger the concurrency block.
 #  18. Built-in review phase still blocks (regression check).
+#  19. Guard still works when the store path contains a space.
 #
 # This harness is the contract Codex's spec calls for in PR 6: a clean
 # sandbox user can complete the entire workflow without reading source.
@@ -312,6 +313,29 @@ NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
 guard_rc=$?
 set -e
 assert_eq "built-in review phase blocks write (exit 1)" "1" "$guard_rc"
+
+# Cell 19: a HOME (or store) path that contains a space must not break
+# the guard. The previous space-separated root iteration in
+# nano_phase_skill_path silently dropped path halves and made the
+# concurrency block a no-op for these users. Codex caught the
+# regression on PR 1 of the architecture round; this cell locks it.
+echo "[19] guard works when store path contains a space"
+SPACE_TMP=$(mktemp -d /tmp/nanostack-space.XXXXXX)
+SPACE_HOME="$SPACE_TMP/home with space"
+SPACE_PROJ="$SPACE_TMP/nogit"
+mkdir -p "$SPACE_HOME" "$SPACE_PROJ"
+cd "$SPACE_PROJ"
+HOME="$SPACE_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
+SPACE_STORE="$SPACE_HOME/.nanostack"
+echo '{"current_phase":"license-audit"}' > "$SPACE_STORE/session.json"
+set +e
+NANOSTACK_STORE="$SPACE_STORE" HOME="$SPACE_HOME" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
+guard_rc=$?
+set -e
+cd "$PROJ"
+rm -rf "$SPACE_TMP"
+assert_eq "store path with space still blocks (exit 1)" "1" "$guard_rc"
 
 cd "$PROJ"
 

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -21,7 +21,8 @@
 #  17. Custom write phase does not trigger the concurrency block.
 #  18. Built-in review phase still blocks (regression check).
 #  19. Guard finds repo-bundled non-core skills (feature, doctor).
-#  20. Guard still works when the store path contains a space.
+#  20. Registered custom skill wins over bundled non-core fallback.
+#  21. Guard still works when the store path contains a space.
 #
 # This harness is the contract Codex's spec calls for in PR 6: a clean
 # sandbox user can complete the entire workflow without reading source.
@@ -343,12 +344,45 @@ for bundled in feature doctor; do
 done
 cd "$PROJ"
 
-# Cell 20: a HOME (or store) path that contains a space must not break
+# Cell 20: a registered custom phase that reuses a repo-bundled
+# directory name (feature, doctor, ...) must win over the bundled
+# fallback. create-skill.sh does not reserve bundled names, so a
+# user can legitimately register `feature` themselves with their own
+# concurrency. Codex caught the precedence regression on the PR 1
+# fifth pass; this cell locks the correct order.
+echo "[20] registered custom skill wins over bundled non-core fallback"
+PREC_PROJ="$TMP_ROOT/precedence-project"
+mkdir -p "$PREC_PROJ/.nanostack/skills/feature"
+cd "$PREC_PROJ"
+git init -q
+cat > "$PREC_PROJ/.nanostack/config.json" <<'EOF'
+{"custom_phases":["feature"]}
+EOF
+cat > "$PREC_PROJ/.nanostack/skills/feature/SKILL.md" <<'EOF'
+---
+name: feature
+description: user-registered feature override
+concurrency: write
+---
+body
+EOF
+echo '{"current_phase":"feature"}' > "$PREC_PROJ/.nanostack/session.json"
+PREC_OUT=$(mktemp -d /tmp/precedence-out.XXXXXX)
+set +e
+NANOSTACK_STORE="$PREC_PROJ/.nanostack" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch $PREC_OUT/x" >/dev/null 2>&1
+guard_rc=$?
+set -e
+rm -rf "$PREC_OUT"
+cd "$PROJ"
+assert_eq "custom feature (write) shadows bundled feature (read)" "0" "$guard_rc"
+
+# Cell 21: a HOME (or store) path that contains a space must not break
 # the guard. The previous space-separated root iteration in
 # nano_phase_skill_path silently dropped path halves and made the
 # concurrency block a no-op for these users. Codex caught the
 # regression on PR 1 of the architecture round; this cell locks it.
-echo "[20] guard works when store path contains a space"
+echo "[21] guard works when store path contains a space"
 SPACE_TMP=$(mktemp -d /tmp/nanostack-space.XXXXXX)
 SPACE_HOME="$SPACE_TMP/home with space"
 SPACE_PROJ="$SPACE_TMP/nogit"

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -22,7 +22,8 @@
 #  18. Built-in review phase still blocks (regression check).
 #  19. Guard finds repo-bundled non-core skills (feature, doctor).
 #  20. Registered custom skill wins over bundled non-core fallback.
-#  21. Guard still works when the store path contains a space.
+#  21. Unrelated user-installed skill does not shadow a bundled phase.
+#  22. Guard still works when the store path contains a space.
 #
 # This harness is the contract Codex's spec calls for in PR 6: a clean
 # sandbox user can complete the entire workflow without reading source.
@@ -377,12 +378,41 @@ rm -rf "$PREC_OUT"
 cd "$PROJ"
 assert_eq "custom feature (write) shadows bundled feature (read)" "0" "$guard_rc"
 
-# Cell 21: a HOME (or store) path that contains a space must not break
+# Cell 21: an unrelated user-installed skill under ~/.claude/skills or
+# ~/.agents/skills that happens to share a name with a bundled non-core
+# phase must NOT silently shadow the bundled SKILL.md. Only an
+# explicitly registered custom phase (in .nanostack/config.json's
+# custom_phases) is allowed to override. Codex caught this on the
+# PR 1 sixth pass.
+echo "[21] unrelated user-installed skill does not shadow bundled phase"
+SHADOW_HOME="$TMP_ROOT/shadow-home"
+SHADOW_PROJ="$TMP_ROOT/shadow-project"
+mkdir -p "$SHADOW_HOME/.claude/skills/feature" "$SHADOW_PROJ/.nanostack"
+cat > "$SHADOW_HOME/.claude/skills/feature/SKILL.md" <<'EOF'
+---
+name: feature
+description: unrelated user-installed skill (no registration)
+concurrency: write
+---
+body
+EOF
+cd "$SHADOW_PROJ"
+git init -q
+echo '{"current_phase":"feature"}' > "$SHADOW_PROJ/.nanostack/session.json"
+set +e
+HOME="$SHADOW_HOME" NANOSTACK_STORE="$SHADOW_PROJ/.nanostack" \
+  "$REPO/guard/bin/check-dangerous.sh" "touch x" >/dev/null 2>&1
+guard_rc=$?
+set -e
+cd "$PROJ"
+assert_eq "bundled feature still wins when no registered custom" "1" "$guard_rc"
+
+# Cell 22: a HOME (or store) path that contains a space must not break
 # the guard. The previous space-separated root iteration in
 # nano_phase_skill_path silently dropped path halves and made the
 # concurrency block a no-op for these users. Codex caught the
 # regression on PR 1 of the architecture round; this cell locks it.
-echo "[21] guard works when store path contains a space"
+echo "[22] guard works when store path contains a space"
 SPACE_TMP=$(mktemp -d /tmp/nanostack-space.XXXXXX)
 SPACE_HOME="$SPACE_TMP/home with space"
 SPACE_PROJ="$SPACE_TMP/nogit"

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -147,22 +147,37 @@ fi
 # If a session is active and the current phase is read-only,
 # block write operations to prevent race conditions in parallel execution.
 # Store path already resolved at the top of the script.
+#
+# Skill resolution goes through bin/lib/phases.sh so custom phases are
+# protected the same way built-in ones are. The previous lookup did a
+# raw $NANOSTACK_ROOT/$CURRENT_PHASE/SKILL.md, which silently no-oped
+# for any phase whose SKILL.md lived outside the repo (every custom
+# skill under $NANOSTACK_STORE/skills, ~/.claude/skills, etc.).
 if [ -n "${NANOSTACK_STORE:-}" ]; then
   SESSION_CHECK="$NANOSTACK_STORE/session.json"
 
   if [ -f "$SESSION_CHECK" ]; then
     CURRENT_PHASE=$(jq -r '.current_phase // ""' "$SESSION_CHECK" 2>/dev/null)
 
-    if [ -n "$CURRENT_PHASE" ]; then
-      # Get concurrency from skill frontmatter
-      SKILL_CONC=""
-      case "$CURRENT_PHASE" in
-        plan) SKILL_MD="$NANOSTACK_ROOT/plan/SKILL.md" ;;
-        build) SKILL_MD="" ;;
-        *) SKILL_MD="$NANOSTACK_ROOT/$CURRENT_PHASE/SKILL.md" ;;
-      esac
+    if [ -n "$CURRENT_PHASE" ] && [ "$CURRENT_PHASE" != "build" ]; then
+      # Resolve the skill directory through the phase registry. Returns
+      # silently for unknown phases so the guard never blocks because of
+      # a stale session pointing at a removed skill.
+      SKILL_MD=""
+      PHASES_LIB="$NANOSTACK_ROOT/bin/lib/phases.sh"
+      if [ -f "$PHASES_LIB" ]; then
+        # shellcheck disable=SC1090
+        source "$PHASES_LIB" 2>/dev/null || true
+        if command -v nano_phase_skill_path >/dev/null 2>&1; then
+          SKILL_DIR=$(nano_phase_skill_path "$CURRENT_PHASE" 2>/dev/null || true)
+          if [ -n "$SKILL_DIR" ] && [ -f "$SKILL_DIR/SKILL.md" ]; then
+            SKILL_MD="$SKILL_DIR/SKILL.md"
+          fi
+        fi
+      fi
 
-      if [ -n "${SKILL_MD:-}" ] && [ -f "$SKILL_MD" ]; then
+      SKILL_CONC=""
+      if [ -n "$SKILL_MD" ]; then
         SKILL_CONC=$(sed -n '/^---$/,/^---$/p' "$SKILL_MD" | grep '^concurrency:' | head -1 | sed 's/^concurrency: *//')
       fi
 
@@ -176,6 +191,7 @@ if [ -n "${NANOSTACK_STORE:-}" ]; then
             echo ""
             echo "Action: report this as a finding instead of auto-fixing. The current phase is read-only to prevent race conditions when multiple agents run in parallel."
             echo "Bypass: complete the current phase first (\`bin/session.sh phase-complete $CURRENT_PHASE\`), or end the session if you're not in a sprint."
+            audit_trail_append blocked "PHASE-RO"
             exit 1
             ;;
         esac

--- a/guard/bin/check-dangerous.sh
+++ b/guard/bin/check-dangerous.sh
@@ -106,47 +106,13 @@ if [ -n "$TIER1" ]; then
   fi
 fi
 
-# ─── Tier 2: In-project operations ──────────────────────────
-# If the command only touches files inside the current git repo,
-# it's reviewable via version control. Let it through.
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-
-if [ -n "$PROJECT_ROOT" ]; then
-  # Commands that write files but stay in-project are Tier 2
-  # We only check simple file-targeting commands, not pipes or chains
-  case "$CMD" in
-    # Skip tier 2 for chained/piped commands (too hard to analyze)
-    *\|*|*\;*|*\&\&*) ;;
-    *)
-      # If command references files, check they're all in-project
-      # Extract paths that look like file references
-      ALL_IN_PROJECT=true
-      for token in $CMD; do
-        # Skip flags and the command itself
-        case "$token" in
-          -*|"$CMD_BASE") continue ;;
-        esac
-        # If it looks like a path and exists or starts with project root
-        if [ -e "$token" ] || [[ "$token" == /* ]]; then
-          REAL_PATH=$(realpath "$token" 2>/dev/null) || REAL_PATH="$token"
-          case "$REAL_PATH" in
-            "$PROJECT_ROOT"*) ;; # in project
-            *) ALL_IN_PROJECT=false ;;
-          esac
-        fi
-      done
-      # Don't auto-pass if command has no file args (could be anything)
-      if [ "$ALL_IN_PROJECT" = true ] && echo "$CMD" | grep -qE '/|\./' ; then
-        exit 0
-      fi
-      ;;
-  esac
-fi
-
-# ─── Tier 2.5: Phase-aware concurrency enforcement ─────────
-# If a session is active and the current phase is read-only,
-# block write operations to prevent race conditions in parallel execution.
-# Store path already resolved at the top of the script.
+# ─── Tier 2.4: Phase-aware concurrency enforcement ─────────
+# Runs BEFORE the in-project fast-path. A read-only phase must block
+# write commands even when they only touch in-project paths, otherwise
+# `touch ./foo` or `mv ./a ./b` slip through the git-reviewable
+# allowlist and silently mutate files during a phase that promised no
+# writes. Codex caught this on the PR 1 review by testing `touch ./x`
+# from a git worktree while concurrency was set to read.
 #
 # Skill resolution goes through bin/lib/phases.sh so custom phases are
 # protected the same way built-in ones are. The previous lookup did a
@@ -198,6 +164,45 @@ if [ -n "${NANOSTACK_STORE:-}" ]; then
       fi
     fi
   fi
+fi
+
+# ─── Tier 2.5: In-project operations ────────────────────────
+# If the command only touches files inside the current git repo,
+# it's reviewable via version control. Let it through. Phase
+# concurrency above already prevented in-project writes during a
+# read phase, so this fast-path only fires when writes are allowed.
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+if [ -n "$PROJECT_ROOT" ]; then
+  # Commands that write files but stay in-project are Tier 2.5
+  # We only check simple file-targeting commands, not pipes or chains
+  case "$CMD" in
+    # Skip tier 2.5 for chained/piped commands (too hard to analyze)
+    *\|*|*\;*|*\&\&*) ;;
+    *)
+      # If command references files, check they're all in-project
+      # Extract paths that look like file references
+      ALL_IN_PROJECT=true
+      for token in $CMD; do
+        # Skip flags and the command itself
+        case "$token" in
+          -*|"$CMD_BASE") continue ;;
+        esac
+        # If it looks like a path and exists or starts with project root
+        if [ -e "$token" ] || [[ "$token" == /* ]]; then
+          REAL_PATH=$(realpath "$token" 2>/dev/null) || REAL_PATH="$token"
+          case "$REAL_PATH" in
+            "$PROJECT_ROOT"*) ;; # in project
+            *) ALL_IN_PROJECT=false ;;
+          esac
+        fi
+      done
+      # Don't auto-pass if command has no file args (could be anything)
+      if [ "$ALL_IN_PROJECT" = true ] && echo "$CMD" | grep -qE '/|\./' ; then
+        exit 0
+      fi
+      ;;
+  esac
 fi
 
 # ─── Tier 2.75: Sprint phase gate ──────────────────────────


### PR DESCRIPTION
## Summary

Guard concurrency now resolves the active phase's `SKILL.md` through `nano_phase_skill_path` from `bin/lib/phases.sh`. Before this change, the lookup was a raw `$NANOSTACK_ROOT/$CURRENT_PHASE/SKILL.md`, which only matched built-in phases. Every custom skill's `SKILL.md` lives under `<store>/skills/<name>/` and was invisible to the guard. The conductor was already custom-aware via the same registry; this PR closes the split so guard enforcement matches conductor scheduling.

## What changes

Before:

- Built-in `review` phase active + `touch x`: blocked.
- Custom `license-audit` (concurrency: read) + `touch x`: allowed.
- Same phase + `touch ./x` (in-project path): allowed.
- Custom phase under a `$HOME` with spaces: allowed.

After, all four cases block.

Additional behavior:

- A registered custom phase with the same directory name as a repo-bundled skill (for example `feature`) wins over the bundled fallback.
- An unrelated `~/.claude/skills/feature/SKILL.md` does not shadow the bundled `feature` phase when `feature` is not registered as a custom phase.

## What does not change

- Built-in phases (`review`, `security`, `qa`) keep the same block behavior.
- `build` (no SKILL.md) keeps skipping the concurrency tier.
- The 17 cases in the existing `guard-regression` lint matrix still pass.
- Audit log entries now also record PHASE blocks under rule id `PHASE-RO`.

## Implementation

`guard/bin/check-dangerous.sh`:

Tier 2.4 (phase-aware concurrency) was relocated to run immediately after the allowlist and before the in-project fast-path. The previous order let `touch ./foo` and `mv ./a ./b` bypass concurrency by hitting the git-reviewable allowlist first. The block sources `bin/lib/phases.sh` once per invocation (idempotent via `_NANO_PHASES_LOADED`) and calls `nano_phase_skill_path` to resolve the active phase's `SKILL.md`.

`bin/lib/phases.sh` resolution order in `nano_phase_skill_path`:

1. Core phase (`think`, `plan`, `review`, `qa`, `security`, `ship`): exact `$repo_root/<phase>` match.
2. Registered custom phase (in `.nanostack/config.json:custom_phases`): walks configured `skill_roots`, then `<store>/skills`, `<config-dir>/skills`, cwd `.nanostack/skills`, `~/.claude/skills`, `~/.agents/skills`.
3. Repo-bundled non-core skill (`feature`, `doctor`, `help`, `compound`, `start`): `$repo_root/<phase>/SKILL.md`. Consulted only when the phase is not in `nano_custom_phases`.
4. Not found.

Membership in `nano_custom_phases` is the trust boundary: only an explicitly registered phase may search user skill roots.

The function also switched from space-separated `for root in $list` iteration to newline-delimited `while IFS= read -r` so paths with spaces (a `$HOME` like `Hello World` or a store under `My Drive`) resolve correctly.

## Codex review

Each finding raised across seven Codex review passes is in its own commit, so the trail is auditable:

1. Initial registry-aware guard tier.
2. `nano_phase_skill_path` split space-separated roots on whitespace. Fix: newline-delimited iteration with inline dedup.
3. `_phases_append_root` bare `return` inherited the previous test's exit status. Fix: explicit `return 0`.
4. In-project fast-path ran before phase concurrency, allowing `touch ./x` to slip through. Fix: tier reorder (2.4 phase before 2.5 in-project).
5. Repo-bundled non-core skills (`feature`, `doctor`) no longer resolved. Fix: repo-root fallback.
6. Bundled fallback shadowed registered customs with the same directory name. Fix: custom-first ordering.
7. Unregistered phase could be shadowed by unrelated user skills. Fix: `nano_custom_phases` membership as trust boundary.

Final Codex pass: no actionable regression introduced.

## Tests

E2E `ci/e2e-custom-stack-flows.sh`: 22 cells, 40 checks. New cells:

- 16: custom read phase blocks write across three command shapes (bare filename, `./` prefix, absolute in-project path).
- 17: custom write phase does not block on the concurrency tier.
- 18: built-in `review` phase still blocks.
- 19: bundled `feature` and `doctor` resolve via the repo-root fallback.
- 20: registered custom `feature` (write) shadows bundled `feature` (read).
- 21: unrelated `~/.claude/skills/feature` does not shadow the bundled phase.
- 22: guard works when the store path contains a space.

Lint `.github/workflows/lint.yml`: new `guard-uses-phase-registry` job. Forbids any raw `$NANOSTACK_ROOT/$<...>PHASE<...>/SKILL.md` lookup in `check-dangerous.sh` (code only; comment lines are stripped first) and requires `nano_phase_skill_path` to be referenced.

The existing 17-case `guard-regression` matrix still passes unchanged.

## Files

- `guard/bin/check-dangerous.sh`: tier reorder + registry-aware lookup.
- `bin/lib/phases.sh`: newline-delimited iteration, bundled fallback, custom trust boundary.
- `ci/e2e-custom-stack-flows.sh`: cells 16 to 22.
- `.github/workflows/lint.yml`: `guard-uses-phase-registry` job.
- `.github/workflows/e2e.yml`: job name update (15-cell to 22-cell).

## Spec

PR 1 of the 2026-05-10 Nanostack Architecture Audit vNext. Closes the P1 finding "Guard Concurrency Is Not Custom-Phase Aware".

Next: PR 2, Artifact Trust v2 (strict integrity verification + `upstream_status` in `bin/resolve.sh`). Closes the P1 finding "Artifact Integrity Verification Is Not Strict Enough For Framework Trust".

## Test plan

- [ ] `bash ci/e2e-custom-stack-flows.sh` reports 40 of 40 checks passed.
- [ ] `.github/workflows/lint.yml` `guard-uses-phase-registry` and existing `guard-regression` jobs pass on CI.
- [ ] `.github/workflows/e2e.yml` `E2E Custom Stack Framework v1 (22-cell journey)` passes on CI.
- [ ] Manual: set `current_phase` to a custom read skill outside the repo, confirm `touch ./x` blocks.
- [ ] Manual: set `current_phase` to `review`, confirm `touch ./x` still blocks (no regression).