### PR TITLE
artifact-trust: shared strict integrity primitive (PR 2 of architecture vNext)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,7 @@ jobs:
           ci/e2e-onboarding-flows.sh
 
   e2e-artifact-trust:
-    name: E2E Artifact Trust v2 (8 cells)
+    name: E2E Artifact Trust v2 (9 cells)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Artifact Trust v2 PR 2 of the 2026-05-10 architecture audit.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,3 +169,22 @@ jobs:
         run: |
           chmod +x ci/e2e-onboarding-flows.sh
           ci/e2e-onboarding-flows.sh
+
+  e2e-artifact-trust:
+    name: E2E Artifact Trust v2 (8 cells)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Artifact Trust v2 PR 2 of the 2026-05-10 architecture audit.
+    # Locks the four-state trust model across the shared helper
+    # (bin/lib/artifact-trust.sh), find-artifact.sh (--verify vs
+    # --require-integrity), and resolve.sh (upstream_status field).
+    # Each cell builds artifacts by hand to exercise verified,
+    # integrity_missing, integrity_mismatch, and missing in isolation.
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq is present
+        run: jq --version
+      - name: Run artifact-trust E2E
+        run: |
+          chmod +x ci/e2e-artifact-trust.sh
+          ci/e2e-artifact-trust.sh

--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -1,16 +1,32 @@
 #!/usr/bin/env bash
 # find-artifact.sh — Find the most recent artifact for a phase and project
-# Usage: find-artifact.sh <phase> [max-age-days]
-# Example: find-artifact.sh plan 2
+# Usage: find-artifact.sh <phase> [max-age-days] [--verify] [--require-integrity]
+# Example: find-artifact.sh plan 2 --require-integrity
 # Returns: path to most recent artifact, or empty + exit 1 if none found
+#
+# Trust flags:
+#   --verify              fail (exit 1) when .integrity is present but the
+#                         recomputed hash does not match. Missing .integrity
+#                         is silently allowed for backward compatibility with
+#                         legacy artifacts saved before integrity was added.
+#   --require-integrity   fail (exit 1) when .integrity is absent OR mismatched.
+#                         Implies --verify. Use this for release gates and any
+#                         consumer that cannot afford to trust unverifiable
+#                         evidence. Added in the 2026-05-10 architecture audit
+#                         PR 2 so callers stop reimplementing the check.
+#
+# On failure, the reason goes to stderr in a stable format so callers can
+# categorize: "INTEGRITY FAILED: <path>" (mismatch) or
+# "INTEGRITY MISSING: <path>" (no .integrity field).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
 [ -f "$SCRIPT_DIR/lib/portable.sh" ] && source "$SCRIPT_DIR/lib/portable.sh"
+[ -f "$SCRIPT_DIR/lib/artifact-trust.sh" ] && source "$SCRIPT_DIR/lib/artifact-trust.sh"
 
-PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days]}"
+PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days] [--verify] [--require-integrity]}"
 MAX_AGE="${2:-30}"
 STORE="$NANOSTACK_STORE/$PHASE"
 PROJECT="$(pwd)"
@@ -18,7 +34,19 @@ PROJECT="$(pwd)"
 [ -d "$STORE" ] || exit 1
 
 VERIFY=false
-[ "${3:-}" = "--verify" ] && VERIFY=true
+REQUIRE_INTEGRITY=false
+# Accept both flags at any position from arg 3 onward so older call
+# sites (find-artifact.sh <phase> <age> --verify) keep working and new
+# call sites can pass --require-integrity alongside --verify.
+shift_count=2
+[ $# -lt 2 ] && shift_count=$#
+shift $shift_count 2>/dev/null || true
+for arg in "$@"; do
+  case "$arg" in
+    --verify) VERIFY=true ;;
+    --require-integrity) REQUIRE_INTEGRITY=true; VERIFY=true ;;
+  esac
+done
 
 RESULT=$(find "$STORE" -name "*.json" -mtime -"$MAX_AGE" 2>/dev/null | while read -r f; do
   # Pre-filter with grep before full jq parse (80% fewer jq calls on multi-project setups)
@@ -63,20 +91,53 @@ if [ -f "$SESSION_FILE" ]; then
   fi
 fi
 
-# Verify artifact integrity if requested
+# Verify artifact integrity if requested. The trust helper at
+# bin/lib/artifact-trust.sh is the single source of truth for the
+# four statuses (verified, integrity_missing, integrity_mismatch,
+# not_found); --verify and --require-integrity differ only in how
+# they react to integrity_missing.
 if [ "$VERIFY" = true ]; then
-  STORED_HASH=$(jq -r '.integrity // ""' "$RESULT" 2>/dev/null)
-  if [ -n "$STORED_HASH" ]; then
-    if declare -F nano_sha256 >/dev/null 2>&1; then
-      COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | nano_sha256 | cut -d' ' -f1)
+  if declare -F nano_artifact_trust >/dev/null 2>&1; then
+    TRUST=$(nano_artifact_trust "$RESULT" 2>/dev/null || echo "not_found")
+  else
+    # Fallback (artifact-trust.sh not loaded for some reason): inline
+    # the same logic so --verify keeps working in degraded setups.
+    STORED_HASH=$(jq -r '.integrity // ""' "$RESULT" 2>/dev/null)
+    if [ -z "$STORED_HASH" ]; then
+      TRUST="integrity_missing"
     else
