### PR TITLE
structured-artifact: per-phase schema enforcement (PR 3 of architecture vNext)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,7 @@ jobs:
           ci/e2e-onboarding-flows.sh
 
   e2e-structured-artifacts:
-    name: E2E Structured Artifact Contract (8 cells)
+    name: E2E Structured Artifact Contract (9 cells)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # PR 3 of the 2026-05-10 architecture audit. Locks the per-phase

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -170,6 +170,24 @@ jobs:
           chmod +x ci/e2e-onboarding-flows.sh
           ci/e2e-onboarding-flows.sh
 
+  e2e-structured-artifacts:
+    name: E2E Structured Artifact Contract (8 cells)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # PR 3 of the 2026-05-10 architecture audit. Locks the per-phase
+    # validator contract end-to-end: bin/lib/artifact-schemas.sh,
+    # bin/save-artifact.sh (strict write + legacy --from-session
+    # bypass), and the lint acceptance regex for the five core
+    # SKILL.md files.
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq is present
+        run: jq --version
+      - name: Run structured artifact E2E
+        run: |
+          chmod +x ci/e2e-structured-artifacts.sh
+          ci/e2e-structured-artifacts.sh
+
   e2e-artifact-trust:
     name: E2E Artifact Trust v2 (9 cells)
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3356,3 +3356,43 @@ jobs:
             exit 1
           fi
           echo "OK: guard concurrency tier uses the phase registry."
+
+  core-skills-save-structured:
+    name: Core skills save structured artifacts (no --from-session normal path)
+    runs-on: ubuntu-latest
+    # PR 3 of the 2026-05-10 architecture audit: core skills
+    # (plan, review, qa, security, ship) must document the structured
+    # save form. --from-session is retained in save-artifact.sh for
+    # manual recovery, but the normal-flow guidance in SKILL.md must
+    # not reference it for these five phases. The lint matches the
+    # acceptance regex from the spec verbatim so a single rg locally
+    # gives the same answer CI does.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: No --from-session save in core normal flows
+        run: |
+          set -e
+          # Acceptance regex from the spec.
+          if grep -nE -- '--from-session (plan|review|qa|security|ship)' \
+              plan/SKILL.md review/SKILL.md qa/SKILL.md security/SKILL.md ship/SKILL.md; then
+            echo "FAIL: core SKILL.md still documents --from-session for a core phase."
+            echo "Use the structured save form (see reference/artifact-schema.md)."
+            exit 1
+          fi
+          echo "OK: core SKILL.md files document the structured save form only."
+      - name: save-artifact.sh validator wiring
+        run: |
+          set -e
+          script=bin/save-artifact.sh
+          # The validator helper must be sourced and called.
+          if ! grep -qF 'artifact-schemas.sh' "$script"; then
+            echo "FAIL: $script does not source bin/lib/artifact-schemas.sh."
+            exit 1
+          fi
+          if ! grep -qF 'nano_validate_artifact' "$script"; then
+            echo "FAIL: $script does not call nano_validate_artifact."
+            exit 1
+          fi
+          echo "OK: save-artifact.sh wires the per-phase validator."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2643,7 +2643,7 @@ jobs:
           # resolver must still emit `build` and `ship` keys with null
           # values for custom phases.
           printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"ship","depends_on":["build"]},{"name":"audit-licenses","depends_on":["build","plan","ship"]}]}' > .nanostack/config.json
-          "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+          "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"goal":"x","planned_files":[],"plan_approval":"manual"},"context_checkpoint":{"summary":"y"}}' >/dev/null
           out=$("$GITHUB_WORKSPACE/bin/resolve.sh" audit-licenses 2>/dev/null)
           echo "$out" | jq -e '.upstream_artifacts.build == null' >/dev/null
           echo "$out" | jq -e '.upstream_artifacts.plan | type == "string"' >/dev/null
@@ -2862,7 +2862,7 @@ jobs:
           # Register a custom phase, save one core + one custom artifact.
           printf '%s' '{"custom_phases":["audit-licenses"]}' > .nanostack/config.json
           "$GITHUB_WORKSPACE/bin/save-artifact.sh" plan \
-            '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+            '{"phase":"plan","summary":{"goal":"x","planned_files":[],"plan_approval":"manual"},"context_checkpoint":{"summary":"y"}}' >/dev/null
           "$GITHUB_WORKSPACE/bin/save-artifact.sh" audit-licenses \
             '{"phase":"audit-licenses","summary":{"status":"OK","headline":"47 deps scanned, 0 GPL/AGPL flagged"},"context_checkpoint":{"summary":"ok"}}' >/dev/null
 

--- a/bin/lib/artifact-schemas.sh
+++ b/bin/lib/artifact-schemas.sh
@@ -101,7 +101,11 @@ nano_validate_artifact() {
       ;;
     review)
       _nano_validate_field "$json" '.summary' 'object'
-      _nano_validate_field "$json" '.scope_drift' 'any'
+      # scope_drift must be an object: bin/sprint-journal.sh reads
+      # .scope_drift.status, so a string-shaped scope_drift silently
+      # loses the drift signal downstream. Codex caught the contract
+      # mismatch on the PR 3 fourth review pass.
+      _nano_validate_field "$json" '.scope_drift' 'object'
       _nano_validate_field "$json" '.findings' 'array'
       _nano_validate_field "$json" '.context_checkpoint' 'object'
       ;;

--- a/bin/lib/artifact-schemas.sh
+++ b/bin/lib/artifact-schemas.sh
@@ -101,11 +101,14 @@ nano_validate_artifact() {
       ;;
     review)
       _nano_validate_field "$json" '.summary' 'object'
-      # scope_drift must be an object: bin/sprint-journal.sh reads
-      # .scope_drift.status, so a string-shaped scope_drift silently
-      # loses the drift signal downstream. Codex caught the contract
-      # mismatch on the PR 3 fourth review pass.
+      # scope_drift must be an object with a .status field: the
+      # downstream consumer bin/sprint-journal.sh reads
+      # .scope_drift.status. An empty object satisfies "is an object"
+      # but still drops the drift signal silently, so .status is
+      # required too. Codex caught the contract mismatch on the PR 3
+      # fourth and fifth review passes.
       _nano_validate_field "$json" '.scope_drift' 'object'
+      _nano_validate_field "$json" '.scope_drift.status' 'string'
       _nano_validate_field "$json" '.findings' 'array'
       _nano_validate_field "$json" '.context_checkpoint' 'object'
       ;;