-      COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | shasum -a 256 | cut -d' ' -f1)
-    fi
-    if [ "$STORED_HASH" != "$COMPUTED_HASH" ]; then
-      echo "INTEGRITY FAILED: $RESULT" >&2
-      exit 1
+      if declare -F nano_sha256 >/dev/null 2>&1; then
+        COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | nano_sha256 | cut -d' ' -f1)
+      else
+        COMPUTED_HASH=$(jq -Sc 'del(.integrity)' "$RESULT" | shasum -a 256 | cut -d' ' -f1)
+      fi
+      if [ "$STORED_HASH" = "$COMPUTED_HASH" ]; then
+        TRUST="verified"
+      else
+        TRUST="integrity_mismatch"
+      fi
     fi
   fi
+
+  case "$TRUST" in
+    verified)
+      ;;
+    integrity_missing)
+      if [ "$REQUIRE_INTEGRITY" = true ]; then
+        echo "INTEGRITY MISSING: $RESULT" >&2
+        exit 1
+      fi
+      ;;
+    integrity_mismatch)
+      echo "INTEGRITY FAILED: $RESULT" >&2
+      exit 1
+      ;;
+    *)
+      # not_found from the helper means the file vanished between
+      # discovery and verification. Treat as a normal "no artifact".
+      exit 1
+      ;;
+  esac
 fi
 
 echo "$RESULT"

--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -27,26 +27,32 @@ source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/artifact-trust.sh" ] && source "$SCRIPT_DIR/lib/artifact-trust.sh"
 
 PHASE="${1:?Usage: find-artifact.sh <phase> [max-age-days] [--verify] [--require-integrity]}"
-MAX_AGE="${2:-30}"
-STORE="$NANOSTACK_STORE/$PHASE"
-PROJECT="$(pwd)"
+shift
 
-[ -d "$STORE" ] || exit 1
-
+MAX_AGE=30
 VERIFY=false
 REQUIRE_INTEGRITY=false
-# Accept both flags at any position from arg 3 onward so older call
-# sites (find-artifact.sh <phase> <age> --verify) keep working and new
-# call sites can pass --require-integrity alongside --verify.
-shift_count=2
-[ $# -lt 2 ] && shift_count=$#
-shift $shift_count 2>/dev/null || true
+# The max-age argument is optional; detect it by shape so callers can
+# skip it and pass a flag in $2 (e.g. find-artifact.sh plan
+# --require-integrity). A leading dash means flag, not age. Codex
+# caught this on the PR 2 review: without the shape check, the flag
+# was assigned to MAX_AGE and find -mtime -"--require-integrity"
+# silently returned nothing.
+if [ $# -gt 0 ] && [ -n "$1" ] && [ "${1#-}" = "$1" ]; then
+  MAX_AGE="$1"
+  shift
+fi
 for arg in "$@"; do
   case "$arg" in
     --verify) VERIFY=true ;;
     --require-integrity) REQUIRE_INTEGRITY=true; VERIFY=true ;;
   esac
 done
+
+STORE="$NANOSTACK_STORE/$PHASE"
+PROJECT="$(pwd)"
+
+[ -d "$STORE" ] || exit 1
 
 RESULT=$(find "$STORE" -name "*.json" -mtime -"$MAX_AGE" 2>/dev/null | while read -r f; do
   # Pre-filter with grep before full jq parse (80% fewer jq calls on multi-project setups)

--- a/bin/lib/artifact-trust.sh
+++ b/bin/lib/artifact-trust.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# artifact-trust.sh — Shared trust primitive for nanostack artifacts.
+#
+# Single source of truth for "can I trust this artifact?" Used by
+# find-artifact.sh (--require-integrity), resolve.sh (upstream_status),
+# and downstream skills that build release gates or compose evidence.
+#
+# Before this library existed, each caller wrote its own jq + sha256
+# dance. release-readiness in particular grew a local check for
+# missing .integrity because find-artifact.sh --verify only failed on
+# mismatch, not absence. The 2026-05-10 architecture audit (PR 2)
+# moves that logic here so every layer agrees on the trust model.
+#
+# Public function:
+#   nano_artifact_trust <path>
+#     Echoes one of: verified, integrity_missing, integrity_mismatch,
+#     not_found. Always exits 0 on a regular file (status is on
+#     stdout); exits 1 only when the path is empty or does not exist.
+#
+# Statuses:
+#   verified           - file is a regular JSON file, .integrity is
+#                        present, and the recomputed SHA-256 over the
+#                        canonical (sorted, no-integrity) JSON matches.
+#   integrity_missing  - file is a regular JSON file, but the
+#                        .integrity field is absent or empty. An
+#                        attacker who can write the file can delete
+#                        the field as easily as mutate the hash, so
+#                        release gates treat this as untrusted.
+#   integrity_mismatch - file is a regular JSON file, .integrity is
+#                        present, and the recomputed hash does not
+#                        match. The artifact was modified after
+#                        save-artifact.sh wrote it.
+#   not_found          - path is empty, does not exist, or is not a
+#                        regular file. Exit code 1.
+
+if [ "${_NANO_ARTIFACT_TRUST_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_ARTIFACT_TRUST_LOADED=1
+
+# Recompute the canonical SHA-256 over a JSON artifact. Strips
+# .integrity (the field is added after the hash is computed), sorts
+# keys for stability, and emits the bare hex digest. Mirrors
+# save-artifact.sh's hashing path so a freshly saved artifact
+# verifies on first read.
+_nano_artifact_recompute_hash() {
+  local path="$1"
+  local hash_cmd
+  if declare -F nano_sha256 >/dev/null 2>&1; then
+    hash_cmd="nano_sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    hash_cmd="shasum -a 256"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    hash_cmd="sha256sum"
+  else
+    return 1
+  fi
+  jq -Sc 'del(.integrity)' "$path" 2>/dev/null \
+    | eval "$hash_cmd" 2>/dev/null \
+    | cut -d' ' -f1
+}
+
+nano_artifact_trust() {
+  local path="${1:-}"
+  if [ -z "$path" ] || [ ! -f "$path" ]; then
+    printf 'not_found\n'
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    # No jq means we cannot inspect the integrity field at all. Treat
+    # as missing so callers under strict mode fail closed.
+    printf 'integrity_missing\n'
+    return 0
+  fi
+  local stored
+  stored=$(jq -r '.integrity // ""' "$path" 2>/dev/null)
+  if [ -z "$stored" ]; then
+    printf 'integrity_missing\n'
+    return 0
+  fi
+  local computed
+  computed=$(_nano_artifact_recompute_hash "$path")
+  if [ -z "$computed" ] || [ "$computed" != "$stored" ]; then
+    printf 'integrity_mismatch\n'
+    return 0
+  fi
+  printf 'verified\n'
+  return 0
+}

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -216,7 +216,20 @@ for entry in $UPSTREAM; do
   STATUS="missing"
   if [ -n "$RAW" ]; then
     if declare -F nano_artifact_trust >/dev/null 2>&1; then
-      STATUS=$(nano_artifact_trust "$RAW" 2>/dev/null || echo "missing")
+      # Keep `||` OUTSIDE the command substitution so a deletion race
+      # (file vanishes between find-artifact.sh and nano_artifact_trust)
+      # cleanly maps to "missing" instead of leaving "not_found" plus a
+      # trailing "missing" inside STATUS. Codex caught this on the PR 2
+      # review: the previous inline `|| echo "missing"` produced a
+      # literal newline that broke jq --argjson upstream_status.
+      STATUS=$(nano_artifact_trust "$RAW" 2>/dev/null) || STATUS="missing"
+      # Defense in depth: normalize any unexpected helper output (empty
+      # string, not_found leaking through, future statuses) to one of
+      # the four contract values so the JSON shape stays stable.
+      case "$STATUS" in
+        verified|integrity_missing|integrity_mismatch) ;;
+        *) STATUS="missing" ;;
+      esac
     else
       STATUS="verified"  # helper unavailable; assume verified to keep legacy behavior
     fi

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -20,6 +20,7 @@ source "$SCRIPT_DIR/lib/store-path.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 [ -f "$SCRIPT_DIR/lib/cache.sh" ] && source "$SCRIPT_DIR/lib/cache.sh"
 . "$SCRIPT_DIR/lib/phases.sh"
+[ -f "$SCRIPT_DIR/lib/artifact-trust.sh" ] && . "$SCRIPT_DIR/lib/artifact-trust.sh"
 
 # Portable timeout wrapper: gtimeout (coreutils on macOS) → timeout (Linux) → run as-is.
 # Used to bound expensive solution lookups so resolve.sh never hangs the sprint.
@@ -180,9 +181,20 @@ case "$PHASE" in
 esac
 
 # ─── 1. Resolve upstream artifacts ─────────────────────────
+#
+# upstream_artifacts keeps its historical shape: only verified paths
+# appear (the --verify call drops integrity-mismatched files). New in
+# the 2026-05-10 architecture audit (PR 2): upstream_status exposes
+# the trust state for every declared upstream so downstream consumers
+# can distinguish "no artifact" from "tampered" from "missing
+# integrity field" without reimplementing the check. release-readiness
+# and other release gates can switch to --require-integrity in their
+# own find-artifact.sh calls when they need strict semantics.
 
 ARTIFACTS_JSON="{"
+STATUS_JSON="{"
 FIRST=true
+SFIRST=true
 for entry in $UPSTREAM; do
   phase="${entry%%:*}"
   age="${entry#*:}"
@@ -195,28 +207,60 @@ for entry in $UPSTREAM; do
       age="$o_age"
     fi
   done
-  # --verify rejects artifacts whose stored content hash does not match
-  # on read, so a tampered file in .nanostack/ cannot become the source
-  # of truth for downstream phases (gates, review context, conflict
-  # precedence). find-artifact.sh returns empty on a verify failure;
-  # that is fine and equivalent to "no artifact for this phase".
-  RESULT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$age" --verify 2>/dev/null) || RESULT=""
-  if [ -n "$RESULT" ]; then
-    $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
-    ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":\"$RESULT\""
-    FIRST=false
-  elif [ "$PHASE_KIND" = "custom" ]; then
-    # Custom phases keep declared-but-missing deps in the output as
-    # `null` so consumers can tell "we asked for this and found
-    # nothing" apart from "this was never a dep". Core phases keep the
-    # historical "omit if missing" behavior to avoid changing the JSON
-    # shape for downstream skills.
-    $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
-    ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":null"
-    FIRST=false
+
+  # Look up the latest artifact for this phase WITHOUT --verify so we
+  # can classify it ourselves via nano_artifact_trust. The verified
+  # variant below decides what goes into upstream_artifacts.
+  RAW=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$age" 2>/dev/null) || RAW=""
+
+  STATUS="missing"
+  if [ -n "$RAW" ]; then
+    if declare -F nano_artifact_trust >/dev/null 2>&1; then
+      STATUS=$(nano_artifact_trust "$RAW" 2>/dev/null || echo "missing")
+    else
+      STATUS="verified"  # helper unavailable; assume verified to keep legacy behavior
+    fi
   fi