--- a/bin/lib/artifact-schemas.sh
+++ b/bin/lib/artifact-schemas.sh
@@ -129,7 +129,12 @@ nano_validate_artifact() {
       # structured summary and a context_checkpoint so /compound and
       # post-deploy verification can read PR / status fields by name.
       local run_mode
-      run_mode=$(printf '%s' "$json" | jq -r '.run_mode // .summary.run_mode // ""' 2>/dev/null)
+      # `?` swallows the "cannot index string with run_mode" jq error
+      # so a ship artifact with a string summary still classifies
+      # cleanly. Without `?`, jq exits 5 and a caller running under
+      # set -e never reaches the validator's documented schema error.
+      # Codex caught the contract violation on the PR 3 sixth pass.
+      run_mode=$(printf '%s' "$json" | jq -r '.run_mode // (.summary.run_mode? // "")' 2>/dev/null) || run_mode=""
       if [ "$run_mode" = "report_only" ]; then
         _nano_validate_field "$json" '.summary' 'any'
       else

--- a/bin/lib/artifact-schemas.sh
+++ b/bin/lib/artifact-schemas.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# artifact-schemas.sh — Phase-specific validators for nanostack artifacts.
+#
+# Single source of truth for "is this artifact shape valid for this
+# phase?" save-artifact.sh calls nano_validate_artifact <phase> <json>
+# in normal (structured) mode and refuses to write when the artifact
+# is missing required fields. The 2026-05-10 architecture audit
+# (PR 3) moves this enforcement out of advisory SKILL.md guidance and
+# into the save path itself so downstream skills (resolve.sh,
+# restore-context.sh, sprint-journal.sh, release-readiness) can rely
+# on named fields being present.
+#
+# Public function:
+#   nano_validate_artifact <phase> <json>
+#     Returns 0 if the artifact JSON conforms to the phase contract.
+#     Returns 1 with a stderr message listing missing or wrong-shape
+#     fields. The function is read-only: it never modifies the JSON.
+#
+# Required fields per phase:
+#   think     — handled by /think SKILL.md autopilot brief gate; here
+#               we only require .summary to be an object so the
+#               structured contract is consistent with the four other
+#               core phases.
+#   plan      — summary.planned_files (array), summary.plan_approval,
+#               context_checkpoint.
+#   review    — summary (object), scope_drift, findings (array),
+#               context_checkpoint.
+#   qa        — summary (object), findings (array), context_checkpoint.
+#   security  — summary (object), findings (array), context_checkpoint.
+#   ship      — summary (object), context_checkpoint. When run_mode is
+#               report_only, summary may be a string and findings is
+#               not required (the artifact is a report, not a release
+#               record). Other ship artifacts must look like a real
+#               PR record (summary.status or summary.pr_number).
+#   custom    — phase + summary only (already enforced by save-artifact).
+#
+# Every core phase requires context_checkpoint so restore-context.sh
+# can rebuild state across long sprints. The field's own shape is
+# documented in reference/artifact-schema.md.
+
+if [ "${_NANO_ARTIFACT_SCHEMAS_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_ARTIFACT_SCHEMAS_LOADED=1
+
+# Helper: report a missing field. Accumulates into the caller's
+# MISSING variable. Stays internal so callers stay small.
+_nano_validate_emit() {
+  if [ -z "$_MISSING_FIELDS" ]; then
+    _MISSING_FIELDS="$1"
+  else
+    _MISSING_FIELDS="$_MISSING_FIELDS, $1"
+  fi
+}
+
+# Helper: check that a jq path resolves to a non-null value of the
+# expected type. type may be "any" (just non-null), "string",
+# "object", "array", "number", "boolean".
+_nano_validate_field() {
+  local json="$1" path="$2" expected="$3"
+  local actual
+  actual=$(printf '%s' "$json" | jq -r "$path | type" 2>/dev/null || echo "missing")
+  case "$actual" in
+    null|missing)
+      _nano_validate_emit "$path"
+      return 1
+      ;;
+  esac
+  if [ "$expected" != "any" ] && [ "$actual" != "$expected" ]; then
+    _nano_validate_emit "$path (expected $expected, got $actual)"
+    return 1
+  fi
+  return 0
+}
+
+nano_validate_artifact() {
+  local phase="${1:?nano_validate_artifact requires <phase> <json>}"
+  local json="${2:?nano_validate_artifact requires <phase> <json>}"
+  _MISSING_FIELDS=""
+
+  # JSON must parse. save-artifact already checks this, but the
+  # validator is callable on its own (lint, ad-hoc verification).
+  if ! printf '%s' "$json" | jq -e '.' >/dev/null 2>&1; then
+    echo "nano_validate_artifact: invalid JSON input" >&2
+    return 1
+  fi
+
+  case "$phase" in
+    think)
+      # /think autopilot brief gate already enforces the rich field
+      # set (value_proposition, scope_mode, ...). Here we only check
+      # that summary is an object so the structured contract is
+      # consistent across core phases.
+      _nano_validate_field "$json" '.summary' 'object'
+      ;;
+    plan)
+      _nano_validate_field "$json" '.summary' 'object'
+      _nano_validate_field "$json" '.summary.planned_files' 'array'
+      _nano_validate_field "$json" '.summary.plan_approval' 'any'
+      _nano_validate_field "$json" '.context_checkpoint' 'object'
+      ;;
+    review)
+      _nano_validate_field "$json" '.summary' 'object'
+      _nano_validate_field "$json" '.scope_drift' 'any'
+      _nano_validate_field "$json" '.findings' 'array'
+      _nano_validate_field "$json" '.context_checkpoint' 'object'
+      ;;
+    qa)
+      _nano_validate_field "$json" '.summary' 'object'
+      _nano_validate_field "$json" '.findings' 'array'
+      _nano_validate_field "$json" '.context_checkpoint' 'object'
+      ;;
+    security)
+      _nano_validate_field "$json" '.summary' 'object'
+      _nano_validate_field "$json" '.findings' 'array'
+      _nano_validate_field "$json" '.context_checkpoint' 'object'
+      ;;
+    ship)
+      # report_only ship artifacts are reports, not release records.
+      # They keep the looser shape (summary may be a string, no
+      # findings expected). Normal-mode ship artifacts must include a
+      # structured summary and a context_checkpoint so /compound and
+      # post-deploy verification can read PR / status fields by name.
+      local run_mode
+      run_mode=$(printf '%s' "$json" | jq -r '.run_mode // .summary.run_mode // ""' 2>/dev/null)
+      if [ "$run_mode" = "report_only" ]; then
+        _nano_validate_field "$json" '.summary' 'any'
+      else
+        _nano_validate_field "$json" '.summary' 'object'
+        _nano_validate_field "$json" '.context_checkpoint' 'object'
+      fi
+      ;;
+    *)
+      # Custom phases and unrecognized core phases: only the base
+      # contract (phase + summary) is enforced. The base check lives
+      # in save-artifact.sh and runs before us.
+      return 0
+      ;;
+  esac
+
+  if [ -n "$_MISSING_FIELDS" ]; then
+    echo "nano_validate_artifact: $phase artifact is missing required fields: $_MISSING_FIELDS" >&2
+    echo "                        see reference/artifact-schema.md for the canonical shape." >&2
+    return 1
+  fi
+  return 0
+}

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 # save-artifact.sh — Save a skill artifact to .nanostack/<phase>/
 # Usage:
-#   save-artifact.sh <phase> <json-string>              (full mode)
-#   save-artifact.sh --from-session <phase> <summary>   (simplified mode)
+#   save-artifact.sh <phase> <json-string>              (structured mode, recommended)
+#   save-artifact.sh --from-session <phase> <summary>   (legacy mode, prose blob)
 #
-# Full mode: pass complete JSON with phase, summary, context_checkpoint.
-# Session mode: reads phase from session, builds JSON from git state + summary string.
-#   Auto-calls session.sh phase-complete after saving.
+# Structured mode is the normal-flow path. The JSON is validated
+# against the phase-specific contract in bin/lib/artifact-schemas.sh
+# before write, so downstream skills (resolve.sh, restore-context.sh,
+# sprint-journal.sh, release-readiness) can rely on named fields
+# being present.
+#
+# --from-session is retained for manual recovery and ad-hoc tooling.
+# It builds JSON from git state + a prose summary string and bypasses
+# the phase-specific validator (the prose blob would never satisfy
+# summary-as-object), so it writes a `schema_legacy: true` flag and
+# emits a deprecation warning to stderr. The core SKILL.md files
+# (plan/review/qa/security/ship) no longer document it.
 #
 # Validates JSON has required fields before saving. Fails on invalid input.
 set -e
@@ -16,11 +25,18 @@ source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 [ -f "$SCRIPT_DIR/lib/portable.sh" ] && source "$SCRIPT_DIR/lib/portable.sh"
+[ -f "$SCRIPT_DIR/lib/artifact-schemas.sh" ] && source "$SCRIPT_DIR/lib/artifact-schemas.sh"
+
+LEGACY_MODE=0
 
 # ─── Session mode: build JSON from git state + summary ──────
 if [ "${1:-}" = "--from-session" ]; then
   PHASE="${2:?Usage: save-artifact.sh --from-session <phase> <summary>}"
   SUMMARY_TEXT="${3:?Missing summary argument}"
+  LEGACY_MODE=1
+
+  echo "save-artifact.sh: --from-session is a legacy mode for manual recovery." >&2
+  echo "                  Normal-path skills must call the structured form (see reference/artifact-schema.md)." >&2
 
   PROJECT="$(pwd)"
   BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
@@ -41,6 +57,7 @@ if [ "${1:-}" = "--from-session" ]; then
     '{
       phase: $phase,
       summary: $summary,