+
+  # upstream_artifacts: only include verified artifacts so a tampered
+  # file in the store cannot drive downstream context. integrity_missing
+  # artifacts also load so legacy stores (saved before integrity was
+  # added) continue to work; release gates that need strict semantics
+  # call find-artifact.sh --require-integrity themselves and read
+  # upstream_status for the explicit signal.
+  case "$STATUS" in
+    verified|integrity_missing)
+      $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
+      ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":\"$RAW\""
+      FIRST=false
+      ;;
+    *)
+      if [ "$PHASE_KIND" = "custom" ]; then
+        # Custom phases keep declared-but-missing deps in the output
+        # as `null` so consumers can tell "we asked for this and found
+        # nothing" apart from "this was never a dep". Core phases keep
+        # the historical "omit if missing" behavior to avoid changing
+        # the JSON shape for downstream skills.
+        $FIRST || ARTIFACTS_JSON="$ARTIFACTS_JSON,"
+        ARTIFACTS_JSON="$ARTIFACTS_JSON\"$phase\":null"
+        FIRST=false
+      fi
+      ;;
+  esac
+
+  # upstream_status: always include every declared upstream so callers
+  # can read a single key to know the trust state. Possible values:
+  # verified, integrity_missing, integrity_mismatch, missing. build is
+  # the conductor's no-artifact stage; record it as not_applicable.
+  if [ "$phase" = "build" ]; then
+    STATUS="not_applicable"
+  fi
+  $SFIRST || STATUS_JSON="$STATUS_JSON,"
+  STATUS_JSON="$STATUS_JSON\"$phase\":\"$STATUS\""
+  SFIRST=false
 done
 ARTIFACTS_JSON="$ARTIFACTS_JSON}"
+STATUS_JSON="$STATUS_JSON}"
 
 # ─── 2. Resolve solutions ──────────────────────────────────
 
@@ -370,6 +414,7 @@ jq -n \
   --arg phase "$PHASE" \
   --arg phase_kind "$PHASE_KIND" \
   --argjson artifacts "$ARTIFACTS_JSON" \
+  --argjson upstream_status "$STATUS_JSON" \
   --argjson solutions "$SOLUTIONS_JSON" \
   --argjson precedents "$PRECEDENTS_JSON" \
   --argjson diarizations "$DIARIZATIONS_JSON" \
@@ -380,6 +425,7 @@ jq -n \
     phase: $phase,
     phase_kind: $phase_kind,
     upstream_artifacts: $artifacts,
+    upstream_status: $upstream_status,
     solutions: $solutions,
     conflict_precedents: $precedents,
     diarizations: $diarizations,