+      schema_legacy: true,
       context_checkpoint: {
         summary: $summary,
         key_files: ($changed + $staged | unique),
@@ -92,6 +109,18 @@ ARTIFACT_PHASE=$(echo "$JSON" | jq -r '.phase')
 if [ "$ARTIFACT_PHASE" != "$PHASE" ]; then
   echo "error: phase argument '$PHASE' does not match artifact phase '$ARTIFACT_PHASE'" >&2
   exit 1
+fi
+
+# Phase-specific schema check (PR 3 of the 2026-05-10 architecture
+# audit). Structured artifacts must include phase-required fields
+# (summary as object, context_checkpoint, findings/scope_drift where
+# applicable). --from-session legacy mode skips this because the
+# prose-blob form cannot satisfy summary-as-object; those artifacts
+# carry schema_legacy: true so downstream consumers can distinguish.
+if [ "$LEGACY_MODE" = "0" ] && declare -F nano_validate_artifact >/dev/null 2>&1; then
+  if ! nano_validate_artifact "$PHASE" "$JSON"; then
+    exit 1
+  fi
 fi
 
 mkdir -p "$STORE"

--- a/ci/e2e-custom-stack-examples.sh
+++ b/ci/e2e-custom-stack-examples.sh
@@ -146,7 +146,7 @@ echo "[4] save core artifacts (review, qa, security) via save-artifact.sh"
 # context_checkpoint). The fixtures below pass the per-phase
 # validator in bin/lib/artifact-schemas.sh.
 "$REPO/bin/save-artifact.sh" review \
-  '{"phase":"review","summary":{"status":"OK","blocking":0,"should_fix":0,"nitpicks":0,"positive":1},"scope_drift":"none","findings":[],"context_checkpoint":{"summary":"reviewed"}}' \
+  '{"phase":"review","summary":{"status":"OK","blocking":0,"should_fix":0,"nitpicks":0,"positive":1},"scope_drift":{"status":"clean"},"findings":[],"context_checkpoint":{"summary":"reviewed"}}' \
   >/dev/null
 "$REPO/bin/save-artifact.sh" qa \
   '{"phase":"qa","summary":{"status":"OK","tests_run":1,"tests_passed":1,"tests_failed":0,"bugs_found":0,"bugs_fixed":0},"findings":[],"context_checkpoint":{"summary":"qa"}}' \

--- a/ci/e2e-custom-stack-examples.sh
+++ b/ci/e2e-custom-stack-examples.sh
@@ -141,14 +141,18 @@ done
 # Each is OK so the rollup later only depends on license-audit /
 # privacy-check / release-readiness.
 echo "[4] save core artifacts (review, qa, security) via save-artifact.sh"
+# PR 3 of the 2026-05-10 architecture audit: core skills must save
+# the structured shape (summary as object, findings array,
+# context_checkpoint). The fixtures below pass the per-phase
+# validator in bin/lib/artifact-schemas.sh.
 "$REPO/bin/save-artifact.sh" review \
-  '{"phase":"review","summary":{"status":"OK","blocking":0,"should_fix":0,"nitpicks":0,"positive":1},"context_checkpoint":{"summary":"reviewed"}}' \
+  '{"phase":"review","summary":{"status":"OK","blocking":0,"should_fix":0,"nitpicks":0,"positive":1},"scope_drift":"none","findings":[],"context_checkpoint":{"summary":"reviewed"}}' \
   >/dev/null
 "$REPO/bin/save-artifact.sh" qa \
-  '{"phase":"qa","summary":{"status":"OK","tests_run":1,"tests_passed":1,"tests_failed":0,"bugs_found":0,"bugs_fixed":0},"context_checkpoint":{"summary":"qa"}}' \
+  '{"phase":"qa","summary":{"status":"OK","tests_run":1,"tests_passed":1,"tests_failed":0,"bugs_found":0,"bugs_fixed":0},"findings":[],"context_checkpoint":{"summary":"qa"}}' \
   >/dev/null
 "$REPO/bin/save-artifact.sh" security \
-  '{"phase":"security","summary":{"status":"OK","critical":0,"high":0,"medium":0,"low":0,"total_findings":0},"context_checkpoint":{"summary":"clean"}}' \
+  '{"phase":"security","summary":{"status":"OK","critical":0,"high":0,"medium":0,"low":0,"total_findings":0},"findings":[],"context_checkpoint":{"summary":"clean"}}' \
   >/dev/null
 assert_true "review artifact saved with .integrity" \
   bash -c 'jq -e ".integrity != null" $(ls $NANOSTACK_STORE/review/*.json | head -1) >/dev/null'

--- a/ci/e2e-delivery-matrix.sh
+++ b/ci/e2e-delivery-matrix.sh
@@ -148,8 +148,25 @@ fake_complete() {
 
   # save-artifact creates the artifact file the phase gate looks for.
   # Use the real save-artifact so the on-disk shape matches production.
-  "$REPO/bin/save-artifact.sh" "$phase" \
-    "{\"phase\":\"$phase\",\"summary\":{\"v\":1}}" >/dev/null 2>&1 || true
+  # PR 3 of the 2026-05-10 audit added per-phase validators; this
+  # fixture must include the strict-mode required fields so the save
+  # succeeds for review/qa/security/ship (plan is not exercised here).
+  local payload
+  case "$phase" in
+    review)
+      payload="{\"phase\":\"review\",\"summary\":{\"v\":1},\"scope_drift\":\"none\",\"findings\":[],\"context_checkpoint\":{\"summary\":\"matrix $phase\"}}"
+      ;;
+    qa|security)
+      payload="{\"phase\":\"$phase\",\"summary\":{\"v\":1},\"findings\":[],\"context_checkpoint\":{\"summary\":\"matrix $phase\"}}"
+      ;;
+    ship)
+      payload="{\"phase\":\"ship\",\"summary\":{\"v\":1,\"status\":\"merged\"},\"context_checkpoint\":{\"summary\":\"matrix ship\"}}"
+      ;;
+    *)
+      payload="{\"phase\":\"$phase\",\"summary\":{\"v\":1}}"
+      ;;
+  esac
+  "$REPO/bin/save-artifact.sh" "$phase" "$payload" >/dev/null 2>&1 || true
 }
 
 # ─── Cell 1: Claude + git => professional ─────────────────────────────

--- a/ci/e2e-delivery-matrix.sh
+++ b/ci/e2e-delivery-matrix.sh
@@ -154,7 +154,7 @@ fake_complete() {
   local payload
   case "$phase" in
     review)
-      payload="{\"phase\":\"review\",\"summary\":{\"v\":1},\"scope_drift\":\"none\",\"findings\":[],\"context_checkpoint\":{\"summary\":\"matrix $phase\"}}"
+      payload="{\"phase\":\"review\",\"summary\":{\"v\":1},\"scope_drift\":{\"status\":\"clean\"},\"findings\":[],\"context_checkpoint\":{\"summary\":\"matrix $phase\"}}"
       ;;
     qa|security)
       payload="{\"phase\":\"$phase\",\"summary\":{\"v\":1},\"findings\":[],\"context_checkpoint\":{\"summary\":\"matrix $phase\"}}"

--- a/ci/e2e-examples.sh
+++ b/ci/e2e-examples.sh
@@ -134,15 +134,30 @@ save_sprint() {
     '{phase:"think", summary:{value_proposition:$vp, scope_mode:"reduce", target_user:$tu, narrowest_wedge:$nw, key_risk:$kr, premise_validated:true, out_of_scope:[], manual_delivery_test:{possible:true, steps:["run start state"]}, search_summary:{mode:"local_only", result:"", existing_solution:"none"}}, context_checkpoint:{summary:"sandbox think"}}')
   "$REPO/bin/save-artifact.sh" think "$think_json" >/dev/null
 
+  # PR 3 of the 2026-05-10 architecture audit added per-phase
+  # validators. plan requires summary.planned_files + plan_approval +
+  # context_checkpoint; review/qa/security require findings (+ scope_drift
+  # for review) + context_checkpoint; ship requires context_checkpoint.
   plan_json=$(jq -n --arg f "$first_file" '{
     phase:"plan",
-    summary:{goal:"first feature", scope:"small", step_count:3, planned_files:[$f], risks:[], out_of_scope:[]}
+    summary:{goal:"first feature", scope:"small", step_count:3, planned_files:[$f], plan_approval:"manual", risks:[], out_of_scope:[]},
+    context_checkpoint:{summary:"sandbox plan", key_files:[$f]}
   }')
   "$REPO/bin/save-artifact.sh" plan "$plan_json" >/dev/null
 
   for phase in review security qa ship; do
     local payload
-    payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}}')
+    case "$phase" in
+      review)
+        payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}, scope_drift:"none", findings:[], context_checkpoint:{summary:"sandbox review"}}')
+        ;;
+      qa|security)
+        payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}, findings:[], context_checkpoint:{summary:"sandbox check"}}')
+        ;;
+      ship)
+        payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"merged"}, context_checkpoint:{summary:"sandbox ship"}}')
+        ;;
+    esac
     "$REPO/bin/save-artifact.sh" "$phase" "$payload" >/dev/null
   done
 }

--- a/ci/e2e-examples.sh
+++ b/ci/e2e-examples.sh
@@ -149,7 +149,7 @@ save_sprint() {
     local payload
     case "$phase" in
       review)
-        payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}, scope_drift:"none", findings:[], context_checkpoint:{summary:"sandbox review"}}')
+        payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}, scope_drift:{status:"clean"}, findings:[], context_checkpoint:{summary:"sandbox review"}}')
         ;;
       qa|security)
         payload=$(jq -n --arg p "$phase" '{phase:$p, summary:{v:1, status:"clean"}, findings:[], context_checkpoint:{summary:"sandbox check"}}')

--- a/ci/e2e-structured-artifacts.sh
+++ b/ci/e2e-structured-artifacts.sh
@@ -203,6 +203,22 @@ grep -qF 'nano_validate_artifact' "$script" && \
   assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "yes" || \
   assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "no"
 
+# Cell 9: nano_validate_artifact stays callable from set -e callers
+# even on malformed ship artifacts. A ship payload with a string
+# summary and no top-level run_mode used to crash the jq probe
+# (rc 5), so an errexit caller exited before the validator could
+# return its documented schema error. Codex caught this on the
+# PR 3 sixth review pass.
+echo "[9] nano_validate_artifact survives jq probes on malformed ship"
+ship_loose='{"phase":"ship","summary":"loose string"}'
+set +e
+bash -ec "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact ship '$ship_loose' 2>/dev/null" >/dev/null
+rc=$?
+set -e
+# Schema failure must return 1 (the documented value), not 5 (jq crash)
+# or any other non-1 non-0 value.
+assert_eq "validator returns 1 (schema fail), not 5 (jq crash)" "1" "$rc"
+
 cd "$TMP_ROOT"
 
 echo

--- a/ci/e2e-structured-artifacts.sh
+++ b/ci/e2e-structured-artifacts.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# e2e-structured-artifacts.sh — PR 3 of the 2026-05-10 architecture
+# audit. Locks the structured artifact contract end-to-end:
+#
+#   - bin/lib/artifact-schemas.sh's per-phase validator accepts valid
+#     shapes and rejects invalid ones.
+#   - bin/save-artifact.sh refuses to write when the per-phase schema
+#     fails, but still writes when it passes.
+#   - --from-session continues to work for manual recovery, marks
+#     artifacts with schema_legacy: true, and emits a deprecation
+#     warning to stderr.
+#   - bin/find-artifact.sh and bin/resolve.sh still load legacy
+#     artifacts so existing stores are not broken.
+#   - core SKILL.md guidance no longer documents --from-session.
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT=$(mktemp -d /tmp/nanostack-structured.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_false() {
+  local name="$1"; shift
+  if ! "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
+  fi
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}expected: %s${NC}\n" "$expected"
+    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
+  fi
+}
+
+# Set up a fresh project + store. Every cell shares this base.
+PROJ="$TMP_ROOT/project"
+STORE="$PROJ/.nanostack"
+mkdir -p "$PROJ" "$STORE"
+cd "$PROJ"
+git init -q
+git config user.email "e2e@test.local"
+git config user.name  "e2e"
+export NANOSTACK_STORE="$STORE"
+
+SAVE="$REPO/bin/save-artifact.sh"
+FIND="$REPO/bin/find-artifact.sh"
+RESOLVE="$REPO/bin/resolve.sh"
+
+echo "Structured Artifact Enforcement E2E"
+echo "==================================="
+echo "Tmp root: $TMP_ROOT"
+echo
+
+# Cell 1: per-phase validator accepts the canonical structured shapes.
+echo "[1] nano_validate_artifact accepts canonical shapes"
+plan_ok=$(jq -n '{phase:"plan",summary:{planned_files:["a.ts"],plan_approval:"manual"},context_checkpoint:{summary:"x"}}')
+review_ok=$(jq -n '{phase:"review",summary:{blocking:0},scope_drift:"none",findings:[],context_checkpoint:{summary:"x"}}')
+qa_ok=$(jq -n '{phase:"qa",summary:{tests_run:5},findings:[],context_checkpoint:{summary:"x"}}')
+sec_ok=$(jq -n '{phase:"security",summary:{total_findings:0},findings:[],context_checkpoint:{summary:"x"}}')
+ship_ok=$(jq -n '{phase:"ship",summary:{pr_number:42,status:"merged"},context_checkpoint:{summary:"x"}}')
+ship_ro=$(jq -n '{phase:"ship",summary:"would have shipped",run_mode:"report_only"}')
+think_ok=$(jq -n '{phase:"think",summary:{value_proposition:"x"}}')
+for kind in plan review qa sec ship ship_ro think; do
+  case "$kind" in
+    plan)    json="$plan_ok";   phase=plan ;;
+    review)  json="$review_ok"; phase=review ;;
+    qa)      json="$qa_ok";     phase=qa ;;
+    sec)     json="$sec_ok";    phase=security ;;
+    ship)    json="$ship_ok";   phase=ship ;;
+    ship_ro) json="$ship_ro";   phase=ship ;;
+    think)   json="$think_ok";  phase=think ;;
+  esac
+  assert_true "validator accepts canonical $kind" \
+    bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
+done
+
+# Cell 2: validator rejects invalid shapes with a stable error format.
+echo "[2] nano_validate_artifact rejects missing required fields"
+plan_bad=$(jq -n '{phase:"plan",summary:{plan_approval:"manual"},context_checkpoint:{summary:"x"}}')
+review_bad=$(jq -n '{phase:"review",summary:{},context_checkpoint:{summary:"x"}}')
+qa_bad=$(jq -n '{phase:"qa",summary:{tests_run:5}}')
+sec_bad=$(jq -n '{phase:"security",summary:"a string"}')
+ship_bad=$(jq -n '{phase:"ship",summary:"loose without report_only"}')
+think_bad=$(jq -n '{phase:"think",summary:"plain string"}')
+for kind in plan review qa sec ship think; do
+  case "$kind" in
+    plan)   json="$plan_bad";   phase=plan ;;
+    review) json="$review_bad"; phase=review ;;
+    qa)     json="$qa_bad";     phase=qa ;;
+    sec)    json="$sec_bad";    phase=security ;;
+    ship)   json="$ship_bad";   phase=ship ;;
+    think)  json="$think_bad";  phase=think ;;
+  esac
+  assert_false "validator rejects invalid $kind" \
+    bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
+done
+
+# Cell 3: save-artifact.sh refuses to write invalid shapes.
+echo "[3] save-artifact.sh exits 1 on invalid shape (no file written)"
+before=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+set +e
+out=$( "$SAVE" plan "$plan_bad" 2>&1 )
+rc=$?
+set -e
+after=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "exit code is 1"           "1"        "$rc"
+assert_eq "no artifact written"      "$before"  "$after"
+echo "$out" | grep -qE 'missing required fields' && \
+  assert_eq "stderr mentions missing required fields" "yes" "yes" || \
+  assert_eq "stderr mentions missing required fields" "yes" "no"
+
+# Cell 4: save-artifact.sh writes valid structured artifacts and the
+# saved file passes nano_artifact_trust (integrity field present).
+echo "[4] save-artifact.sh writes valid structured artifacts"
+saved_plan=$( "$SAVE" plan "$plan_ok" )
+assert_true "plan artifact file exists" test -f "$saved_plan"
+assert_true "plan artifact has context_checkpoint" \
+  bash -c "jq -e '.context_checkpoint != null' '$saved_plan' >/dev/null"
+assert_true "plan artifact has integrity field" \
+  bash -c "jq -e '.integrity != null' '$saved_plan' >/dev/null"
+assert_true "plan artifact has summary.planned_files array" \
+  bash -c "jq -e '(.summary.planned_files | type) == \"array\"' '$saved_plan' >/dev/null"
+
+saved_ship_ro=$( "$SAVE" ship "$ship_ro" )
+assert_true "ship report_only artifact file exists" test -f "$saved_ship_ro"
+
+# Cell 5: --from-session still works, emits deprecation, marks legacy.
+echo "[5] --from-session writes a legacy artifact with deprecation warning"
+set +e
+out=$( "$SAVE" --from-session qa 'N tests passed' 2>&1 )
+rc=$?
+set -e
+saved_legacy=$(echo "$out" | tail -1)
+assert_eq "legacy save exit code is 0" "0" "$rc"
+assert_true "legacy artifact file exists" test -f "$saved_legacy"
+assert_true "legacy artifact has schema_legacy: true" \
+  bash -c "jq -e '.schema_legacy == true' '$saved_legacy' >/dev/null"
+echo "$out" | grep -qE '^save-artifact.sh: --from-session is a legacy mode' && \
+  assert_eq "deprecation warning printed" "yes" "yes" || \
+  assert_eq "deprecation warning printed" "yes" "no"
+
+# Cell 6: legacy artifacts remain readable by find-artifact + resolve.
+echo "[6] legacy artifacts are still readable by downstream tools"
+found=$( "$FIND" qa 30 2>/dev/null )
+assert_true "find-artifact returns the legacy qa artifact" test -f "$found"
+# resolve.sh /ship reads qa upstream; the legacy qa load should not break it
+# but the legacy artifact has summary as string, so upstream_status will
+# be verified (because save-artifact still writes integrity).
+resolved=$( "$RESOLVE" ship 2>/dev/null )
+status_qa=$( echo "$resolved" | jq -r '.upstream_status.qa // ""' )
+assert_eq "resolve.sh upstream_status.qa is verified" "verified" "$status_qa"
+
+# Cell 7: SKILL.md acceptance regex (mirrors the lint job).
+echo "[7] core SKILL.md no longer references --from-session normal save"
+set +e
+out=$( grep -nE -- '--from-session (plan|review|qa|security|ship)' \
+  "$REPO/plan/SKILL.md" "$REPO/review/SKILL.md" "$REPO/qa/SKILL.md" \
+  "$REPO/security/SKILL.md" "$REPO/ship/SKILL.md" 2>&1 )
+rc=$?
+set -e
+assert_eq "spec acceptance regex matches nothing (rc 1)" "1" "$rc"
+
+# Cell 8: save-artifact.sh sources artifact-schemas.sh and calls the
+# validator (the lint guards this too; cell exists so the harness is
+# self-contained for local development).
+echo "[8] save-artifact.sh wires the per-phase validator"
+script="$REPO/bin/save-artifact.sh"
+grep -qF 'artifact-schemas.sh' "$script" && \
+  assert_eq "save-artifact.sh sources artifact-schemas.sh" "yes" "yes" || \
+  assert_eq "save-artifact.sh sources artifact-schemas.sh" "yes" "no"
+grep -qF 'nano_validate_artifact' "$script" && \
+  assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "yes" || \
+  assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "no"
+
+cd "$TMP_ROOT"
+
+echo
+echo "==================================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf "${GREEN}Structured Artifact E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
+  exit 0
+else
+  printf "${RED}Structured Artifact E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/ci/e2e-structured-artifacts.sh
+++ b/ci/e2e-structured-artifacts.sh
@@ -85,7 +85,7 @@ echo
 # Cell 1: per-phase validator accepts the canonical structured shapes.
 echo "[1] nano_validate_artifact accepts canonical shapes"
 plan_ok=$(jq -n '{phase:"plan",summary:{planned_files:["a.ts"],plan_approval:"manual"},context_checkpoint:{summary:"x"}}')