--- a/ci/e2e-artifact-trust.sh
+++ b/ci/e2e-artifact-trust.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# e2e-artifact-trust.sh — Artifact Trust v2 contract.
+#
+# Locks the shared trust model introduced in PR 2 of the 2026-05-10
+# architecture audit. Covers the four canonical artifact states across
+# three consumer surfaces:
+#
+#   - bin/lib/artifact-trust.sh  (the helper itself)
+#   - bin/find-artifact.sh       (--verify and --require-integrity)
+#   - bin/resolve.sh             (upstream_status field)
+#
+# The harness writes artifacts by hand so each trust state is exercised
+# in isolation, then runs the public CLI surfaces and asserts the
+# observable outputs. Save-artifact.sh always writes .integrity, so
+# integrity_missing only happens for legacy artifacts or after an
+# attacker strips the field; both paths are tested here.
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT=$(mktemp -d /tmp/nanostack-artifact-trust.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_false() {
+  local name="$1"; shift
+  if ! "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
+  fi
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}expected: %s${NC}\n" "$expected"
+    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
+  fi
+}
+
+# Write a json artifact under <store>/<phase>/<ts>.json in one of three
+# trust states. The body is fixed so the canonical hash is reproducible.
+mk_artifact() {
+  local store="$1" phase="$2" mode="$3" ts="$4" project="$5"
+  mkdir -p "$store/$phase"
+  local body
+  body=$(printf '{"phase":"%s","project":"%s","summary":"x"}' "$phase" "$project")
+  case "$mode" in
+    verified)
+      local h
+      h=$(printf '%s' "$body" | jq -Sc 'del(.integrity)' | shasum -a 256 | cut -d' ' -f1)
+      printf '%s' "$body" | jq --arg h "$h" '. + {integrity:$h}' > "$store/$phase/$ts.json"
+      ;;
+    missing)
+      printf '%s' "$body" > "$store/$phase/$ts.json"
+      ;;
+    mismatch)
+      printf '%s' "$body" | jq '. + {integrity:"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}' > "$store/$phase/$ts.json"
+      ;;
+  esac
+}
+
+echo "Artifact Trust v2 E2E"
+echo "====================="
+echo "Tmp root: $TMP_ROOT"
+echo
+
+PROJ="$TMP_ROOT/project"
+STORE="$PROJ/.nanostack"
+mkdir -p "$PROJ" "$STORE"
+cd "$PROJ"
+git init -q
+
+# Cell 1: nano_artifact_trust returns each of the four statuses.
+echo "[1] nano_artifact_trust returns the four canonical statuses"
+mk_artifact "$STORE" trust verified  2026-05-10T01-00-00 "$PROJ"
+mk_artifact "$STORE" trust missing   2026-05-10T01-01-00 "$PROJ"
+mk_artifact "$STORE" trust mismatch  2026-05-10T01-02-00 "$PROJ"
+ok_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-00-00.json'")
+miss_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-01-00.json'")
+bad_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-02-00.json'")
+none_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/does-not-exist.json' || true")
+assert_eq "verified artifact"           "verified"           "$ok_status"
+assert_eq "integrity_missing artifact"  "integrity_missing"  "$miss_status"
+assert_eq "integrity_mismatch artifact" "integrity_mismatch" "$bad_status"
+assert_eq "not_found artifact"          "not_found"          "$none_status"
+
+# Cell 2: find-artifact.sh without --verify returns the newest artifact
+# regardless of trust state. This preserves the historical default.
+echo "[2] find-artifact.sh default returns newest regardless of trust"
+NANOSTACK_STORE="$STORE" out=$( NANOSTACK_STORE="$STORE" "$REPO/bin/find-artifact.sh" trust 30 2>/dev/null || true )
+assert_eq "default returns the newest (mismatch) artifact" "2026-05-10T01-02-00.json" "$(basename "${out:-}")"
+
+# Cell 3: find-artifact.sh --verify keeps the legacy lenient contract:
+# integrity_missing passes, integrity_mismatch fails.
+echo "[3] find-artifact.sh --verify is lenient on missing integrity"
+PROJ2="$TMP_ROOT/project2"
+STORE2="$PROJ2/.nanostack"
+mkdir -p "$PROJ2" "$STORE2"
+cd "$PROJ2"
+git init -q
+mk_artifact "$STORE2" review verified 2026-05-10T02-00-00 "$PROJ2"
+set +e
+out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
+rc=$?
+set -e
+assert_eq "verified passes --verify (rc 0)" "0" "$rc"
+assert_eq "verified path returned"          "2026-05-10T02-00-00.json" "$(basename "${out:-}")"
+mk_artifact "$STORE2" review missing 2026-05-10T02-01-00 "$PROJ2"
+set +e
+out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
+rc=$?
+set -e
+assert_eq "integrity_missing passes --verify (rc 0)" "0" "$rc"
+assert_eq "newest missing-integrity path returned"   "2026-05-10T02-01-00.json" "$(basename "${out:-}")"
+mk_artifact "$STORE2" review mismatch 2026-05-10T02-02-00 "$PROJ2"
+set +e
+out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
+rc=$?
+set -e
+assert_eq "integrity_mismatch fails --verify (rc 1)" "1" "$rc"
+echo "$out" | grep -qE '^INTEGRITY FAILED:' && \
+  assert_eq "stderr labelled INTEGRITY FAILED" "yes" "yes" || \
+  assert_eq "stderr labelled INTEGRITY FAILED" "yes" "no"
+
+# Cell 4: find-artifact.sh --require-integrity is strict: integrity_missing
+# also fails, with a distinct stderr category.
+echo "[4] find-artifact.sh --require-integrity is strict on missing + mismatch"
+PROJ3="$TMP_ROOT/project3"
+STORE3="$PROJ3/.nanostack"
+mkdir -p "$PROJ3" "$STORE3"
+cd "$PROJ3"
+git init -q
+mk_artifact "$STORE3" qa verified 2026-05-10T03-00-00 "$PROJ3"
+set +e
+out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
+rc=$?
+set -e
+assert_eq "verified passes --require-integrity (rc 0)" "0" "$rc"
+mk_artifact "$STORE3" qa missing 2026-05-10T03-01-00 "$PROJ3"
+set +e
+out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
+rc=$?
+set -e
+assert_eq "integrity_missing fails --require-integrity (rc 1)" "1" "$rc"
+echo "$out" | grep -qE '^INTEGRITY MISSING:' && \
+  assert_eq "stderr labelled INTEGRITY MISSING" "yes" "yes" || \
+  assert_eq "stderr labelled INTEGRITY MISSING" "yes" "no"
+mk_artifact "$STORE3" qa mismatch 2026-05-10T03-02-00 "$PROJ3"
+set +e
+out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
+rc=$?
+set -e
+assert_eq "integrity_mismatch fails --require-integrity (rc 1)" "1" "$rc"
+
+# Cell 5: resolve.sh exposes upstream_status for every declared upstream.
+# /ship pulls review, security, qa — one of each trust state.
+echo "[5] resolve.sh upstream_status reports every declared upstream"
+PROJ4="$TMP_ROOT/project4"
+STORE4="$PROJ4/.nanostack"
+mkdir -p "$PROJ4" "$STORE4"
+cd "$PROJ4"
+git init -q
+mk_artifact "$STORE4" review   verified 2026-05-10T04-00-00 "$PROJ4"
+mk_artifact "$STORE4" security missing  2026-05-10T04-00-00 "$PROJ4"
+mk_artifact "$STORE4" qa       mismatch 2026-05-10T04-00-00 "$PROJ4"
+resolved=$( NANOSTACK_STORE="$STORE4" "$REPO/bin/resolve.sh" ship 2>/dev/null )
+status_review=$( echo "$resolved"   | jq -r '.upstream_status.review // ""' )
+status_security=$( echo "$resolved" | jq -r '.upstream_status.security // ""' )
+status_qa=$( echo "$resolved"       | jq -r '.upstream_status.qa // ""' )
+assert_eq "upstream_status.review == verified"            "verified"           "$status_review"
+assert_eq "upstream_status.security == integrity_missing" "integrity_missing"  "$status_security"
+assert_eq "upstream_status.qa == integrity_mismatch"      "integrity_mismatch" "$status_qa"
+
+# Cell 6: upstream_artifacts shape stays backward compatible. Verified
+# and integrity_missing artifacts include their path so legacy stores
+# load; mismatched artifacts are omitted (current --verify behavior).
+echo "[6] upstream_artifacts shape: verified + missing-integrity load, mismatch omitted"
+has_review=$( echo "$resolved"   | jq -e '.upstream_artifacts.review != null' >/dev/null 2>&1 && echo yes || echo no )
+has_security=$( echo "$resolved" | jq -e '.upstream_artifacts.security != null' >/dev/null 2>&1 && echo yes || echo no )
+has_qa=$( echo "$resolved"       | jq -e '.upstream_artifacts.qa != null' >/dev/null 2>&1 && echo yes || echo no )
+assert_eq "verified artifact loads"          "yes" "$has_review"
+assert_eq "integrity_missing artifact loads" "yes" "$has_security"
+assert_eq "integrity_mismatch artifact omitted from upstream_artifacts" "no" "$has_qa"
+
+# Cell 7: missing upstream (never saved) is reported as "missing".
+echo "[7] never-saved upstream reports status=missing"
+PROJ5="$TMP_ROOT/project5"
+STORE5="$PROJ5/.nanostack"
+mkdir -p "$PROJ5" "$STORE5"
+cd "$PROJ5"
+git init -q
+mk_artifact "$STORE5" review verified 2026-05-10T05-00-00 "$PROJ5"
+# security and qa are deliberately not created
+resolved=$( NANOSTACK_STORE="$STORE5" "$REPO/bin/resolve.sh" ship 2>/dev/null )
+status_security=$( echo "$resolved" | jq -r '.upstream_status.security // ""' )
+status_qa=$( echo "$resolved"       | jq -r '.upstream_status.qa // ""' )
+assert_eq "missing security reports status=missing" "missing" "$status_security"
+assert_eq "missing qa reports status=missing"       "missing" "$status_qa"
+
+# Cell 8: custom phases also get upstream_status. The custom dep graph
+# resolves through phase_graph or SKILL.md frontmatter, same as before.
+echo "[8] custom phase upstream_status follows the dep graph"
+PROJ6="$TMP_ROOT/project6"
+STORE6="$PROJ6/.nanostack"
+mkdir -p "$PROJ6" "$STORE6/skills/license-audit"
+cd "$PROJ6"
+git init -q
+cat > "$STORE6/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build","review"]},
+    {"name":"review","depends_on":["build"]},
+    {"name":"ship","depends_on":["license-audit"]}
+  ]
+}
+EOF
+cat > "$STORE6/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: license check
+concurrency: read
+---
+body
+EOF
+mk_artifact "$STORE6" review verified 2026-05-10T06-00-00 "$PROJ6"
+# build has no artifact directory; it should resolve to not_applicable
+resolved=$( NANOSTACK_STORE="$STORE6" "$REPO/bin/resolve.sh" license-audit 2>/dev/null )
+status_review=$(  echo "$resolved" | jq -r '.upstream_status.review // ""' )
+status_build=$(   echo "$resolved" | jq -r '.upstream_status.build // ""' )
+phase_kind=$(     echo "$resolved" | jq -r '.phase_kind // ""' )
+assert_eq "custom phase_kind = custom"                 "custom"          "$phase_kind"
+assert_eq "custom upstream_status.review = verified"   "verified"        "$status_review"
+assert_eq "custom upstream_status.build = not_applicable" "not_applicable" "$status_build"
+
+cd "$TMP_ROOT"
+
+echo
+echo "====================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf "${GREEN}Artifact Trust v2 E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
+  exit 0
+else
+  printf "${RED}Artifact Trust v2 E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/ci/e2e-artifact-trust.sh
+++ b/ci/e2e-artifact-trust.sh
@@ -225,6 +225,32 @@ status_qa=$( echo "$resolved"       | jq -r '.upstream_status.qa // ""' )
 assert_eq "missing security reports status=missing" "missing" "$status_security"
 assert_eq "missing qa reports status=missing"       "missing" "$status_qa"
 