-review_ok=$(jq -n '{phase:"review",summary:{blocking:0},scope_drift:"none",findings:[],context_checkpoint:{summary:"x"}}')
+review_ok=$(jq -n '{phase:"review",summary:{blocking:0},scope_drift:{status:"clean"},findings:[],context_checkpoint:{summary:"x"}}')
 qa_ok=$(jq -n '{phase:"qa",summary:{tests_run:5},findings:[],context_checkpoint:{summary:"x"}}')
 sec_ok=$(jq -n '{phase:"security",summary:{total_findings:0},findings:[],context_checkpoint:{summary:"x"}}')
 ship_ok=$(jq -n '{phase:"ship",summary:{pr_number:42,status:"merged"},context_checkpoint:{summary:"x"}}')

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -363,7 +363,7 @@ JS
     "$NS" phase-start "$phase" >/dev/null
     case "$phase" in
       review)
-        "$ART" "$phase" '{"phase":"review","summary":{"v":1,"blocking":0},"scope_drift":"none","findings":[],"context_checkpoint":{"summary":"e2e review"}}' >/dev/null
+        "$ART" "$phase" '{"phase":"review","summary":{"v":1,"blocking":0},"scope_drift":{"status":"clean"},"findings":[],"context_checkpoint":{"summary":"e2e review"}}' >/dev/null
         ;;
       security|qa)
         "$ART" "$phase" "{\"phase\":\"$phase\",\"summary\":{\"v\":1},\"findings\":[],\"context_checkpoint\":{\"summary\":\"e2e $phase\"}}" >/dev/null

--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -319,8 +319,10 @@ flow_sprint_phase_gate() {
   "$NS" init development --autopilot >/dev/null
 
   # Save think + plan artifacts the way the real skills would.
+  # PR 3 of the 2026-05-10 architecture audit: structured shape with
+  # context_checkpoint for plan, plus the required summary fields.
   "$ART" think '{"phase":"think","summary":{"value":"e2e think"}}' >/dev/null
-  "$ART" plan  '{"phase":"plan","summary":{"value":"e2e plan","planned_files":["index.html","app.js","tests/todo.test.js"]}}' >/dev/null
+  "$ART" plan  '{"phase":"plan","summary":{"value":"e2e plan","planned_files":["index.html","app.js","tests/todo.test.js"],"plan_approval":"manual"},"context_checkpoint":{"summary":"e2e plan"}}' >/dev/null
 
   # Mini TODO app so /review and /qa have something real to look at.
   cat > index.html <<'HTML'
@@ -354,10 +356,19 @@ JS
   # Run the sprint trio. save-artifact.sh auto-calls session.sh
   # phase-complete after writing each artifact, so the harness only
   # needs to start each phase and save its artifact — exactly the
-  # contract a real skill follows.
+  # contract a real skill follows. PR 3 of the 2026-05-10 architecture
+  # audit added the structured shape (findings, scope_drift,
+  # context_checkpoint) to the validator; the fixtures match it.
   for phase in review security qa; do
     "$NS" phase-start "$phase" >/dev/null
-    "$ART" "$phase" "{\"phase\":\"$phase\",\"summary\":{\"v\":1}}" >/dev/null
+    case "$phase" in
+      review)
+        "$ART" "$phase" '{"phase":"review","summary":{"v":1,"blocking":0},"scope_drift":"none","findings":[],"context_checkpoint":{"summary":"e2e review"}}' >/dev/null
+        ;;
+      security|qa)
+        "$ART" "$phase" "{\"phase\":\"$phase\",\"summary\":{\"v\":1},\"findings\":[],\"context_checkpoint\":{\"summary\":\"e2e $phase\"}}" >/dev/null
+        ;;
+    esac
   done
 
   # *** Regression check: current_phase must be null after qa-complete. ***
@@ -390,7 +401,7 @@ JS
   assert_contains "resolve.sh ship loads security artifact" '"security"' "$resolved"
   assert_contains "resolve.sh ship loads qa artifact"       '"qa"'       "$resolved"
 
-  "$ART" ship '{"phase":"ship","summary":{"v":1,"pr_number":null,"ci_passed":true}}' >/dev/null
+  "$ART" ship '{"phase":"ship","summary":{"v":1,"pr_number":null,"ci_passed":true},"context_checkpoint":{"summary":"e2e ship"}}' >/dev/null
   assert_true "ship artifact saved" \
     bash -c "ls '$NANOSTACK_STORE/ship/'*.json 2>/dev/null | head -1 | grep -q ."
 
@@ -465,7 +476,7 @@ flow_local_no_git() {
 
   export NANOSTACK_STORE="$proj/.nanostack"
   "$REPO/bin/session.sh" init development >/dev/null
-  "$REPO/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"v":1}}' >/dev/null
+  "$REPO/bin/save-artifact.sh" plan '{"phase":"plan","summary":{"v":1,"planned_files":[],"plan_approval":"manual"},"context_checkpoint":{"summary":"local-mode plan"}}' >/dev/null
   echo "hola" > notes.txt
 
   local out
@@ -584,7 +595,7 @@ flow_phase_registry() {
   # build appears as null (no artifact dir), plan appears as a path.
   printf '%s' '{"custom_phases":["audit-licenses"],"phase_graph":[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"audit-licenses","depends_on":["build","plan"]},{"name":"ship","depends_on":["audit-licenses"]}]}' > .nanostack/config.json
   "$REPO/bin/save-artifact.sh" plan \
-    '{"phase":"plan","summary":{"goal":"x"},"context_checkpoint":{"summary":"y"}}' >/dev/null
+    '{"phase":"plan","summary":{"goal":"x","planned_files":[],"plan_approval":"manual"},"context_checkpoint":{"summary":"y"}}' >/dev/null
   resolved=$( "$REPO/bin/resolve.sh" audit-licenses 2>/dev/null )
   assert_true "resolver: build dep renders as null" \
     bash -c "echo '$resolved' | jq -e '.upstream_artifacts.build == null' >/dev/null"

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -173,15 +173,27 @@ Behavior depends on `PLAN_APPROVAL` (read above):
 
 After the plan is approved (or auto-approved), do these two steps in order:
 
-**Step 1: Save the artifact.** Run this command now — do not skip it. Include the resolved `plan_approval` so reviewers can see how the plan was approved:
+**Step 1: Save the artifact.** Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a plan artifact requires `summary.planned_files` (array), `summary.plan_approval`, and `context_checkpoint`. `/review` uses `planned_files` for scope drift.
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session plan 'N files planned: file1, file2, ... Key decisions: X, Y. plan_approval: '"$PLAN_APPROVAL"'.'
-```
-
-Or pass full JSON for richer detail (recommended — `/review` uses `planned_files` for scope drift):
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh plan '<json with phase, summary including planned_files array, plan_approval, context_checkpoint>'
+PLAN_JSON=$(jq -n \
+  --argjson planned_files '["file1.ts","file2.ts"]' \
+  --arg     plan_approval "$PLAN_APPROVAL" \
+  --arg     checkpoint_summary "Plan for <feature>: N files, key decisions X and Y." \
+  '{
+     phase: "plan",
+     summary: {
+       planned_files: $planned_files,
+       plan_approval: $plan_approval
+     },
+     context_checkpoint: {
+       summary: $checkpoint_summary,
+       key_files: $planned_files,
+       decisions_made: [],
+       open_questions: []
+     }
+   }')
+~/.claude/skills/nanostack/bin/save-artifact.sh plan "$PLAN_JSON"
 ```
 
 **Step 2: Build and proceed.**

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -182,15 +182,27 @@ Then the full report:
 
 Report progress as you go. After each test group (happy path, error states, edge cases), output results immediately. Don't wait until the end to dump everything.
 
-After completing all tests, save the artifact. Run this command now — do not skip it:
+After completing all tests, save the artifact. Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a qa artifact requires `summary` (object), `findings` (array), and `context_checkpoint`.
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session qa 'N tests passed, M failed. WTF likelihood: low/medium/high.'
-```
-
-Or pass full JSON for richer detail:
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh qa '<json with phase, mode, summary including wtf_likelihood, findings, context_checkpoint>'
+QA_JSON=$(jq -n \
+  --arg  mode             "$QA_MODE" \
+  --argjson summary       '{"tests_run":0,"tests_passed":0,"tests_failed":0,"wtf_likelihood":"low"}' \
+  --argjson findings      '[]' \
+  --arg  checkpoint_summary "QA found N bugs, M passed. WTF likelihood low/medium/high." \
+  '{
+     phase: "qa",
+     mode: $mode,
+     summary: $summary,
+     findings: $findings,
+     context_checkpoint: {
+       summary: $checkpoint_summary,
+       key_files: [],
+       decisions_made: [],
+       open_questions: []
+     }
+   }')
+~/.claude/skills/nanostack/bin/save-artifact.sh qa "$QA_JSON"
 ```
 
 ## Mode Summary

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -1,5 +1,29 @@
 # Artifact Schema
 
+## Save modes
+
+`bin/save-artifact.sh` has two modes:
+
+- **Structured (normal path)**: `save-artifact.sh <phase> '<json>'`. The JSON is validated against the per-phase contract in `bin/lib/artifact-schemas.sh` before write. Core SKILL.md files (`plan`, `review`, `qa`, `security`, `ship`) document only this form. See "Required fields per phase" below for the contract each phase must satisfy.
+- **Legacy `--from-session` (manual recovery)**: `save-artifact.sh --from-session <phase> '<prose summary>'`. Builds a minimal JSON from git state plus the prose summary, marks it with `schema_legacy: true`, emits a deprecation warning to stderr, and writes without strict validation. Use this only when an artifact must be reconstructed after the fact (for example, `/think` ran but did not save, and `/plan` needs the artifact to exist). Normal flows never call this form.
+
+Legacy artifacts saved before this contract are still readable by `bin/find-artifact.sh` and `bin/resolve.sh`; only the write path enforces the structured contract.
+
+## Required fields per phase
+
+| Phase | Required fields |
+|-------|-----------------|
+| `think` | `summary` (object). The `/think` autopilot brief gate enforces the rich set (`value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`); the schema validator only checks summary shape. |
+| `plan` | `summary` (object) with `planned_files` (array) and `plan_approval`; `context_checkpoint` (object). |
+| `review` | `summary` (object); `scope_drift` (any non-null value); `findings` (array); `context_checkpoint` (object). |
+| `qa` | `summary` (object); `findings` (array); `context_checkpoint` (object). |
+| `security` | `summary` (object); `findings` (array); `context_checkpoint` (object). |
+| `ship` (normal mode) | `summary` (object); `context_checkpoint` (object). Typical summary fields: `pr_number`, `pr_url`, `title`, `status`, `ci_passed`. |
+| `ship` (`run_mode == "report_only"`) | `summary` (any value). Report-only ship runs are reports, not release records; no `context_checkpoint` is required. |
+| Custom phases | `phase` and `summary` only (the base contract; no per-phase shape enforced). |
+
+A failing validator prints the missing fields to stderr and `save-artifact.sh` exits 1 before any file is written. Existing artifacts in the store are unaffected.
+
 ## Common fields
 
 All artifacts share this base structure:

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -161,8 +161,15 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
       "src/auth/login.ts",
       "tests/auth/login.test.ts"
     ],
+    "plan_approval": "manual|auto|not_required",
     "risks": ["string"],
     "out_of_scope": ["string"]
+  },
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
   }
 }
 ```
@@ -194,7 +201,13 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
       "line": 42
     }
   ],
-  "conflicts": []
+  "conflicts": [],
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
+  }
 }
 ```
 
@@ -222,7 +235,13 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
       "root_cause": "string",
       "fixed": true
     }
-  ]
+  ],
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
+  }
 }
 ```
 
@@ -251,11 +270,19 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
       "confidence": 8
     }
   ],
-  "conflicts": []
+  "conflicts": [],
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
+  }
 }
 ```
 
 ### /ship