+# Cell 8a: find-artifact.sh parses flags even when max-age is omitted.
+# Codex caught this on the PR 2 first pass: `find-artifact.sh plan
+# --require-integrity` (the documented optional-age form) used to
+# assign the flag string to MAX_AGE and the strict gate silently
+# no-oped. Locked here so the regression cannot return.
+echo "[8a] find-artifact.sh detects flags in the max-age slot"
+PROJ_FLAG="$TMP_ROOT/project-flag"
+STORE_FLAG="$PROJ_FLAG/.nanostack"
+mkdir -p "$PROJ_FLAG" "$STORE_FLAG"
+cd "$PROJ_FLAG"
+git init -q
+mk_artifact "$STORE_FLAG" plan missing 2026-05-10T08-00-00 "$PROJ_FLAG"
+set +e
+out=$( NANOSTACK_STORE="$STORE_FLAG" "$REPO/bin/find-artifact.sh" plan --require-integrity 2>&1 )
+rc=$?
+set -e
+assert_eq "no max-age + --require-integrity fails on missing (rc 1)" "1" "$rc"
+echo "$out" | grep -qE '^INTEGRITY MISSING:' && \
+  assert_eq "no max-age + --require-integrity emits INTEGRITY MISSING" "yes" "yes" || \
+  assert_eq "no max-age + --require-integrity emits INTEGRITY MISSING" "yes" "no"
+set +e
+out=$( NANOSTACK_STORE="$STORE_FLAG" "$REPO/bin/find-artifact.sh" plan --verify 2>&1 )
+rc=$?
+set -e
+assert_eq "no max-age + --verify is lenient (rc 0)" "0" "$rc"
+
 # Cell 8: custom phases also get upstream_status. The custom dep graph
 # resolves through phase_graph or SKILL.md frontmatter, same as before.
 echo "[8] custom phase upstream_status follows the dep graph"

--- a/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh
+++ b/examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh
@@ -20,11 +20,15 @@
 #   - artifact present + verified, status absent or
 #     unrecognized                                  -> WARN
 #
-# Each lookup goes through find-artifact.sh --verify so a tampered
-# artifact (mtime untouched, content rewritten) cannot quietly roll
-# the gate up to OK. The tampered case is recorded as TAMPERED in
-# the per-check entry and forces the rollup to BLOCKED, separately
-# from "artifact never saved" which records as MISSING.
+# Each lookup goes through find-artifact.sh --require-integrity so a
+# tampered artifact (mtime untouched, content rewritten) or one whose
+# .integrity field has been stripped cannot quietly roll the gate up
+# to OK. Both failure modes are recorded as TAMPERED in the per-check
+# entry and force the rollup to BLOCKED, separately from "artifact
+# never saved" which records as MISSING. The --require-integrity flag
+# is the shared primitive added in the 2026-05-10 architecture audit
+# (PR 2); release gates that need strict semantics call it directly
+# instead of layering their own jq checks on top of --verify.
 #
 # save-artifact.sh always writes the .integrity field, so a
 # legitimate artifact never trips the missing-integrity check.