+
+Normal mode:
 
 ```json
 {
@@ -266,7 +293,23 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
     "title": "string",
     "status": "created|merged|reverted",
     "ci_passed": true
+  },
+  "context_checkpoint": {
+    "summary": "string",
+    "key_files": ["string"],
+    "decisions_made": ["string"],
+    "open_questions": ["string"]
   }
+}
+```
+
+Report-only mode (no commit, no PR):
+
+```json
+{
+  "phase": "ship",
+  "run_mode": "report_only",
+  "summary": "string or object describing what would have shipped"
 }
 ```
 

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -15,7 +15,7 @@ Legacy artifacts saved before this contract are still readable by `bin/find-arti
 |-------|-----------------|
 | `think` | `summary` (object). The `/think` autopilot brief gate enforces the rich set (`value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`); the schema validator only checks summary shape. |
 | `plan` | `summary` (object) with `planned_files` (array) and `plan_approval`; `context_checkpoint` (object). |
-| `review` | `summary` (object); `scope_drift` (any non-null value); `findings` (array); `context_checkpoint` (object). |
+| `review` | `summary` (object); `scope_drift` (object with `status` string); `findings` (array); `context_checkpoint` (object). |
 | `qa` | `summary` (object); `findings` (array); `context_checkpoint` (object). |
 | `security` | `summary` (object); `findings` (array); `context_checkpoint` (object). |
 | `ship` (normal mode) | `summary` (object); `context_checkpoint` (object). Typical summary fields: `pr_number`, `pr_url`, `title`, `status`, `ci_passed`. |

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -146,15 +146,31 @@ When a conflict is detected, mark it inline:
 **In `--standard` mode:** Document conflicts inline in output.
 **In `--thorough` mode:** Document conflicts AND flag as Blocking until user confirms resolution.
 
-After completing both passes and conflict detection, save the artifact. Run this command now — do not skip it:
+After completing both passes and conflict detection, save the artifact. Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a review artifact requires `summary` (object), `scope_drift`, `findings` (array), and `context_checkpoint`.
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session review 'N findings (X blocking). Scope drift: none/detected. Conflicts: none/N.'
-```
-
-Or pass full JSON for richer detail:
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh review '<json with phase, mode, summary, scope_drift, findings, conflicts, context_checkpoint>'
+REVIEW_JSON=$(jq -n \
+  --arg  mode        "$REVIEW_MODE" \
+  --argjson summary  '{"blocking":0,"should_fix":0,"nitpicks":0,"positive":0}' \
+  --arg  scope_drift "none" \
+  --argjson findings '[]' \
+  --argjson conflicts '[]' \
+  --arg  checkpoint_summary "Review found N issues, scope drift status, conflict count." \
+  '{
+     phase: "review",
+     mode: $mode,
+     summary: $summary,
+     scope_drift: $scope_drift,
+     findings: $findings,
+     conflicts: $conflicts,
+     context_checkpoint: {
+       summary: $checkpoint_summary,
+       key_files: [],
+       decisions_made: [],
+       open_questions: []
+     }
+   }')
+~/.claude/skills/nanostack/bin/save-artifact.sh review "$REVIEW_JSON"
 ```
 
 ## Mode Summary

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -146,16 +146,16 @@ When a conflict is detected, mark it inline:
 **In `--standard` mode:** Document conflicts inline in output.
 **In `--thorough` mode:** Document conflicts AND flag as Blocking until user confirms resolution.
 
-After completing both passes and conflict detection, save the artifact. Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a review artifact requires `summary` (object), `scope_drift`, `findings` (array), and `context_checkpoint`.
+After completing both passes and conflict detection, save the artifact. Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a review artifact requires `summary` (object), `scope_drift` (object with at least `status`), `findings` (array), and `context_checkpoint`. `bin/sprint-journal.sh` reads `.scope_drift.status`, so the object shape is not optional.
 
 ```bash
 REVIEW_JSON=$(jq -n \
-  --arg  mode        "$REVIEW_MODE" \
-  --argjson summary  '{"blocking":0,"should_fix":0,"nitpicks":0,"positive":0}' \
-  --arg  scope_drift "none" \
-  --argjson findings '[]' \
-  --argjson conflicts '[]' \
-  --arg  checkpoint_summary "Review found N issues, scope drift status, conflict count." \
+  --arg     mode        "$REVIEW_MODE" \
+  --argjson summary     '{"blocking":0,"should_fix":0,"nitpicks":0,"positive":0}' \
+  --argjson scope_drift '{"status":"clean","planned_files":[],"actual_files":[],"out_of_scope_files":[],"missing_files":[]}' \
+  --argjson findings    '[]' \
+  --argjson conflicts   '[]' \
+  --arg     checkpoint_summary "Review found N issues, scope drift status, conflict count." \
   '{
      phase: "review",
      mode: $mode,

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -207,15 +207,29 @@ In `--quick` mode, apply default precedence (security > review) without document
 In `--standard` mode, document conflicts inline.
 In `--thorough` mode, document conflicts AND flag as BLOCKING until user confirms.
 
-After completing the audit and conflict detection, save the artifact. Run this command now — do not skip it:
+After completing the audit and conflict detection, save the artifact. Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a security artifact requires `summary` (object), `findings` (array), and `context_checkpoint`.
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session security 'N findings (X critical). OWASP: covered A01-A10. Conflicts: none/N.'
-```
-
-Or pass full JSON for richer detail:
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh security '<json with phase, mode, summary, findings, conflicts, context_checkpoint>'
+SEC_JSON=$(jq -n \
+  --arg  mode              "$SEC_MODE" \
+  --argjson summary        '{"total_findings":0,"critical":0,"high":0,"medium":0,"low":0}' \
+  --argjson findings       '[]' \
+  --argjson conflicts      '[]' \
+  --arg  checkpoint_summary "Security audit found N findings across OWASP categories." \
+  '{
+     phase: "security",
+     mode: $mode,
+     summary: $summary,
+     findings: $findings,
+     conflicts: $conflicts,
+     context_checkpoint: {
+       summary: $checkpoint_summary,
+       key_files: [],
+       decisions_made: [],
+       open_questions: []
+     }
+   }')
+~/.claude/skills/nanostack/bin/save-artifact.sh security "$SEC_JSON"
 ```
 
 ## Mode Summary

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -223,16 +223,33 @@ Before creating the PR, verify the standards in `ship/references/repo-quality-st
 
 After shipping, do these steps in order:
 
-**Step 1: Save the artifact.** Run this command now — do not skip it:
+**Step 1: Save the artifact.** Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a normal-mode ship artifact requires `summary` (object) and `context_checkpoint`. Report-only ship runs may save a looser shape with `run_mode: "report_only"`.
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session ship 'PR #N: title. Status: merged/open. CI: passed/failed.'
-~/.claude/skills/nanostack/bin/sprint-journal.sh
-```
-
-Or pass full JSON for richer detail:
-```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh ship '<json with phase, summary including pr_number, pr_url, title, status, ci_passed, context_checkpoint>'
+SHIP_JSON=$(jq -n \
+  --argjson pr_number "$PR_NUMBER" \
+  --arg     pr_url    "$PR_URL" \
+  --arg     title     "$PR_TITLE" \
+  --arg     status    "$PR_STATUS" \
+  --argjson ci_passed "$CI_PASSED" \
+  --arg     checkpoint_summary "PR #N <title> shipped, CI status, deploy result." \
+  '{
+     phase: "ship",
+     summary: {
+       pr_number: $pr_number,
+       pr_url:    $pr_url,
+       title:     $title,
+       status:    $status,
+       ci_passed: $ci_passed
+     },
+     context_checkpoint: {
+       summary: $checkpoint_summary,
+       key_files: [],
+       decisions_made: [],
+       open_questions: []
+     }
+   }')
+~/.claude/skills/nanostack/bin/save-artifact.sh ship "$SHIP_JSON"
 ~/.claude/skills/nanostack/bin/sprint-journal.sh
 ```
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -225,7 +225,17 @@ After shipping, do these steps in order:
 
 **Step 1: Save the artifact.** Run this command now — do not skip it. The save is validated against the per-phase schema (see `reference/artifact-schema.md`); a normal-mode ship artifact requires `summary` (object) and `context_checkpoint`. Report-only ship runs may save a looser shape with `run_mode: "report_only"`.
 
+The snippet below sets safe JSON defaults first so `jq --argjson` does not fail when a shell variable is unset (`PR_NUMBER` may legitimately be unset in local-mode ships, on a no-PR push, or when CI has not reported yet).
+
 ```bash
+# Safe defaults so --argjson always gets valid JSON, even when a
+# variable was not exported in this ship path.
+: "${PR_NUMBER:=null}"
+: "${PR_URL:=}"
+: "${PR_TITLE:=}"
+: "${PR_STATUS:=open}"
+: "${CI_PASSED:=false}"
+
 SHIP_JSON=$(jq -n \
   --argjson pr_number "$PR_NUMBER" \
   --arg     pr_url    "$PR_URL" \
@@ -251,6 +261,13 @@ SHIP_JSON=$(jq -n \
    }')
 ~/.claude/skills/nanostack/bin/save-artifact.sh ship "$SHIP_JSON"
 ~/.claude/skills/nanostack/bin/sprint-journal.sh
+```
+
+For a report-only ship (no PR cut, no commit), save the artifact with `run_mode: "report_only"` instead so the validator accepts the looser shape:
+
+```bash
+~/.claude/skills/nanostack/bin/save-artifact.sh ship \
+  '{"phase":"ship","run_mode":"report_only","summary":"Pre-flight check only; nothing was pushed."}'
 ```
 
 **Step 2: Proof block.** Before "How to see the result", emit a proof block summarizing what was verified during the sprint. Read it from session phase_log:


### PR DESCRIPTION
## Summary

Core skill saves used to accept any shape with `.phase` and `.summary`. Downstream consumers (`resolve.sh`, `restore-context.sh`, `sprint-journal.sh`, release-readiness) hoped the fields they needed were there but had no way to require them. `/think` had already moved to a structured artifact in an earlier round; this PR finishes the job for the other four core phases and adds the missing enforcement at write time.

`bin/lib/artifact-schemas.sh` exposes `nano_validate_artifact <phase> <json>` and checks per-phase required fields. `bin/save-artifact.sh` calls it on every structured-mode save and exits 1 with the missing fields listed on stderr. `--from-session` is preserved for manual recovery but marked legacy (writes `schema_legacy: true`, prints a deprecation warning, bypasses strict validation).

## What changes

Per-phase required fields (enforced by `bin/lib/artifact-schemas.sh`):

| Phase | Required fields |
|-------|-----------------|
| `think` | `summary` (object). The `/think` autopilot brief gate already enforces the rich set. |
| `plan` | `summary.planned_files` (array); `summary.plan_approval`; `context_checkpoint` (object). |
| `review` | `summary` (object); `scope_drift` (object with `status` string); `findings` (array); `context_checkpoint`. |
| `qa` | `summary` (object); `findings` (array); `context_checkpoint`. |
| `security` | `summary` (object); `findings` (array); `context_checkpoint`. |
| `ship` (normal) | `summary` (object); `context_checkpoint`. |
| `ship` (`run_mode: "report_only"`) | `summary` (any value). Report-only runs are reports, not release records. |
| Custom | `phase` + `summary` only (base contract unchanged). |

The five core SKILL.md files (`plan`, `review`, `qa`, `security`, `ship`) now document only the structured save form (`jq -n` inline example). `--from-session` no longer appears in their normal-flow guidance. `plan/SKILL.md` keeps one `--from-session` line for retroactive `/think` recovery, which the lint regex excludes by phase name.

## What does not change

- Existing artifacts in the store remain readable. The strict contract applies on the write path only; `find-artifact.sh` and `resolve.sh` continue to load legacy artifacts.
- `--from-session` still works (manual recovery, ad-hoc tooling). It just emits a deprecation warning, marks the artifact with `schema_legacy: true`, and bypasses strict validation since the prose-blob form cannot satisfy `summary` as object.
- The `think` autopilot brief gate is unchanged; the validator only checks summary shape and leaves the rich-field enforcement to `/think` itself.
- `bin/save-artifact.sh` integrity hashing, secret redaction, and finding truncation paths are unchanged.

## Implementation

`bin/lib/artifact-schemas.sh` (new): exposes `nano_validate_artifact` with internal `_nano_validate_field` and `_nano_validate_emit` helpers. The function accumulates missing-field errors and prints them in one stable line so callers can grep.

`bin/save-artifact.sh`: sources the new library and calls `nano_validate_artifact` after the existing base validation (`.phase` matches, `.phase` and `.summary` present). `--from-session` sets `LEGACY_MODE=1` to skip the validator and writes `schema_legacy: true` on the artifact.

`plan/SKILL.md`, `review/SKILL.md`, `qa/SKILL.md`, `security/SKILL.md`, `ship/SKILL.md`: each phase now shows a concrete `jq -n` save example that satisfies the validator. `ship/SKILL.md` includes safe defaults (`: "${PR_NUMBER:=null}"`) so the snippet works when shell variables are unset, plus a separate report-only example.

`reference/artifact-schema.md`: new "Save modes" + "Required fields per phase" section. Every per-phase JSON example now includes `context_checkpoint`; the `/nano` example also lists `summary.plan_approval`. Both `/ship` examples (normal + report_only) are present.

`.github/workflows/lint.yml`: new `core-skills-save-structured` job. Enforces the spec acceptance regex (`grep -nE -- '--from-session (plan|review|qa|security|ship)' plan/SKILL.md review/SKILL.md qa/SKILL.md security/SKILL.md ship/SKILL.md` returns nothing) and checks that `save-artifact.sh` sources `artifact-schemas.sh` + calls `nano_validate_artifact`. Two existing lint fixtures (resolve and analytics test setups) were updated to the strict plan shape.

`ci/e2e-structured-artifacts.sh` (new): 9 cells, 31 checks. Covers validator accept/reject, save write/refusal, `--from-session` deprecation + `schema_legacy` flag, legacy read path, lint regex, and the jq-probe-safe behavior on malformed ship payloads.

## Codex review trail (six iterations)

| Pass | Finding | Fix |
|------|---------|-----|
| 1 | `tests/run.sh` fixtures broke; `ship/SKILL.md` snippet failed with unset vars | Updated local fixtures with the strict shape; added `: "${VAR:=default}"` defaults to the ship snippet |
| 2 | `reference/artifact-schema.md` per-phase examples still showed the pre-PR-3 shape | Added `context_checkpoint` to every example; added `summary.plan_approval` to plan; split ship into normal + report_only |
| 3 | `tests/e2e-user-flows.sh` fixtures (local-only) failed under strict mode | Updated `plan_approval` + moved `scope_drift` to top-level object |
| 4 | `scope_drift: "none"` (string) silently dropped `.scope_drift.status` in sprint-journal | Validator now requires `scope_drift` as object; all fixtures + SKILL.md example updated |
| 5 | `.github/workflows/lint.yml` plan fixtures still used pre-PR-3 shape; `scope_drift: {}` (empty) bypassed the check | Updated lint fixtures; validator now requires `.scope_drift.status` (non-null string) |
| 6 | Ship validator's jq probe crashed (rc 5) on string-summary payloads under `set -e` | Used `?` operator on `.summary.run_mode` indexing; added Cell 9 regression lock |

Final pass clean: "I did not find any correctness issues that should block this patch."

## Tests

All checks green locally:

- `ci/e2e-structured-artifacts.sh`: 31 checks (new harness).
- `ci/e2e-user-flows.sh`: 100 checks (fixtures updated for plan + scope_drift).
- `ci/e2e-custom-stack-flows.sh`: 40 checks.
- `ci/e2e-custom-stack-examples.sh`: 51 checks (compliance-release fixtures updated).
- `ci/e2e-artifact-trust.sh`: 29 checks (PR 2 contract preserved).
- `ci/e2e-delivery-matrix.sh`: 17 cells (fake_complete fixtures updated).
- `ci/e2e-examples.sh`: 40 checks (per-archetype fixtures updated).
- `ci/e2e-think-flows.sh`: 32 checks.
- `ci/e2e-think-archetypes.sh`: 25 checks.
- `ci/e2e-onboarding-flows.sh`: 34 checks.
- `tests/run.sh` (local-only): 83 tests.
- `tests/e2e-user-flows.sh` (local-only): 5 checks.

Total: 487 checks pass across 10 CI suites + 2 local suites.

## Files

New:

- `bin/lib/artifact-schemas.sh`
- `ci/e2e-structured-artifacts.sh`

Changed:

- `bin/save-artifact.sh`: validator wiring + `--from-session` legacy mode.
- `plan/SKILL.md`, `review/SKILL.md`, `qa/SKILL.md`, `security/SKILL.md`, `ship/SKILL.md`: structured save documentation only.
- `reference/artifact-schema.md`: trust contract + per-phase examples updated.
- `.github/workflows/lint.yml`: new `core-skills-save-structured` job; two lint fixtures updated.
- `.github/workflows/e2e.yml`: new job for `ci/e2e-structured-artifacts.sh`.
- `ci/e2e-custom-stack-examples.sh`, `ci/e2e-delivery-matrix.sh`, `ci/e2e-examples.sh`, `ci/e2e-user-flows.sh`: fixtures updated for strict shape.

## Spec

PR 3 of the 2026-05-10 Nanostack Architecture Audit vNext. Closes the P1 finding "Structured Artifact Contract Is Still Optional For Most Core Skills".

Next: PR 4, Graph-Aware Session And Next-Step. Targets `bin/session.sh` and `bin/next-step.sh` so session lifecycle and next-step output consume the same `phase_graph` as the conductor.

## Test plan

- [ ] `bash ci/e2e-structured-artifacts.sh` reports 31 of 31 checks passed.
- [ ] Existing CI E2E suites continue to pass (user-flows, custom-stack-flows, custom-stack-examples, artifact-trust, delivery-matrix, examples, think-flows, think-archetypes, onboarding-flows).
- [ ] Existing lint jobs continue to pass, plus the new `core-skills-save-structured` job.
- [ ] Manual: save a malformed plan artifact (`{"phase":"plan","summary":{}}`), confirm `save-artifact.sh` exits 1 and lists the missing fields.
- [ ] Manual: save the canonical plan artifact from `reference/artifact-schema.md`, confirm it writes successfully.
- [ ] Manual: `save-artifact.sh --from-session qa 'manual recovery'`, confirm it writes with `schema_legacy: true` and emits the deprecation warning.