@@ -68,34 +72,33 @@ for phase in $UPSTREAMS; do
     status="MISSING"
     evidence=""
   else
-    # Then: does it pass integrity verification? --verify exits 1 and
-    # prints "INTEGRITY FAILED" to stderr when the stored hash does
-    # not match the recomputed hash. A release gate must surface that
-    # explicitly, not treat a tampered file as clean evidence.
-    verified=$( "$FIND_ARTIFACT" "$phase" 30 --verify 2>/dev/null || true )
+    # Second: does the artifact pass strict integrity verification?
+    # find-artifact.sh --require-integrity fails on BOTH a hash
+    # mismatch AND a missing .integrity field, with distinct stderr
+    # categories ("INTEGRITY FAILED" / "INTEGRITY MISSING"). Before
+    # PR 2 of the 2026-05-10 architecture audit this skill grew its
+    # own jq-based check because --verify alone passed missing-
+    # integrity artifacts; the strict flag is the shared primitive
+    # so every release gate agrees on the trust model.
+    err_file=$(mktemp /tmp/release-readiness-err.XXXXXX)
+    verified=$( "$FIND_ARTIFACT" "$phase" 30 --require-integrity 2>"$err_file" || true )
     if [ -z "$verified" ] || [ ! -f "$verified" ]; then
       status="TAMPERED"
-      evidence="integrity_failure"
-    else
-      # find-artifact.sh --verify silently accepts artifacts whose
-      # .integrity field is missing — it only fails on a hash
-      # MISMATCH, not on absence. A release gate cannot afford that:
-      # an attacker who can write the file can delete the field as
-      # easily as mutate the hash. Require .integrity to be present.
-      stored_integrity=$( jq -r '.integrity // ""' "$verified" 2>/dev/null )
-      if [ -z "$stored_integrity" ]; then
-        status="TAMPERED"
+      if grep -q "^INTEGRITY MISSING:" "$err_file" 2>/dev/null; then
         evidence="missing_integrity"
       else
-        raw_status=$( jq -r '.summary.status // ""' "$verified" 2>/dev/null )
-        case "$raw_status" in
-          OK|WARN|BLOCKED) status="$raw_status" ;;
-          "") status="WARN" ;;
-          *)  status="WARN" ;;
-        esac
-        evidence="artifact"
+        evidence="integrity_failure"
       fi
+    else
+      raw_status=$( jq -r '.summary.status // ""' "$verified" 2>/dev/null )
+      case "$raw_status" in
+        OK|WARN|BLOCKED) status="$raw_status" ;;
+        "") status="WARN" ;;
+        *)  status="WARN" ;;
+      esac
+      evidence="artifact"
     fi
+    rm -f "$err_file"
   fi
 
   case "$status" in

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -14,9 +14,39 @@ All artifacts share this base structure:
   "mode": "<quick|standard|thorough>",
   "summary": {},
   "findings": [],
-  "conflicts": []
+  "conflicts": [],
+  "integrity": "<sha256 hex digest of the artifact with .integrity stripped>"
 }
 ```
+
+## Artifact trust model
+
+Every artifact saved by `bin/save-artifact.sh` carries a `.integrity` field: a SHA-256 over the canonical (sorted, no-integrity) JSON. Readers verify integrity through one of two shared primitives so every layer agrees on what "trustworthy" means.
+
+### Trust statuses
+
+`bin/lib/artifact-trust.sh` exposes `nano_artifact_trust <path>` which echoes one of four statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `verified` | Regular JSON file. `.integrity` is present and the recomputed hash matches. Safe to use as evidence. |
+| `integrity_missing` | Regular JSON file. `.integrity` is absent or empty. An attacker who can write the file can also delete the field, so release gates treat this as untrusted. |
+| `integrity_mismatch` | Regular JSON file. `.integrity` is present but the recomputed hash does not match. The artifact was modified after `save-artifact.sh` wrote it. |
+| `not_found` | Path is empty, does not exist, or is not a regular file. The helper returns exit 1 in this case. |
+
+### Verification flags on `bin/find-artifact.sh`
+
+| Flag | Behavior on `verified` | Behavior on `integrity_missing` | Behavior on `integrity_mismatch` |
+|------|------------------------|---------------------------------|----------------------------------|
+| (none) | path on stdout, exit 0 | path on stdout, exit 0 | path on stdout, exit 0 |
+| `--verify` | path on stdout, exit 0 | path on stdout, exit 0 (backward compatible with legacy artifacts) | `INTEGRITY FAILED:` on stderr, exit 1 |
+| `--require-integrity` | path on stdout, exit 0 | `INTEGRITY MISSING:` on stderr, exit 1 | `INTEGRITY FAILED:` on stderr, exit 1 |
+
+`--require-integrity` implies `--verify`. Use it from release gates and any consumer that cannot tolerate unverifiable evidence. The shared primitive replaces the per-skill jq checks that grew up around `--verify` before this flag existed.
+
+### `resolve.sh` `upstream_status`
+
+`bin/resolve.sh` adds a `upstream_status` field to its JSON output: a map from each declared upstream phase to its trust status (`verified`, `integrity_missing`, `integrity_mismatch`, `missing`, or `not_applicable` for the conductor's `build` stage). `upstream_artifacts` continues to include `verified` and `integrity_missing` paths so legacy stores load; consumers that need strict semantics read `upstream_status` and decide for themselves.
 
 ## Context Checkpoint
 


### PR DESCRIPTION
## Summary

Adds a shared trust primitive at `bin/lib/artifact-trust.sh`. Every layer that reads nanostack artifacts (find-artifact.sh, resolve.sh, release gates) now routes through `nano_artifact_trust`, which returns one of four statuses: `verified`, `integrity_missing`, `integrity_mismatch`, `not_found`. Before this change the trust model lived in two places that disagreed: `find-artifact.sh --verify` failed only on hash mismatch, while release-readiness grew its own jq check because a release gate cannot afford to trust evidence whose hash is absent.

## What changes

`bin/find-artifact.sh`

Adds `--require-integrity`. The flag implies `--verify` and additionally fails on artifacts whose `.integrity` field is missing. Distinct stderr categories so callers can categorize:

- `INTEGRITY FAILED:` for a hash mismatch (existing).
- `INTEGRITY MISSING:` for a missing `.integrity` field (new).

`--verify` keeps its existing lenient behavior for backward compatibility with legacy artifacts. Argument parsing also accepts flags in the max-age slot, so `find-artifact.sh plan --require-integrity` works without a placeholder age.

`bin/resolve.sh`

Adds `upstream_status` to the JSON output: a map from each declared upstream phase to one of `verified`, `integrity_missing`, `integrity_mismatch`, `missing`, or `not_applicable` (for the conductor's `build` stage). `upstream_artifacts` keeps its existing shape so consumers that only read it continue to work.

`examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh`

Drops the local jq check for `.integrity` and switches to `find-artifact.sh --require-integrity`. Per-check evidence still distinguishes `integrity_failure` from `missing_integrity` via the stderr category, so the rollup behavior is identical. The release-readiness smoke suite still passes all 7 cases.

`reference/artifact-schema.md`

Documents the four trust statuses, the flag matrix on `find-artifact.sh`, and the `upstream_status` contract on `resolve.sh`.

## What does not change

- `bin/save-artifact.sh` keeps writing `.integrity` unchanged. Fresh saves are always `verified`.
- `find-artifact.sh --verify` keeps its lenient behavior. Existing callers continue to load legacy artifacts saved before integrity was added.
- `resolve.sh upstream_artifacts` shape is unchanged. Verified and integrity-missing artifacts still load; integrity-mismatched artifacts are still dropped.
- All existing E2E suites pass without modification: custom-stack-flows (40), custom-stack-examples (51), release-readiness smoke (7), guard regression (17).

## Tests

New harness `ci/e2e-artifact-trust.sh`: 9 cells, 29 checks. Wired into `.github/workflows/e2e.yml` as job "E2E Artifact Trust v2 (9 cells)".

- Cell 1: `nano_artifact_trust` returns each of the four canonical statuses.
- Cell 2: `find-artifact.sh` without flags returns the newest artifact regardless of trust.
- Cell 3: `--verify` is lenient on missing integrity, strict on mismatch.
- Cell 4: `--require-integrity` is strict on missing AND mismatch, with distinct stderr categories.
- Cell 5: `resolve.sh` `upstream_status` reports every declared upstream with the correct status.
- Cell 6: `upstream_artifacts` shape stays backward compatible (verified + missing load, mismatch omitted).
- Cell 7: never-saved upstream reports status=missing.
- Cell 8: custom phases follow the dep graph, build stage reports `not_applicable`.
- Cell 8a: regression lock for the flag-parsing fix (no max-age + `--require-integrity` triggers strict mode).

## Codex review

Each finding from the two Codex review passes was addressed in its own commit:

1. Initial shared primitive + find-artifact + resolve + release-readiness wiring.
2. Two findings: flag parsing now recognizes flags in the max-age slot; `||` moved outside the command substitution in resolve.sh so a deletion race cannot embed a literal newline in `upstream_status`.

Final pass clean: "I did not identify actionable correctness issues in the diff."

## Files

- `bin/lib/artifact-trust.sh` (new): the shared `nano_artifact_trust` primitive.
- `bin/find-artifact.sh`: `--require-integrity` flag, flag-shape argument parsing.
- `bin/resolve.sh`: `upstream_status` field, race-safe nano_artifact_trust invocation.
- `examples/custom-stack-template/compliance-release/skills/release-readiness/bin/summarize.sh`: drops the local jq check.
- `reference/artifact-schema.md`: trust model documentation.
- `ci/e2e-artifact-trust.sh` (new): 9-cell, 29-check harness.
- `.github/workflows/e2e.yml`: new job.

## Spec

PR 2 of the 2026-05-10 Nanostack Architecture Audit vNext. Closes the P1 finding "Artifact Integrity Verification Is Not Strict Enough For Framework Trust".

Next: PR 3, Structured Core Artifact Enforcement. Closes the P1 "Structured Artifact Contract Is Still Optional For Most Core Skills". Targets save-artifact.sh phase-specific validators and removes `--from-session` from normal-path SKILL.md guidance.

## Test plan

- [ ] `bash ci/e2e-artifact-trust.sh` reports 29 of 29 checks passed.
- [ ] `bash ci/e2e-custom-stack-flows.sh` reports 40 of 40 checks passed.
- [ ] `bash ci/e2e-custom-stack-examples.sh` reports 51 of 51 checks passed.
- [ ] `NANOSTACK_ROOT=... bash examples/.../release-readiness/bin/smoke.sh` reports 7 of 7 cases passed.
- [ ] `.github/workflows/e2e.yml` job "E2E Artifact Trust v2 (9 cells)" passes on CI.
- [ ] `.github/workflows/lint.yml` jobs continue to pass.