### PR TITLE
session: graph-aware lifecycle (PR 4 of architecture vNext)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,7 @@ jobs:
           ci/e2e-onboarding-flows.sh
 
   e2e-graph-aware-session:
-    name: E2E Graph-aware Session + Next-step (7 cells)
+    name: E2E Graph-aware Session + Next-step (10 cells)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # PR 4 of the 2026-05-10 architecture audit. Locks the graph-aware

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -170,6 +170,24 @@ jobs:
           chmod +x ci/e2e-onboarding-flows.sh
           ci/e2e-onboarding-flows.sh
 
+  e2e-graph-aware-session:
+    name: E2E Graph-aware Session + Next-step (7 cells)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # PR 4 of the 2026-05-10 architecture audit. Locks the graph-aware
+    # session lifecycle: session.json snapshots phase_graph at init,
+    # phase-complete fills next_phase + ready_phases from the snapshot,
+    # next-step.sh surfaces custom required_before_ship and keeps
+    # guided wording free of phase-graph jargon.
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq is present
+        run: jq --version
+      - name: Run graph-aware session E2E
+        run: |
+          chmod +x ci/e2e-graph-aware-session.sh
+          ci/e2e-graph-aware-session.sh
+
   e2e-structured-artifacts:
     name: E2E Structured Artifact Contract (9 cells)
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3357,6 +3357,60 @@ jobs:
           fi
           echo "OK: guard concurrency tier uses the phase registry."
 
+  session-graph-aware-wiring:
+    name: session.sh + next-step.sh route through the phase registry
+    runs-on: ubuntu-latest
+    # PR 4 of the 2026-05-10 architecture audit. The case-statement
+    # next-phase logic in session.sh used to hardcode the built-in
+    # sprint sequence; the registry-aware replacement must stay in
+    # place so custom workflow stacks advance correctly. Same gate
+    # for next-step.sh: it must source the phase registry and emit
+    # the ready_phases field that downstream skills now read.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: session.sh sources the phase registry
+        run: |
+          set -e
+          script=bin/session.sh
+          if ! grep -qF 'lib/phases.sh' "$script"; then
+            echo "FAIL: $script does not source bin/lib/phases.sh."
+            exit 1
+          fi
+          if ! grep -qF 'nano_phase_ready_from_graph' "$script"; then
+            echo "FAIL: $script does not call nano_phase_ready_from_graph."
+            echo "The next-phase computation must consume the active phase_graph."
+            exit 1
+          fi
+      - name: session.sh init writes phase_graph + ready_phases
+        run: |
+          set -e
+          script=bin/session.sh
+          for field in phase_graph ready_phases; do
+            if ! grep -qE "^\s*$field:" "$script"; then
+              echo "FAIL: $script does not write the $field field at session init."
+              exit 1
+            fi
+          done
+      - name: next-step.sh emits ready_phases and routes through phases.sh
+        run: |
+          set -e
+          script=bin/next-step.sh
+          if ! grep -qF 'lib/phases.sh' "$script"; then
+            echo "FAIL: $script does not source bin/lib/phases.sh."
+            exit 1
+          fi
+          if ! grep -qF 'ready_phases:' "$script"; then
+            echo "FAIL: $script does not emit ready_phases in its JSON output."
+            exit 1
+          fi
+          if ! grep -qF 'phase_graph' "$script"; then
+            echo "FAIL: $script does not read .phase_graph from session.json."
+            exit 1
+          fi
+          echo "OK: graph-aware wiring is present in both scripts."
+
   core-skills-save-structured:
     name: Core skills save structured artifacts (no --from-session normal path)
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1044,12 +1044,21 @@ jobs:
 
           "$NS" init feature --profile guided --autopilot >/dev/null
 
+          # PR 4 of the 2026-05-10 audit made session.sh init seed
+          # next_phase with the graph root (think). Walk past think
+          # and plan so the assertions land on the post-build state
+          # the rest of this matrix exercises.
+          for phase in think plan; do
+            "$NS" phase-start "$phase" >/dev/null
+            "$NS" phase-complete "$phase" >/dev/null
+          done
+
           # Empty post-build state: review/security/qa all pending.
           out=$("$NEXT" --json)
           echo "$out" | jq -e '.profile == "guided"' >/dev/null || { echo "FAIL: profile not propagated"; fail=1; }
-          echo "$out" | jq -e '.next_phase == "review"' >/dev/null || { echo "FAIL: empty state should suggest review"; fail=1; }
-          echo "$out" | jq -e '.can_ship == false' >/dev/null || { echo "FAIL: empty state should not allow ship"; fail=1; }
-          echo "$out" | jq -e '.pending_phases | length == 3' >/dev/null || { echo "FAIL: empty state should list 3 pending peers"; fail=1; }
+          echo "$out" | jq -e '.next_phase == "review"' >/dev/null || { echo "FAIL: post-build state should suggest review"; fail=1; }
+          echo "$out" | jq -e '.can_ship == false' >/dev/null || { echo "FAIL: post-build state should not allow ship"; fail=1; }
+          echo "$out" | jq -e '.pending_phases | length == 3' >/dev/null || { echo "FAIL: post-build state should list 3 pending peers"; fail=1; }
           echo "$out" | jq -e '.user_message | length > 0' >/dev/null || { echo "FAIL: user_message empty"; fail=1; }
 
           # Legacy text mode: review/security/qa caller passes its own phase.
@@ -1061,7 +1070,7 @@ jobs:
           # Mark review + security + qa complete in session phase_log.
           for phase in review security qa; do
             "$NS" phase-start "$phase" >/dev/null
-            jq --arg p "$phase" '.phase_log[-1].status = "completed"' .nanostack/session.json > .tmp && mv .tmp .nanostack/session.json
+            "$NS" phase-complete "$phase" >/dev/null
           done
           out=$("$NEXT" --json)
           echo "$out" | jq -e '.next_phase == "ship"' >/dev/null || { echo "FAIL: all peers done should suggest ship"; fail=1; }

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -213,7 +213,14 @@ _nano_phase_graph_is_valid() {
 nano_phase_graph_json() {
   local config
   config=$(_nano_phases_resolve_config "${1:-}") || true
-  local default_graph='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"ship","depends_on":["review","qa","security"]}]'
+  # Node order under `review`/`qa`/`security` matches the legacy
+  # PEERS list in bin/next-step.sh (review, security, qa). Downstream
+  # consumers (next-step's required_before_ship, sprint-journal,
+  # docs) expect that ordering, so the graph is the single source
+  # of truth and they read from it. PR 4 of the 2026-05-10 audit
+  # made the order load-bearing; Codex caught a sort-induced drift
+  # on the seventh review pass.
+  local default_graph='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"ship","depends_on":["review","security","qa"]}]'
   if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
     local graph
     graph=$(jq -c '.phase_graph // empty' "$config" 2>/dev/null)

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -275,14 +275,21 @@ nano_phase_ready_from_graph() {
     . as $graph
     | $done as $base
     # Auto-promote "build" when its declared deps (if any) are all
-    # already completed. Treat a "build"-less graph as a no-op for
-    # this step.
+    # already completed AND build itself is not currently in_progress.
+    # The in_progress check is the load-bearing piece: a caller can
+    # record the build handoff with session.sh phase-start build, and
+    # treating that as satisfied would unblock review/qa/security
+    # while build is still running. Codex caught the racy promotion
+    # on the PR 4 sixth review pass. Treat a "build"-less graph as a
+    # no-op for this step.
     | (
         ($graph | map(select(.name == "build")) | first // null) as $build_node
         | if $build_node == null then $base
           else
             ($build_node.depends_on // []) as $bdeps
-            | if ($bdeps | all(. as $d | $base | any(. == $d))) then ($base + ["build"] | unique)
+            | if (($bdeps | all(. as $d | $base | any(. == $d)))
+                  and (($active | any(. == "build")) | not))
+              then ($base + ["build"] | unique)
               else $base
               end
           end

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -228,6 +228,77 @@ nano_phase_graph_json() {
   printf '%s\n' "$default_graph"
 }
 
+# Compute the ready phases for a phase_graph given the set of phases
+# that have already been completed (and optionally the phases currently
+# in_progress). A phase is "ready" when every entry in its depends_on
+# is in the completed set AND the phase itself is neither completed nor
+# in_progress. Returns the ready phase names, one per line, in the
+# graph's declared order so callers that need a single "next_phase"
+# pick the first line.
+#
+# The conductor's "build" stage produces no session-tracked artifact
+# (developers do the work, no phase-complete call lands), so the helper
+# treats "build" as auto-satisfied for dependency checks unless the
+# caller passes it explicitly in completed. Without that escape hatch,
+# the default sprint graph (review/qa/security depend on build) would
+# never advance.
+#
+# Arguments:
+#   $1  graph JSON array of {name, depends_on}
+#   $2  completed JSON array of phase names
+#   $3  in_progress JSON array of phase names (optional, defaults to [])
+#
+# PR 4 of the 2026-05-10 architecture audit: replaces the hardcoded
+# next-phase case statement in bin/session.sh with registry-aware
+# traversal so custom workflow stacks get the same lifecycle support
+# as the built-in sprint.
+nano_phase_ready_from_graph() {
+  local graph="${1:?nano_phase_ready_from_graph requires a graph JSON argument}"
+  local completed="${2:-[]}"
+  local in_progress="${3:-[]}"
+  command -v jq >/dev/null 2>&1 || return 1
+  # IN() is used instead of `index()` because some jq builds (1.6 on
+  # macOS in particular) refuse `array | index(.field)` when the field
+  # is computed inside a .[] context, while IN() accepts the stream
+  # syntax cleanly. The filter does not need the returned position,
+  # only set membership.
+  #
+  # "build" is auto-promoted into the satisfied set, but ONLY when its
+  # own depends_on entries are all satisfied. Without that gate the
+  # default sprint graph (review/qa/security depend on build, build
+  # depends on plan) would report review/qa/security as ready right
+  # after /think completes, even though /plan has not run yet.
+  echo "$graph" | jq -r \
+    --argjson done "$completed" \
+    --argjson active "$in_progress" \
+    '
+    . as $graph
+    | $done as $base
+    # Auto-promote "build" when its declared deps (if any) are all
+    # already completed. Treat a "build"-less graph as a no-op for
+    # this step.
+    | (
+        ($graph | map(select(.name == "build")) | first // null) as $build_node
+        | if $build_node == null then $base
+          else
+            ($build_node.depends_on // []) as $bdeps
+            | if ($bdeps | all(. as $d | $base | any(. == $d))) then ($base + ["build"] | unique)
+              else $base
+              end
+          end
+      ) as $satisfied
+    | [.[]
+        | select(
+            (.name | IN($satisfied[]) | not)
+            and (.name | IN($active[]) | not)
+            and ((.depends_on // []) | all(. as $d | $satisfied | any(. == $d)))
+          )
+        | .name
+      ]
+    | .[]
+    ' 2>/dev/null
+}
+
 # Topologically sort a phase_graph and emit the phase names, one per
 # line. Uses Kahn's algorithm (the same shape as the cycle check in
 # the validator). The graph is assumed valid; pass a graph that has

--- a/bin/lib/phases.sh
+++ b/bin/lib/phases.sh
@@ -214,13 +214,16 @@ nano_phase_graph_json() {
   local config
   config=$(_nano_phases_resolve_config "${1:-}") || true
   # Node order under `review`/`qa`/`security` matches the legacy
-  # PEERS list in bin/next-step.sh (review, security, qa). Downstream
-  # consumers (next-step's required_before_ship, sprint-journal,
-  # docs) expect that ordering, so the graph is the single source
-  # of truth and they read from it. PR 4 of the 2026-05-10 audit
-  # made the order load-bearing; Codex caught a sort-induced drift
-  # on the seventh review pass.
-  local default_graph='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"ship","depends_on":["review","security","qa"]}]'
+  # hardcoded progression in bin/session.sh that this PR replaces:
+  # review -> qa -> security -> ship. Next-phase walks graph order,
+  # so the graph IS the progression contract. required_before_ship
+  # ends up as ["review","qa","security"] (graph-derived order);
+  # consumers that need set semantics work either way and the doc
+  # is the single source of truth on the wire shape. Two earlier
+  # Codex passes pulled in opposite directions on the array order
+  # vs the progression; we side with the progression because that
+  # is what the previous PR (PR 4) explicitly promised to preserve.
+  local default_graph='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"ship","depends_on":["review","qa","security"]}]'
   if [ -n "$config" ] && command -v jq >/dev/null 2>&1; then
     local graph
     graph=$(jq -c '.phase_graph // empty' "$config" 2>/dev/null)

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -103,43 +103,56 @@ fi
 # duplicate starts.
 SESSION_READY="[]"
 SESSION_NEXT=""
+HAS_GRAPH_AWARE_SESSION=0
 HAS_SESSION=0
 if [ -f "$SESSION_FILE" ]; then
   HAS_SESSION=1
-  SESSION_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
-  SESSION_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
+  # A session that was written by a pre-PR-4 build has neither
+  # phase_graph nor ready_phases. Detect that and route through the
+  # legacy artifact-based lookup so an in-progress sprint upgraded
+  # mid-flight still gets sensible next-step output. Codex flagged
+  # the upgrade regression on the PR 4 fifth review pass.
+  if jq -e '(.phase_graph // []) | length > 0' "$SESSION_FILE" >/dev/null 2>&1; then
+    HAS_GRAPH_AWARE_SESSION=1
+    SESSION_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
+    SESSION_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
+  fi
 fi
 
-if [ "$HAS_SESSION" = "1" ]; then
+# can_ship derives from the graph contract, not from NEXT_PHASE.
+# It means "every phase in required_before_ship has completed" so a
+# graph where ship is parallel-ready alongside another phase still
+# reports can_ship=true. Codex flagged the dependency-vs-display
+# mix-up on the PR 4 fifth review pass.
+compute_can_ship_from_session() {
+  jq -r '
+    (.phase_graph // []) as $g
+    | def ancestors($name):
+        ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
+        | $deps + ($deps | map(ancestors(.)) | add // []);
+      ([.phase_log[]? | select(.status == "completed") | .phase] | unique) as $done
+      | (ancestors("ship") | unique | map(select(. != "think" and . != "plan" and . != "build"))) as $required
+      | ($required - $done | length == 0)
+  ' "$SESSION_FILE" 2>/dev/null || echo "false"
+}
+
+if [ "$HAS_GRAPH_AWARE_SESSION" = "1" ]; then
   PENDING_JSON="$SESSION_READY"
   NEXT_PHASE="$SESSION_NEXT"
   PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
+  CAN_SHIP=$(compute_can_ship_from_session)
   if [ -z "$NEXT_PHASE" ] || [ "$NEXT_PHASE" = "null" ]; then
-    # No phase is ready right now. This can mean two things:
-    #   - The sprint is finished (everything past ship completed).
-    #   - The sprint has not started yet and the initial ready set
-    #     was not snapshotted (legacy session pre-PR-4).
-    # Safe answer: "no specific next phase" with can_ship gated on
-    # ship having actually completed. We never collapse to "ship"
-    # implicitly; that wrongly suggested a fresh session was ship-
-    # ready (Codex caught this on the PR 4 first review pass).
     NEXT_PHASE=""
     ship_done=$(jq -r '[.phase_log[]? | select(.phase == "ship" and .status == "completed")] | length' "$SESSION_FILE" 2>/dev/null || echo "0")
     if [ "$ship_done" -gt 0 ]; then
       NEXT_PHASE="compound"
-      CAN_SHIP="true"
-    else
-      CAN_SHIP="false"
     fi
-  elif [ "$NEXT_PHASE" = "ship" ] || [ "$NEXT_PHASE" = "compound" ]; then
-    CAN_SHIP="true"
-  else
-    CAN_SHIP="false"
   fi
 else
-  # No session file. Fall back to the legacy artifact-based lookup
-  # so a host that drives /review/security/qa without going through
-  # session.sh init still gets sensible output.
+  # No session file OR a legacy session without phase_graph. Fall
+  # back to the artifact-based lookup so a host that drives
+  # /review/security/qa without going through (or before) the
+  # graph-aware session contract still gets sensible output.
   PENDING_JSON="[]"
   for phase in $PEERS; do
     if ! phase_completed "$phase"; then
@@ -199,12 +212,12 @@ fi
 # hardcoded shape continue to receive it when the session uses the
 # default graph.
 REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
-if [ "$HAS_SESSION" = "1" ]; then
+if [ "$HAS_GRAPH_AWARE_SESSION" = "1" ]; then
   # The graph snapshot inside session.json is authoritative. For the
   # default sprint that yields ["review","qa","security"] (same set
   # as the legacy default); for a custom graph it returns the actual
   # transitive chain ship depends on. Falls back to the legacy default
-  # if the jq filter fails (legacy session pre-PR-4).
+  # if the jq filter fails.
   REQUIRED_BEFORE_SHIP_JSON=$(jq -c '
     (.phase_graph // []) as $g
     | def ancestors($name):

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -16,6 +16,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
+[ -f "$SCRIPT_DIR/lib/phases.sh" ] && . "$SCRIPT_DIR/lib/phases.sh"
 
 JSON=0
 CURRENT=""
@@ -81,30 +82,65 @@ if [ -f "$SESSION_FILE" ]; then
   PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION_FILE" 2>/dev/null || echo "professional")
 fi
 
-PENDING_JSON="[]"
-for phase in $PEERS; do
-  if ! phase_completed "$phase"; then
-    PENDING_JSON=$(echo "$PENDING_JSON" | jq --arg p "$phase" '. + [$p]')
+# PR 4 of the 2026-05-10 architecture audit: when the session has a
+# non-default phase_graph (custom workflow stack), read next_phase and
+# ready_phases that session.sh already computed graph-aware. The
+# review/security/qa shape only describes the built-in sprint, so a
+# compliance-release graph like build -> license-audit -> ...
+# would otherwise see next_phase always default to "review".
+GRAPH_AWARE_NEXT=""
+GRAPH_AWARE_READY="[]"
+IS_CUSTOM_GRAPH=0
+if [ -f "$SESSION_FILE" ]; then
+  default_graph_names="think plan build review qa security ship"
+  session_graph_names=$(jq -r '(.phase_graph // []) | map(.name) | join(" ")' "$SESSION_FILE" 2>/dev/null || echo "")
+  if [ -n "$session_graph_names" ] && [ "$session_graph_names" != "$default_graph_names" ]; then
+    IS_CUSTOM_GRAPH=1
+    GRAPH_AWARE_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
+    GRAPH_AWARE_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
   fi
-done
+fi
 
-NEXT_PHASE=$(echo "$PENDING_JSON" | jq -r '.[0] // "ship"')
-PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
-if [ "$PENDING_COUNT" -eq 0 ]; then
-  if phase_completed "ship"; then
-    NEXT_PHASE="compound"
-    CAN_SHIP="true"
-  else
+if [ "$IS_CUSTOM_GRAPH" = "1" ]; then
+  PENDING_JSON="$GRAPH_AWARE_READY"
+  NEXT_PHASE="${GRAPH_AWARE_NEXT:-ship}"
+  if [ -z "$NEXT_PHASE" ] || [ "$NEXT_PHASE" = "null" ]; then
     NEXT_PHASE="ship"
     CAN_SHIP="true"
+  elif [ "$NEXT_PHASE" = "ship" ] || [ "$NEXT_PHASE" = "compound" ]; then
+    CAN_SHIP="true"
+  else
+    CAN_SHIP="false"
   fi
 else
-  CAN_SHIP="false"
+  PENDING_JSON="[]"
+  for phase in $PEERS; do
+    if ! phase_completed "$phase"; then
+      PENDING_JSON=$(echo "$PENDING_JSON" | jq --arg p "$phase" '. + [$p]')
+    fi
+  done
+
+  NEXT_PHASE=$(echo "$PENDING_JSON" | jq -r '.[0] // "ship"')
+  PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
+  if [ "$PENDING_COUNT" -eq 0 ]; then
+    if phase_completed "ship"; then
+      NEXT_PHASE="compound"
+      CAN_SHIP="true"
+    else
+      NEXT_PHASE="ship"
+      CAN_SHIP="true"
+    fi
+  else
+    CAN_SHIP="false"
+  fi
 fi
 
 # user_message wording rules:
 #  - guided: one plain action, no slash commands, no phase jargon.
 #  - professional: name the phase explicitly (callers print evidence).
+# Custom phases (anything outside the built-in sprint) fall back to
+# generic wording that uses the phase name without exposing "graph"
+# or "DAG" jargon to a Guided user.
 case "$PROFILE:$NEXT_PHASE" in
   guided:review)   MSG="I will check that what was built actually works and has no obvious risks." ;;
   guided:security) MSG="I will check for risky patterns or leaked secrets." ;;
@@ -116,20 +152,41 @@ case "$PROFILE:$NEXT_PHASE" in
   professional:qa)       MSG="Run /qa to verify the feature works." ;;
   professional:ship)     MSG="Run /ship to commit, push, and create the PR." ;;
   professional:compound) MSG="Sprint complete. Run /compound to record learnings." ;;
-  *) MSG="" ;;
+  guided:*)              MSG="I will run the $NEXT_PHASE step next." ;;
+  professional:*)        MSG="Run /$NEXT_PHASE next." ;;
+  *)                     MSG="" ;;
 esac
+
+# required_before_ship reflects the active graph: for the default
+# sprint that is ["review","security","qa"]; for a custom graph it is
+# every phase that ship transitively depends on (excluding think/plan/
+# build, which are pre-build phases). Consumers that gated on the
+# hardcoded shape continue to receive it when the session uses the
+# default graph.
+REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
+if [ "$IS_CUSTOM_GRAPH" = "1" ] && [ -f "$SESSION_FILE" ]; then
+  REQUIRED_BEFORE_SHIP_JSON=$(jq -c '
+    (.phase_graph // []) as $g
+    | def ancestors($name):
+        ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
+        | $deps + ($deps | map(ancestors(.)) | add // []);
+      ancestors("ship") | unique | map(select(. != "think" and . != "plan" and . != "build"))
+  ' "$SESSION_FILE" 2>/dev/null || echo '["review","security","qa"]')
+fi
 
 jq -n \
   --arg profile "$PROFILE" \
   --arg next "$NEXT_PHASE" \
   --argjson pending "$PENDING_JSON" \
+  --argjson required "$REQUIRED_BEFORE_SHIP_JSON" \
   --arg can_ship "$CAN_SHIP" \
   --arg msg "$MSG" \
   '{
     profile: $profile,
     next_phase: $next,
     pending_phases: $pending,
-    required_before_ship: ["review","security","qa"],
+    ready_phases: $pending,
+    required_before_ship: $required,
     user_message: $msg,
     can_ship: ($can_ship == "true")
   }'

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -125,22 +125,20 @@ fi
 # reports can_ship=true. Codex flagged the dependency-vs-display
 # mix-up on the PR 4 fifth review pass.
 compute_can_ship_from_session() {
-  # The `unique` on the completed-set is fine (set comparison) but the
-  # required-set is built by walking the graph in declared order to
-  # match required_before_ship's external contract. Both filters
-  # produce sets; the resulting boolean is order-insensitive.
+  # can_ship means "ship is actually ready to run or has already
+  # completed". The previous form computed it from "required set
+  # minus completed", but for a graph where ship depends only on
+  # think/plan/build (no post-build gates), the required set was
+  # empty after filtering and can_ship was true even before any
+  # phase ran. Codex caught this on the PR 4 eighth review pass.
+  # Reading from the session's ready_phases (which session.sh keeps
+  # current via nano_phase_ready_from_graph) is the single source
+  # of truth: ship is ready exactly when its declared deps are all
+  # completed and ship itself is neither completed nor in_progress.
   jq -r '
-    (.phase_graph // []) as $g
-    | def ancestors($name):
-        ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
-        | $deps + ($deps | map(ancestors(.)) | add // []);
-      ([.phase_log[]? | select(.status == "completed") | .phase] | unique) as $done
-      | (ancestors("ship")) as $ancs
-      | ([$g[].name
-            | select(. as $n | $ancs | any(. == $n))
-            | select(. != "think" and . != "plan" and . != "build")
-         ]) as $required
-      | ($required - $done | length == 0)
+    ((.ready_phases // []) | any(. == "ship")) as $ship_ready
+    | ([.phase_log[]? | select(.phase == "ship" and .status == "completed")] | length > 0) as $ship_done
+    | ($ship_ready or $ship_done)
   ' "$SESSION_FILE" 2>/dev/null || echo "false"
 }
 
@@ -241,10 +239,14 @@ if [ "$HAS_GRAPH_AWARE_SESSION" = "1" ]; then
           | select(. as $n | $ancs | any(. == $n))
           | select(. != "think" and . != "plan" and . != "build")
         ]
-  ' "$SESSION_FILE" 2>/dev/null || echo '["review","security","qa"]')
-  # Empty filter result (e.g. session has no phase_graph) keeps the
-  # legacy default so existing consumers do not see an empty array.
-  if [ -z "$REQUIRED_BEFORE_SHIP_JSON" ] || [ "$REQUIRED_BEFORE_SHIP_JSON" = "[]" ]; then
+  ' "$SESSION_FILE" 2>/dev/null)
+  # Only fall back to the legacy default when the jq filter failed
+  # outright (empty stdout). A legitimate empty array means the graph
+  # really has no post-build gates ahead of ship, which is unusual
+  # but valid; we keep it as-is so consumers see the graph's truth.
+  # The legacy default applies only when there is no session-level
+  # graph to read from.
+  if [ -z "$REQUIRED_BEFORE_SHIP_JSON" ]; then
     REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
   fi
 fi

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -125,13 +125,21 @@ fi
 # reports can_ship=true. Codex flagged the dependency-vs-display
 # mix-up on the PR 4 fifth review pass.
 compute_can_ship_from_session() {
+  # The `unique` on the completed-set is fine (set comparison) but the
+  # required-set is built by walking the graph in declared order to
+  # match required_before_ship's external contract. Both filters
+  # produce sets; the resulting boolean is order-insensitive.
   jq -r '
     (.phase_graph // []) as $g
     | def ancestors($name):
         ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
         | $deps + ($deps | map(ancestors(.)) | add // []);
       ([.phase_log[]? | select(.status == "completed") | .phase] | unique) as $done
-      | (ancestors("ship") | unique | map(select(. != "think" and . != "plan" and . != "build"))) as $required
+      | (ancestors("ship")) as $ancs
+      | ([$g[].name
+            | select(. as $n | $ancs | any(. == $n))
+            | select(. != "think" and . != "plan" and . != "build")
+         ]) as $required
       | ($required - $done | length == 0)
   ' "$SESSION_FILE" 2>/dev/null || echo "false"
 }
@@ -214,16 +222,25 @@ fi
 REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
 if [ "$HAS_GRAPH_AWARE_SESSION" = "1" ]; then
   # The graph snapshot inside session.json is authoritative. For the
-  # default sprint that yields ["review","qa","security"] (same set
-  # as the legacy default); for a custom graph it returns the actual
-  # transitive chain ship depends on. Falls back to the legacy default
-  # if the jq filter fails.
+  # default sprint that yields ["review","security","qa"] (the legacy
+  # order, preserved by walking the graph in declared order); for a
+  # custom graph it returns the actual transitive chain ship depends
+  # on. Falls back to the legacy default if the jq filter fails.
+  #
+  # The previous form used `unique`, which sorts in jq and produced
+  # ["qa","review","security"]. Consumers that compared the array
+  # exactly broke on that ordering. Codex caught the regression on
+  # the PR 4 seventh review pass.
   REQUIRED_BEFORE_SHIP_JSON=$(jq -c '
     (.phase_graph // []) as $g
     | def ancestors($name):
         ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
         | $deps + ($deps | map(ancestors(.)) | add // []);
-      ancestors("ship") | unique | map(select(. != "think" and . != "plan" and . != "build"))
+      (ancestors("ship")) as $ancs
+      | [$g[].name
+          | select(. as $n | $ancs | any(. == $n))
+          | select(. != "think" and . != "plan" and . != "build")
+        ]
   ' "$SESSION_FILE" 2>/dev/null || echo '["review","security","qa"]')
   # Empty filter result (e.g. session has no phase_graph) keeps the
   # legacy default so existing consumers do not see an empty array.

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -95,18 +95,23 @@ GRAPH_AWARE_NEXT=""
 GRAPH_AWARE_READY="[]"
 IS_CUSTOM_GRAPH=0
 if [ -f "$SESSION_FILE" ]; then
-  # Compare the full graph (sorted, normalized) rather than just the
-  # set of node names. A project can keep the default names but rewire
-  # the dependencies; Codex caught the name-only false-negative on the
-  # PR 4 first review pass.
+  # Preserve the graph's declared node order during comparison. The
+  # depends_on array inside each node is a set (so it sorts for
+  # equality), but the array of nodes itself is order-sensitive
+  # because nano_phase_ready_from_graph returns ready phases in the
+  # graph's declared order and session.sh writes next_phase from
+  # that order. A project that keeps the default names and deps but
+  # reorders the nodes (for example security before review) is a
+  # legitimate custom graph; sorting the outer array would have
+  # collapsed it to the default and the script would have suggested
+  # review while session.json said security. Codex caught the
+  # declared-order regression on the PR 4 second review pass.
   session_graph=$(jq -c '
     (.phase_graph // [])
     | map({name: .name, depends_on: (.depends_on // [] | sort)})
-    | sort_by(.name)
   ' "$SESSION_FILE" 2>/dev/null || echo "[]")
   default_normalized=$(echo "$DEFAULT_GRAPH_JSON" | jq -c '
     map({name: .name, depends_on: (.depends_on // [] | sort)})
-    | sort_by(.name)
   ')
   if [ -n "$session_graph" ] && [ "$session_graph" != "[]" ] && [ "$session_graph" != "$default_normalized" ]; then
     IS_CUSTOM_GRAPH=1

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -83,18 +83,32 @@ if [ -f "$SESSION_FILE" ]; then
 fi
 
 # PR 4 of the 2026-05-10 architecture audit: when the session has a
-# non-default phase_graph (custom workflow stack), read next_phase and
-# ready_phases that session.sh already computed graph-aware. The
+# non-default phase_graph (custom workflow stack OR a project that
+# customized dependencies between built-in phases), read next_phase
+# and ready_phases that session.sh already computed graph-aware. The
 # review/security/qa shape only describes the built-in sprint, so a
-# compliance-release graph like build -> license-audit -> ...
-# would otherwise see next_phase always default to "review".
+# graph like build -> license-audit -> ... or a serialized review ->
+# qa -> security override would otherwise fall back to the legacy
+# peer logic and miss the configured dependencies.
+DEFAULT_GRAPH_JSON='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"ship","depends_on":["review","qa","security"]}]'
 GRAPH_AWARE_NEXT=""
 GRAPH_AWARE_READY="[]"
 IS_CUSTOM_GRAPH=0
 if [ -f "$SESSION_FILE" ]; then
-  default_graph_names="think plan build review qa security ship"
-  session_graph_names=$(jq -r '(.phase_graph // []) | map(.name) | join(" ")' "$SESSION_FILE" 2>/dev/null || echo "")
-  if [ -n "$session_graph_names" ] && [ "$session_graph_names" != "$default_graph_names" ]; then
+  # Compare the full graph (sorted, normalized) rather than just the
+  # set of node names. A project can keep the default names but rewire
+  # the dependencies; Codex caught the name-only false-negative on the
+  # PR 4 first review pass.
+  session_graph=$(jq -c '
+    (.phase_graph // [])
+    | map({name: .name, depends_on: (.depends_on // [] | sort)})
+    | sort_by(.name)
+  ' "$SESSION_FILE" 2>/dev/null || echo "[]")
+  default_normalized=$(echo "$DEFAULT_GRAPH_JSON" | jq -c '
+    map({name: .name, depends_on: (.depends_on // [] | sort)})
+    | sort_by(.name)
+  ')
+  if [ -n "$session_graph" ] && [ "$session_graph" != "[]" ] && [ "$session_graph" != "$default_normalized" ]; then
     IS_CUSTOM_GRAPH=1
     GRAPH_AWARE_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
     GRAPH_AWARE_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
@@ -103,10 +117,31 @@ fi
 
 if [ "$IS_CUSTOM_GRAPH" = "1" ]; then
   PENDING_JSON="$GRAPH_AWARE_READY"
-  NEXT_PHASE="${GRAPH_AWARE_NEXT:-ship}"
+  NEXT_PHASE="$GRAPH_AWARE_NEXT"
+  PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
   if [ -z "$NEXT_PHASE" ] || [ "$NEXT_PHASE" = "null" ]; then
-    NEXT_PHASE="ship"
-    CAN_SHIP="true"
+    # No phase is ready right now. This can mean two things:
+    #   - The sprint is finished (everything past ship completed).
+    #   - The sprint has not started yet and the initial ready set
+    #     was not snapshotted (legacy session pre-PR-4).
+    # In both cases the safe answer is "no specific next phase" with
+    # can_ship gated on the required_before_ship chain still being
+    # incomplete. We do not collapse to "ship" because that wrongly
+    # suggested a fresh custom session was ship-ready (Codex caught
+    # this on the PR 4 first review pass).
+    NEXT_PHASE=""
+    if [ "$PENDING_COUNT" -eq 0 ]; then
+      # Check whether ship has actually completed in this session.
+      ship_done=$(jq -r '[.phase_log[]? | select(.phase == "ship" and .status == "completed")] | length' "$SESSION_FILE" 2>/dev/null || echo "0")
+      if [ "$ship_done" -gt 0 ]; then
+        NEXT_PHASE="compound"
+        CAN_SHIP="true"
+      else
+        CAN_SHIP="false"
+      fi
+    else
+      CAN_SHIP="false"
+    fi
   elif [ "$NEXT_PHASE" = "ship" ] || [ "$NEXT_PHASE" = "compound" ]; then
     CAN_SHIP="true"
   else
@@ -141,21 +176,29 @@ fi
 # Custom phases (anything outside the built-in sprint) fall back to
 # generic wording that uses the phase name without exposing "graph"
 # or "DAG" jargon to a Guided user.
-case "$PROFILE:$NEXT_PHASE" in
-  guided:review)   MSG="I will check that what was built actually works and has no obvious risks." ;;
-  guided:security) MSG="I will check for risky patterns or leaked secrets." ;;
-  guided:qa)       MSG="I will try the feature end to end and confirm it behaves." ;;
-  guided:ship)     MSG="I will package the result so you can try it." ;;
-  guided:compound) MSG="Done. I will record what I learned for next time." ;;
-  professional:review)   MSG="Run /review to check scope, structure, and edge cases." ;;
-  professional:security) MSG="Run /security to audit for vulnerabilities." ;;
-  professional:qa)       MSG="Run /qa to verify the feature works." ;;
-  professional:ship)     MSG="Run /ship to commit, push, and create the PR." ;;
-  professional:compound) MSG="Sprint complete. Run /compound to record learnings." ;;
-  guided:*)              MSG="I will run the $NEXT_PHASE step next." ;;
-  professional:*)        MSG="Run /$NEXT_PHASE next." ;;
-  *)                     MSG="" ;;
-esac
+if [ -z "$NEXT_PHASE" ]; then
+  case "$PROFILE" in
+    guided)        MSG="Nothing is queued to run right now." ;;
+    professional)  MSG="No phase is ready. Start the next sprint or finish the in-progress phase." ;;
+    *)             MSG="" ;;
+  esac
+else
+  case "$PROFILE:$NEXT_PHASE" in
+    guided:review)   MSG="I will check that what was built actually works and has no obvious risks." ;;
+    guided:security) MSG="I will check for risky patterns or leaked secrets." ;;
+    guided:qa)       MSG="I will try the feature end to end and confirm it behaves." ;;
+    guided:ship)     MSG="I will package the result so you can try it." ;;
+    guided:compound) MSG="Done. I will record what I learned for next time." ;;
+    professional:review)   MSG="Run /review to check scope, structure, and edge cases." ;;
+    professional:security) MSG="Run /security to audit for vulnerabilities." ;;
+    professional:qa)       MSG="Run /qa to verify the feature works." ;;
+    professional:ship)     MSG="Run /ship to commit, push, and create the PR." ;;
+    professional:compound) MSG="Sprint complete. Run /compound to record learnings." ;;
+    guided:*)              MSG="I will run the $NEXT_PHASE step next." ;;
+    professional:*)        MSG="Run /$NEXT_PHASE next." ;;
+    *)                     MSG="" ;;
+  esac
+fi
 
 # required_before_ship reflects the active graph: for the default
 # sprint that is ["review","security","qa"]; for a custom graph it is
@@ -183,7 +226,7 @@ jq -n \
   --arg msg "$MSG" \
   '{
     profile: $profile,
-    next_phase: $next,
+    next_phase: (if $next == "" then null else $next end),
     pending_phases: $pending,
     ready_phases: $pending,
     required_before_ship: $required,

--- a/bin/next-step.sh
+++ b/bin/next-step.sh
@@ -90,60 +90,44 @@ fi
 # graph like build -> license-audit -> ... or a serialized review ->
 # qa -> security override would otherwise fall back to the legacy
 # peer logic and miss the configured dependencies.
-DEFAULT_GRAPH_JSON='[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"review","depends_on":["build"]},{"name":"qa","depends_on":["build"]},{"name":"security","depends_on":["build"]},{"name":"ship","depends_on":["review","qa","security"]}]'
-GRAPH_AWARE_NEXT=""
-GRAPH_AWARE_READY="[]"
-IS_CUSTOM_GRAPH=0
+# When a session exists, trust the session-computed ready_phases /
+# next_phase. session.sh already runs nano_phase_ready_from_graph on
+# every phase-start and phase-complete with the correct completed +
+# in_progress lists, so we get parallel-graph correctness AND
+# in-progress exclusion for free. The legacy artifact-based fallback
+# only kicks in when no session file exists.
+#
+# Codex flagged the in-progress leak on the PR 4 fourth review pass:
+# the previous default-sprint branch only consulted phase_completed,
+# so an active /review showed up in ready_phases and could trigger
+# duplicate starts.
+SESSION_READY="[]"
+SESSION_NEXT=""
+HAS_SESSION=0
 if [ -f "$SESSION_FILE" ]; then
-  # Preserve the graph's declared node order during comparison. The
-  # depends_on array inside each node is a set (so it sorts for
-  # equality), but the array of nodes itself is order-sensitive
-  # because nano_phase_ready_from_graph returns ready phases in the
-  # graph's declared order and session.sh writes next_phase from
-  # that order. A project that keeps the default names and deps but
-  # reorders the nodes (for example security before review) is a
-  # legitimate custom graph; sorting the outer array would have
-  # collapsed it to the default and the script would have suggested
-  # review while session.json said security. Codex caught the
-  # declared-order regression on the PR 4 second review pass.
-  session_graph=$(jq -c '
-    (.phase_graph // [])
-    | map({name: .name, depends_on: (.depends_on // [] | sort)})
-  ' "$SESSION_FILE" 2>/dev/null || echo "[]")
-  default_normalized=$(echo "$DEFAULT_GRAPH_JSON" | jq -c '
-    map({name: .name, depends_on: (.depends_on // [] | sort)})
-  ')
-  if [ -n "$session_graph" ] && [ "$session_graph" != "[]" ] && [ "$session_graph" != "$default_normalized" ]; then
-    IS_CUSTOM_GRAPH=1
-    GRAPH_AWARE_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
-    GRAPH_AWARE_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
-  fi
+  HAS_SESSION=1
+  SESSION_READY=$(jq -c '.ready_phases // []' "$SESSION_FILE" 2>/dev/null || echo "[]")
+  SESSION_NEXT=$(jq -r '.next_phase // ""' "$SESSION_FILE" 2>/dev/null || echo "")
 fi
 
-if [ "$IS_CUSTOM_GRAPH" = "1" ]; then
-  PENDING_JSON="$GRAPH_AWARE_READY"
-  NEXT_PHASE="$GRAPH_AWARE_NEXT"
+if [ "$HAS_SESSION" = "1" ]; then
+  PENDING_JSON="$SESSION_READY"
+  NEXT_PHASE="$SESSION_NEXT"
   PENDING_COUNT=$(echo "$PENDING_JSON" | jq 'length')
   if [ -z "$NEXT_PHASE" ] || [ "$NEXT_PHASE" = "null" ]; then
     # No phase is ready right now. This can mean two things:
     #   - The sprint is finished (everything past ship completed).
     #   - The sprint has not started yet and the initial ready set
     #     was not snapshotted (legacy session pre-PR-4).
-    # In both cases the safe answer is "no specific next phase" with
-    # can_ship gated on the required_before_ship chain still being
-    # incomplete. We do not collapse to "ship" because that wrongly
-    # suggested a fresh custom session was ship-ready (Codex caught
-    # this on the PR 4 first review pass).
+    # Safe answer: "no specific next phase" with can_ship gated on
+    # ship having actually completed. We never collapse to "ship"
+    # implicitly; that wrongly suggested a fresh session was ship-
+    # ready (Codex caught this on the PR 4 first review pass).
     NEXT_PHASE=""
-    if [ "$PENDING_COUNT" -eq 0 ]; then
-      # Check whether ship has actually completed in this session.
-      ship_done=$(jq -r '[.phase_log[]? | select(.phase == "ship" and .status == "completed")] | length' "$SESSION_FILE" 2>/dev/null || echo "0")
-      if [ "$ship_done" -gt 0 ]; then
-        NEXT_PHASE="compound"
-        CAN_SHIP="true"
-      else
-        CAN_SHIP="false"
-      fi
+    ship_done=$(jq -r '[.phase_log[]? | select(.phase == "ship" and .status == "completed")] | length' "$SESSION_FILE" 2>/dev/null || echo "0")
+    if [ "$ship_done" -gt 0 ]; then
+      NEXT_PHASE="compound"
+      CAN_SHIP="true"
     else
       CAN_SHIP="false"
     fi
@@ -153,6 +137,9 @@ if [ "$IS_CUSTOM_GRAPH" = "1" ]; then
     CAN_SHIP="false"
   fi
 else
+  # No session file. Fall back to the legacy artifact-based lookup
+  # so a host that drives /review/security/qa without going through
+  # session.sh init still gets sensible output.
   PENDING_JSON="[]"
   for phase in $PEERS; do
     if ! phase_completed "$phase"; then
@@ -212,7 +199,12 @@ fi
 # hardcoded shape continue to receive it when the session uses the
 # default graph.
 REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
-if [ "$IS_CUSTOM_GRAPH" = "1" ] && [ -f "$SESSION_FILE" ]; then
+if [ "$HAS_SESSION" = "1" ]; then
+  # The graph snapshot inside session.json is authoritative. For the
+  # default sprint that yields ["review","qa","security"] (same set
+  # as the legacy default); for a custom graph it returns the actual
+  # transitive chain ship depends on. Falls back to the legacy default
+  # if the jq filter fails (legacy session pre-PR-4).
   REQUIRED_BEFORE_SHIP_JSON=$(jq -c '
     (.phase_graph // []) as $g
     | def ancestors($name):
@@ -220,6 +212,11 @@ if [ "$IS_CUSTOM_GRAPH" = "1" ] && [ -f "$SESSION_FILE" ]; then
         | $deps + ($deps | map(ancestors(.)) | add // []);
       ancestors("ship") | unique | map(select(. != "think" and . != "plan" and . != "build"))
   ' "$SESSION_FILE" 2>/dev/null || echo '["review","security","qa"]')
+  # Empty filter result (e.g. session has no phase_graph) keeps the
+  # legacy default so existing consumers do not see an empty array.
+  if [ -z "$REQUIRED_BEFORE_SHIP_JSON" ] || [ "$REQUIRED_BEFORE_SHIP_JSON" = "[]" ]; then
+    REQUIRED_BEFORE_SHIP_JSON='["review","security","qa"]'
+  fi
 fi
 
 jq -n \

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -14,6 +14,7 @@ NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
+[ -f "$SCRIPT_DIR/lib/phases.sh" ] && . "$SCRIPT_DIR/lib/phases.sh"
 
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 PROJECT="$(pwd)"
@@ -206,6 +207,17 @@ cmd_init() {
     fi
   fi
 
+  # Snapshot the active phase_graph at session creation. Custom
+  # workflow stacks read this back during phase-complete so the
+  # graph cannot drift mid-sprint (e.g. user edits config.json after
+  # /think runs). Falls back to an empty array when the helper is
+  # unavailable; cmd_phase_complete handles that by skipping the
+  # graph-aware path.
+  local phase_graph_json="[]"
+  if declare -F nano_phase_graph_json >/dev/null 2>&1; then
+    phase_graph_json=$(nano_phase_graph_json 2>/dev/null || echo "[]")
+  fi
+
   jq -n \
     --arg id "$session_id" \
     --arg type "$type" \
@@ -221,6 +233,7 @@ cmd_init() {
     --argjson autopilot "$autopilot" \
     --argjson capabilities "$capabilities_json" \
     --argjson policy "$policy_json" \
+    --argjson phase_graph "$phase_graph_json" \
     '{
       schema_version: "2",
       session_id: $id,
@@ -238,6 +251,8 @@ cmd_init() {
       policy: $policy,
       current_phase: null,
       next_phase: null,
+      ready_phases: [],
+      phase_graph: $phase_graph,
       stop_conditions_met: [],
       phase_log: [],
       evidence: {review:null, security:null, qa:null, ship:null},
@@ -357,43 +372,58 @@ cmd_phase_complete() {
     exit 1
   fi
 
-  # Calculate next phase from default sequence
-  local next=""
-  case "$phase" in
-    think) next="plan" ;;
-    plan)  next="build" ;;
-    build) next="review" ;;
-    review)
-      # Check if qa and security are done
-      local qa_done sec_done
-      qa_done=$(jq -r '[.phase_log[] | select(.phase == "qa" and .status == "completed")] | length' "$SESSION_FILE")
-      sec_done=$(jq -r '[.phase_log[] | select(.phase == "security" and .status == "completed")] | length' "$SESSION_FILE")
-      if [ "$qa_done" -gt 0 ] && [ "$sec_done" -gt 0 ]; then next="ship"
-      elif [ "$qa_done" -gt 0 ]; then next="security"
-      else next="qa"
+  # ─── next phase via phase_graph ───────────────────────────
+  # PR 4 of the 2026-05-10 architecture audit: next-phase logic now
+  # consumes the active phase_graph (default sprint OR the project's
+  # custom graph from .nanostack/config.json). nano_phase_ready_from_graph
+  # returns every phase whose deps are met and which has not yet been
+  # completed or started; next_phase is the first such phase and
+  # ready_phases captures the full list so next-step.sh can surface
+  # parallel options. The previous hardcoded case statement only knew
+  # about think/plan/build/review/qa/security/ship/compound and left
+  # custom workflow stacks with next_phase=null forever.
+  local next="" ready_json="[]"
+  local completed_now
+  # Add the phase we just completed in case the JSON write below has
+  # not landed yet (this function runs immediately after the in-flight
+  # jq mutation), then dedup. Also include any prior completed phases.
+  completed_now=$(jq -c --arg p "$phase" \
+    '[(.phase_log // [])[] | select(.status == "completed") | .phase] + [$p] | unique' \
+    "$SESSION_FILE" 2>/dev/null || echo "[]")
+  local in_progress_now
+  in_progress_now=$(jq -c --arg p "$phase" \
+    '[(.phase_log // [])[] | select(.status == "in_progress" and .phase != $p) | .phase] | unique' \
+    "$SESSION_FILE" 2>/dev/null || echo "[]")
+
+  if declare -F nano_phase_ready_from_graph >/dev/null 2>&1; then
+    # Prefer the graph snapshot inside session.json (set at init time)
+    # so a mid-sprint edit to .nanostack/config.json cannot change the
+    # path under the session. Fall back to nano_phase_graph_json (which
+    # rereads config) only when the session has no snapshot.
+    local graph
+    graph=$(jq -c '.phase_graph // empty' "$SESSION_FILE" 2>/dev/null || echo "")
+    if [ -z "$graph" ] || [ "$graph" = "null" ] || [ "$graph" = "[]" ]; then
+      if declare -F nano_phase_graph_json >/dev/null 2>&1; then
+        graph=$(nano_phase_graph_json 2>/dev/null || echo "")
       fi
-      ;;
-    qa)
-      local rev_done sec_done
-      rev_done=$(jq -r '[.phase_log[] | select(.phase == "review" and .status == "completed")] | length' "$SESSION_FILE")
-      sec_done=$(jq -r '[.phase_log[] | select(.phase == "security" and .status == "completed")] | length' "$SESSION_FILE")
-      if [ "$rev_done" -gt 0 ] && [ "$sec_done" -gt 0 ]; then next="ship"
-      elif [ "$rev_done" -gt 0 ]; then next="security"
-      else next="review"
+    fi
+    if [ -n "$graph" ] && [ "$graph" != "null" ] && [ "$graph" != "[]" ]; then
+      local ready_list
+      ready_list=$(nano_phase_ready_from_graph "$graph" "$completed_now" "$in_progress_now" 2>/dev/null || true)
+      if [ -n "$ready_list" ]; then
+        next=$(echo "$ready_list" | head -1)
+        ready_json=$(echo "$ready_list" | jq -R . | jq -sc 'map(select(length > 0))')
       fi
-      ;;
-    security)
-      local rev_done qa_done
-      rev_done=$(jq -r '[.phase_log[] | select(.phase == "review" and .status == "completed")] | length' "$SESSION_FILE")
-      qa_done=$(jq -r '[.phase_log[] | select(.phase == "qa" and .status == "completed")] | length' "$SESSION_FILE")
-      if [ "$rev_done" -gt 0 ] && [ "$qa_done" -gt 0 ]; then next="ship"
-      elif [ "$rev_done" -gt 0 ]; then next="qa"
-      else next="review"
-      fi
-      ;;
-    ship) next="compound" ;;
-    compound) next="" ;;
-  esac
+    fi
+  fi
+
+  # Compound is intentionally not in the canonical phase_graph (it is
+  # a post-sprint reflection skill). Preserve the historical post-ship
+  # hint so the existing user prompts and tests continue to advance.
+  if [ -z "$next" ] && [ "$phase" = "ship" ]; then
+    next="compound"
+    ready_json='["compound"]'
+  fi
 
   # Calculate duration from stored epoch. save-artifact.sh auto-calls
   # phase-complete after writing the artifact, so this function must be
@@ -415,11 +445,13 @@ cmd_phase_complete() {
     --arg date "$NOW" \
     --arg artifact "$artifact" \
     --arg next "$next" \
+    --argjson ready "$ready_json" \
     --argjson duration "$duration" \
     '(.phase_log[] | select(.phase == $phase and .status == "in_progress")) |=
        (.status = "completed" | .completed_at = $date | .duration_seconds = $duration | .artifact = (if $artifact != "" then $artifact else null end)) |
      .current_phase = ([.phase_log[] | select(.status == "in_progress") | .phase] | last // null) |
      .next_phase = (if $next != "" then $next else null end) |
+     .ready_phases = $ready |
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -214,8 +214,27 @@ cmd_init() {
   # unavailable; cmd_phase_complete handles that by skipping the
   # graph-aware path.
   local phase_graph_json="[]"
+  local initial_ready_json="[]"
   if declare -F nano_phase_graph_json >/dev/null 2>&1; then
     phase_graph_json=$(nano_phase_graph_json 2>/dev/null || echo "[]")
+    # Compute the initial ready set so a caller that asks for
+    # next_phase BEFORE the first phase-complete sees the actual root
+    # of the graph (e.g. think for the default sprint) rather than an
+    # empty array. Without this, bin/next-step.sh used to fall back to
+    # "ship" for a freshly-initialized session, which Codex caught
+    # on the PR 4 first review pass.
+    if declare -F nano_phase_ready_from_graph >/dev/null 2>&1 && [ "$phase_graph_json" != "[]" ]; then
+      local initial_ready
+      initial_ready=$(nano_phase_ready_from_graph "$phase_graph_json" "[]" "[]" 2>/dev/null || true)
+      if [ -n "$initial_ready" ]; then
+        initial_ready_json=$(echo "$initial_ready" | jq -R . | jq -sc 'map(select(length > 0))')
+      fi
+    fi
+  fi
+  local initial_next_phase="null"
+  if [ "$initial_ready_json" != "[]" ]; then
+    initial_next_phase=$(echo "$initial_ready_json" | jq -r '.[0] // "null"')
+    initial_next_phase="\"$initial_next_phase\""
   fi
 
   jq -n \
@@ -234,6 +253,8 @@ cmd_init() {
     --argjson capabilities "$capabilities_json" \
     --argjson policy "$policy_json" \
     --argjson phase_graph "$phase_graph_json" \
+    --argjson initial_ready "$initial_ready_json" \
+    --argjson initial_next "$initial_next_phase" \
     '{
       schema_version: "2",
       session_id: $id,
@@ -250,8 +271,8 @@ cmd_init() {
       capabilities: $capabilities,
       policy: $policy,
       current_phase: null,
-      next_phase: null,
-      ready_phases: [],
+      next_phase: $initial_next,
+      ready_phases: $initial_ready,
       phase_graph: $phase_graph,
       stop_conditions_met: [],
       phase_log: [],

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -374,6 +374,36 @@ cmd_phase_start() {
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
 
+  # Recompute ready_phases and next_phase so they exclude the phase
+  # we just moved to in_progress. Without this, a custom graph with
+  # multiple ready phases would keep advertising the active one and
+  # downstream schedulers could start it twice. Codex caught the
+  # stale-cache bug on the PR 4 third review pass.
+  if declare -F nano_phase_ready_from_graph >/dev/null 2>&1; then
+    local graph completed_now in_progress_now ready_list ready_json next_phase_value
+    graph=$(jq -c '.phase_graph // empty' "$SESSION_FILE" 2>/dev/null || echo "")
+    if [ -z "$graph" ] || [ "$graph" = "null" ] || [ "$graph" = "[]" ]; then
+      if declare -F nano_phase_graph_json >/dev/null 2>&1; then
+        graph=$(nano_phase_graph_json 2>/dev/null || echo "")
+      fi
+    fi
+    if [ -n "$graph" ] && [ "$graph" != "null" ] && [ "$graph" != "[]" ]; then
+      completed_now=$(jq -c '[(.phase_log // [])[] | select(.status == "completed") | .phase] | unique' "$SESSION_FILE" 2>/dev/null || echo "[]")
+      in_progress_now=$(jq -c '[(.phase_log // [])[] | select(.status == "in_progress") | .phase] | unique' "$SESSION_FILE" 2>/dev/null || echo "[]")
+      ready_list=$(nano_phase_ready_from_graph "$graph" "$completed_now" "$in_progress_now" 2>/dev/null || true)
+      ready_json="[]"
+      next_phase_value="null"
+      if [ -n "$ready_list" ]; then
+        ready_json=$(echo "$ready_list" | jq -R . | jq -sc 'map(select(length > 0))')
+        next_phase_value=$(echo "$ready_json" | jq -c '.[0] // "null"')
+      fi
+      jq --argjson ready "$ready_json" --argjson next "$next_phase_value" \
+        '.ready_phases = $ready | .next_phase = (if ($next | type) == "string" then $next else null end)' \
+        "$SESSION_FILE" > "${SESSION_FILE}.tmp"
+      mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+    fi
+  fi
+
   rm -rf "$lockdir" 2>/dev/null || true
 
   audit_log "phase_start" "$phase"

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -215,6 +215,17 @@ cmd_init() {
   # graph-aware path.
   local phase_graph_json="[]"
   local initial_ready_json="[]"
+  local initial_phase_log_json="[]"
+  # /feature sessions skip /think by contract (feature/SKILL.md goes
+  # straight to /plan). Pre-seed think as completed in the phase_log
+  # so the graph-aware lifecycle does not advertise it as ready after
+  # /plan completes. Codex caught the regression on the PR 4 eleventh
+  # review pass: after a /feature plan ran, next-step.sh reported
+  # next_phase = think.
+  if [ "$type" = "feature" ]; then
+    initial_phase_log_json=$(jq -nc --arg date "$NOW" \
+      '[{phase:"think", status:"completed", started_at:$date, started_epoch:0, completed_at:$date, duration_seconds:0, artifact:null, source:"feature-skip"}]')
+  fi
   if declare -F nano_phase_graph_json >/dev/null 2>&1; then
     phase_graph_json=$(nano_phase_graph_json 2>/dev/null || echo "[]")
     # Compute the initial ready set so a caller that asks for
@@ -222,10 +233,13 @@ cmd_init() {
     # of the graph (e.g. think for the default sprint) rather than an
     # empty array. Without this, bin/next-step.sh used to fall back to
     # "ship" for a freshly-initialized session, which Codex caught
-    # on the PR 4 first review pass.
+    # on the PR 4 first review pass. /feature pre-seeds think above
+    # so its initial ready set starts from plan onward.
     if declare -F nano_phase_ready_from_graph >/dev/null 2>&1 && [ "$phase_graph_json" != "[]" ]; then
+      local completed_seed_init
+      completed_seed_init=$(echo "$initial_phase_log_json" | jq -c '[.[] | select(.status == "completed") | .phase]')
       local initial_ready
-      initial_ready=$(nano_phase_ready_from_graph "$phase_graph_json" "[]" "[]" 2>/dev/null || true)
+      initial_ready=$(nano_phase_ready_from_graph "$phase_graph_json" "$completed_seed_init" "[]" 2>/dev/null || true)
       if [ -n "$initial_ready" ]; then
         initial_ready_json=$(echo "$initial_ready" | jq -R . | jq -sc 'map(select(length > 0))')
       fi
@@ -255,6 +269,7 @@ cmd_init() {
     --argjson phase_graph "$phase_graph_json" \
     --argjson initial_ready "$initial_ready_json" \
     --argjson initial_next "$initial_next_phase" \
+    --argjson initial_phase_log "$initial_phase_log_json" \
     '{
       schema_version: "2",
       session_id: $id,
@@ -275,7 +290,7 @@ cmd_init() {
       ready_phases: $initial_ready,
       phase_graph: $phase_graph,
       stop_conditions_met: [],
-      phase_log: [],
+      phase_log: $initial_phase_log,
       evidence: {review:null, security:null, qa:null, ship:null},
       budget: {
         max_usd: null,

--- a/ci/e2e-delivery-matrix.sh
+++ b/ci/e2e-delivery-matrix.sh
@@ -272,11 +272,19 @@ cell_professional_next_step_uses_slash() {
   new_project "cell8"
   git init -q
   "$REPO/bin/session.sh" init development --profile professional --autopilot >/dev/null
+  # PR 4 of the 2026-05-10 audit made session.sh init seed next_phase
+  # with the graph root (think). Walk past think+plan so the state is
+  # post-build, when the graph reports review as the next phase — that
+  # is the state this cell wants to exercise (professional uses slash
+  # commands in user_message).
+  for ph in think plan; do
+    "$REPO/bin/session.sh" phase-start "$ph" >/dev/null
+    "$REPO/bin/session.sh" phase-complete "$ph" >/dev/null
+  done
   local out msg
   out=$("$REPO/bin/next-step.sh" --json 2>/dev/null)
   msg=$(echo "$out" | jq -r .user_message)
   assert_eq "professional profile propagated" "professional" "$(echo "$out" | jq -r .profile)"
-  # Empty post-build state suggests review next.
   assert_contains "professional user_message names /review" "/review" "$msg"
 }
 

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -471,6 +471,40 @@ assert_eq "build in_progress: ready_phases is empty" '[]' "$ready_during_build"
 ready_after_build=$(jq -c '.ready_phases | sort' "$NANOSTACK_STORE/session.json")
 assert_eq "build completed: post-build phases ready" \
   '["qa","review","security"]' "$ready_after_build"
+# Cell 9g: a custom graph where ship has no post-build gates (only
+# depends on build/plan/think) must NOT report can_ship=true on a
+# fresh session. The previous form computed can_ship from "required
+# set minus completed" — empty required set collapsed to true even
+# before think/plan ran. Codex caught the premature-ship hazard on
+# the PR 4 eighth review pass.
+echo "[9g] ship-on-build-only graph gates can_ship on ship readiness"
+new_project "cell9g-no-gates"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"ship","depends_on":["build"]}
+  ]
+}
+EOF
+"$SESSION_SH" init development >/dev/null
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "fresh ship-on-build graph: can_ship = false" "false" \
+  "$(echo "$out" | jq -r '.can_ship')"
+assert_eq "fresh ship-on-build graph: next_phase = think" "think" \
+  "$(echo "$out" | jq -r '.next_phase')"
+# After think + plan, build auto-promotes and ship becomes ready
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "after plan: can_ship = true (ship is ready)" "true" \
+  "$(echo "$out" | jq -r '.can_ship')"
+assert_eq "after plan: next_phase = ship" "ship" \
+  "$(echo "$out" | jq -r '.next_phase')"
 
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -656,6 +656,31 @@ rc=$?
 set -e
 assert_eq "no-gate graph: phase-gate allows commit (rc 0)" "0" "$rc"
 
+# Cell 9l: phase-gate must not activate solely because /feature
+# pre-seeded think as completed. Before /plan starts, the gate
+# stays dormant; once /plan runs, the gate enforces. Codex caught
+# the premature-block regression on the PR 4 thirteenth review
+# pass.
+echo "[9l] /feature pre-seed does not activate the phase gate"
+new_project "cell9l-feature-gate"
+"$SESSION_SH" init feature --autopilot --plan-approval auto >/dev/null
+echo "scratch" > scratch.txt
+git add scratch.txt && git commit -q -m "scratch" >/dev/null 2>&1 || true
+echo "more" >> scratch.txt
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m wip" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "/feature post-init: gate allows commit (rc 0)" "0" "$rc"
+"$SESSION_SH" phase-start plan >/dev/null
+"$SESSION_SH" phase-complete plan >/dev/null
+echo "more2" >> scratch.txt
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m wip" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "/feature after plan: gate now enforces (rc 1)" "1" "$rc"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -681,6 +681,36 @@ rc=$?
 set -e
 assert_eq "/feature after plan: gate now enforces (rc 1)" "1" "$rc"
 
+# Cell 9m: a graph that omits the ship node entirely must fall back
+# to the legacy review/security/qa default. The gate exists to
+# protect ship-like actions, so a ship-less graph cannot be allowed
+# to loosen it. Codex caught the ship-absent bypass on the PR 4
+# fourteenth review pass.
+echo "[9m] phase-gate falls back to legacy when ship is absent"
+new_project "cell9m-no-ship"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]}
+  ]
+}
+EOF
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+echo "scratch" > scratch.txt
+git add scratch.txt && git commit -q -m "scratch" >/dev/null 2>&1 || true
+echo "more" >> scratch.txt
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m wip" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "ship-less graph blocks commit (rc 1, legacy fallback)" "1" "$rc"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# e2e-graph-aware-session.sh — PR 4 of the 2026-05-10 architecture audit.
+#
+# Locks the graph-aware session lifecycle end-to-end:
+#
+#   - bin/session.sh init snapshots the active phase_graph into
+#     session.json (default sprint OR project custom graph).
+#   - bin/session.sh phase-complete sets next_phase and ready_phases
+#     from the snapshot, not from a hardcoded sequence.
+#   - bin/next-step.sh --json surfaces ready_phases plus a
+#     custom-graph-aware required_before_ship list.
+#   - Guided wording never exposes "phase graph" / "DAG" jargon, even
+#     for custom phases.
+#
+# Spec acceptance, verbatim:
+#   "In a graph build -> license-audit -> privacy-check ->
+#    release-readiness -> ship, completing license-audit sets
+#    next_phase = 'privacy-check'."
+#   "Default sprint output remains unchanged."
+#   "When multiple ready phases exist, next-step.sh --json returns
+#    all ready phases in pending_phases or a new ready_phases field."
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT=$(mktemp -d /tmp/nanostack-graph-session.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}expected: %s${NC}\n" "$expected"
+    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
+  fi
+}
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}did not want to find: %s${NC}\n" "$needle"
+  else
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  fi
+}
+
+new_project() {
+  local name="$1"
+  local proj="$TMP_ROOT/$name"
+  mkdir -p "$proj/.nanostack"
+  cd "$proj"
+  git init -q
+  git config user.email "ci@graph.test"
+  git config user.name  "ci"
+  export NANOSTACK_STORE="$proj/.nanostack"
+}
+
+echo "Graph-aware Session E2E"
+echo "======================="
+echo "Tmp root: $TMP_ROOT"
+echo
+
+SESSION_SH="$REPO/bin/session.sh"
+NEXT_STEP="$REPO/bin/next-step.sh"
+
+# Cell 1: session init snapshots the default phase_graph.
+echo "[1] session init snapshots the active phase_graph"
+new_project "cell1-default"
+"$SESSION_SH" init development >/dev/null
+nodes=$(jq -r '.phase_graph // [] | map(.name) | join(",")' "$NANOSTACK_STORE/session.json")
+assert_eq "default graph nodes" "think,plan,build,review,qa,security,ship" "$nodes"
+ready_init=$(jq -c '.ready_phases // []' "$NANOSTACK_STORE/session.json")
+assert_eq "ready_phases starts empty" "[]" "$ready_init"
+
+# Cell 2: default sprint progression matches the legacy ordering.
+# review/qa/security ARE ready in parallel after plan, but next_phase
+# picks the first in graph order so existing skills continue to land
+# on /review first.
+echo "[2] default sprint walk preserves the historical next_phase order"
+new_project "cell2-default-walk"
+"$SESSION_SH" init development >/dev/null
+declare -a expected_next=("plan" "review" "qa" "security" "ship" "compound")
+declare -a phases_to_complete=("think" "plan" "review" "qa" "security" "ship")
+for i in 0 1 2 3 4 5; do
+  ph="${phases_to_complete[$i]}"
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+  np=$(jq -r '.next_phase // "null"' "$NANOSTACK_STORE/session.json")
+  assert_eq "after $ph, next_phase = ${expected_next[$i]}" "${expected_next[$i]}" "$np"
+done
+
+# Cell 3: after /plan, ready_phases lists every parallel branch
+# (review, qa, security) so next-step can fan out.
+echo "[3] ready_phases lists every parallel branch after /plan"
+new_project "cell3-fanout"
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+ready=$(jq -c '.ready_phases | sort' "$NANOSTACK_STORE/session.json")
+assert_eq "ready_phases after plan" '["qa","review","security"]' "$ready"
+
+# Cell 4: spec custom graph — license-audit -> privacy-check ->
+# release-readiness -> ship. Each completion advances the next ready
+# phase.
+echo "[4] custom compliance-release graph advances spec-correctly"
+new_project "cell4-custom"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit","privacy-check","release-readiness"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build"]},
+    {"name":"privacy-check","depends_on":["license-audit"]},
+    {"name":"release-readiness","depends_on":["privacy-check"]},
+    {"name":"ship","depends_on":["release-readiness"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit" \
+         "$NANOSTACK_STORE/skills/privacy-check" \
+         "$NANOSTACK_STORE/skills/release-readiness"
+for skill in license-audit privacy-check release-readiness; do
+  cat > "$NANOSTACK_STORE/skills/$skill/SKILL.md" <<EOF
+---
+name: $skill
+description: custom skill
+concurrency: read
+---
+EOF
+done
+"$SESSION_SH" init development >/dev/null
+
+# Spec walk: license-audit -> privacy-check (the documented case)
+declare -a custom_chain=("think" "plan" "license-audit" "privacy-check" "release-readiness" "ship")
+declare -a custom_next=("plan" "license-audit" "privacy-check" "release-readiness" "ship" "compound")
+for i in 0 1 2 3 4 5; do
+  ph="${custom_chain[$i]}"
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+  np=$(jq -r '.next_phase // "null"' "$NANOSTACK_STORE/session.json")
+  assert_eq "custom: after $ph, next_phase = ${custom_next[$i]}" "${custom_next[$i]}" "$np"
+done
+
+# Cell 5: next-step --json on a custom graph reports the custom
+# required_before_ship chain, not the default review/security/qa.
+echo "[5] next-step --json reports custom required_before_ship"
+new_project "cell5-required"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit","privacy-check","release-readiness"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build"]},
+    {"name":"privacy-check","depends_on":["license-audit"]},
+    {"name":"release-readiness","depends_on":["privacy-check"]},
+    {"name":"ship","depends_on":["release-readiness"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit"
+cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: custom
+concurrency: read
+---
+EOF
+"$SESSION_SH" init development >/dev/null
+for ph in think plan license-audit; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+out=$("$NEXT_STEP" --json 2>/dev/null)
+required_sorted=$(echo "$out" | jq -c '.required_before_ship | sort')
+assert_eq "required_before_ship reflects the custom graph" \
+  '["license-audit","privacy-check","release-readiness"]' \
+  "$required_sorted"
+next=$(echo "$out" | jq -r '.next_phase')
+assert_eq "next_phase = privacy-check (spec acceptance)" "privacy-check" "$next"
+
+# Cell 6: guided wording never exposes graph jargon for custom phases.
+# "I will run the <phase> step next." is acceptable; anything that
+# mentions graph, DAG, dependency, topology, or upstream is not.
+echo "[6] guided wording stays plain for custom phases"
+new_project "cell6-guided"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit","privacy-check","release-readiness"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build"]},
+    {"name":"privacy-check","depends_on":["license-audit"]},
+    {"name":"release-readiness","depends_on":["privacy-check"]},
+    {"name":"ship","depends_on":["release-readiness"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit"
+cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: custom
+concurrency: read
+---
+EOF
+"$SESSION_SH" init development --profile guided >/dev/null
+for ph in think plan license-audit; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+msg=$("$NEXT_STEP" --json 2>/dev/null | jq -r '.user_message')
+for jargon in "phase_graph" "phase graph" "DAG" "dependency" "topology" "upstream"; do
+  assert_not_contains "guided user_message has no \"$jargon\"" "$jargon" "$msg"
+done
+assert_true "guided user_message names the custom phase" \
+  bash -c "echo '$msg' | grep -qiF 'privacy-check'"
+
+# Cell 7: default sprint user_message remains exactly the historical
+# wording. No regression for built-in flows.
+echo "[7] default sprint user_message is unchanged"
+new_project "cell7-default-msg"
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+msg=$("$NEXT_STEP" --json 2>/dev/null | jq -r '.user_message')
+assert_eq "professional after plan = review wording" \
+  "Run /review to check scope, structure, and edge cases." \
+  "$msg"
+
+cd "$TMP_ROOT"
+
+echo
+echo "======================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf "${GREEN}Graph-aware Session E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
+  exit 0
+else
+  printf "${RED}Graph-aware Session E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -625,6 +625,37 @@ rc=$?
 set -e
 assert_eq "phase-gate allows git commit after license-audit (rc 0)" "0" "$rc"
 
+# Cell 9k: a graph with no post-build gates (think -> plan -> build
+# -> ship) must let phase-gate allow the commit. Codex caught the
+# symmetric collapse on the PR 4 twelfth review pass: an empty
+# graph-derived REQUIRED_PHASES used to fall back to the built-in
+# trio, blocking valid no-gate workflows.
+echo "[9k] phase-gate honors an empty post-build gate set"
+new_project "cell9k-nogate"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"ship","depends_on":["build"]}
+  ]
+}
+EOF
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+echo "scratch" > scratch.txt
+git add scratch.txt && git commit -q -m "scratch" >/dev/null 2>&1 || true
+echo "more" >> scratch.txt
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m wip" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "no-gate graph: phase-gate allows commit (rc 0)" "0" "$rc"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -546,6 +546,85 @@ next_after_plan=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
 assert_eq "after plan in a conductor sprint: next_phase = license-audit" \
   "license-audit" "$next_after_plan"
 
+# Cell 9i: /feature sessions skip /think by contract. The graph-aware
+# lifecycle must NOT advertise think as ready after /plan completes;
+# session.sh init must pre-seed think as completed so the dep graph
+# treats it as satisfied. Codex caught the regression on the PR 4
+# eleventh review pass.
+echo "[9i] /feature session pre-seeds think as completed"
+new_project "cell9i-feature"
+"$SESSION_SH" init feature --autopilot --plan-approval auto >/dev/null
+think_status=$(jq -r '.phase_log[] | select(.phase == "think") | .status' "$NANOSTACK_STORE/session.json")
+assert_eq "/feature init seeds think as completed" "completed" "$think_status"
+assert_eq "/feature init next_phase = plan (not think)" "plan" \
+  "$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")"
+# Walk plan + review and confirm next_phase never falls back to think
+for ph in plan review; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+next_after_review=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
+assert_eq "/feature after review: next_phase != think" "security" "$next_after_review"
+
+# Cell 9j: the guard's phase-gate reads required phases from the
+# session's phase_graph too. A custom workflow stack whose ship
+# depends on license-audit must gate git commit on license-audit
+# being completed, not on the hardcoded review/security/qa trio.
+# Codex caught the gate-vs-can_ship drift on the PR 4 eleventh
+# review pass.
+echo "[9j] phase-gate gates on the graph's ship ancestors"
+new_project "cell9j-gate"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build"]},
+    {"name":"ship","depends_on":["license-audit"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit"
+cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: custom
+concurrency: read
+---
+EOF
+"$SESSION_SH" init development >/dev/null
+# Walk think + plan first so the gate is in "active sprint" mode.
+# The gate skips when no phases have started (a freshly-initialized
+# session is not yet a sprint to enforce).
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+# Touch a tracked file so last_code_timestamp gives the gate something
+# fresher than any artifact (otherwise the missing-phase check is
+# bypassed because nothing changed since the last commit).
+echo "scratch" > scratch.txt
+git add scratch.txt && git commit -q -m "scratch" >/dev/null 2>&1 || true
+echo "more" >> scratch.txt
+# Before license-audit completes, phase-gate must block git commit.
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m wip" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "phase-gate blocks git commit before license-audit (rc 1)" "1" "$rc"
+# Complete license-audit via real save-artifact so the gate finds
+# a fresh artifact for the only graph-required ancestor of ship.
+"$SESSION_SH" phase-start license-audit >/dev/null
+"$REPO/bin/save-artifact.sh" license-audit \
+  '{"phase":"license-audit","summary":{"status":"OK"},"context_checkpoint":{"summary":"clean"}}' >/dev/null
+set +e
+"$REPO/guard/bin/phase-gate.sh" "git commit -m ship" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "phase-gate allows git commit after license-audit (rc 0)" "0" "$rc"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -94,7 +94,7 @@ echo "[1] session init snapshots the active phase_graph"
 new_project "cell1-default"
 "$SESSION_SH" init development >/dev/null
 nodes=$(jq -r '.phase_graph // [] | map(.name) | join(",")' "$NANOSTACK_STORE/session.json")
-assert_eq "default graph nodes" "think,plan,build,review,security,qa,ship" "$nodes"
+assert_eq "default graph nodes" "think,plan,build,review,qa,security,ship" "$nodes"
 # At init, ready_phases is populated with the graph roots (every node
 # with empty depends_on). For the default sprint that is just `think`.
 # A previous form populated this with []; that was the regression
@@ -112,8 +112,8 @@ assert_eq "next_phase at init = think" "think" "$next_init"
 echo "[2] default sprint walk preserves the historical next_phase order"
 new_project "cell2-default-walk"
 "$SESSION_SH" init development >/dev/null
-declare -a expected_next=("plan" "review" "security" "qa" "ship" "compound")
-declare -a phases_to_complete=("think" "plan" "review" "security" "qa" "ship")
+declare -a expected_next=("plan" "review" "qa" "security" "ship" "compound")
+declare -a phases_to_complete=("think" "plan" "review" "qa" "security" "ship")
 for i in 0 1 2 3 4 5; do
   ph="${phases_to_complete[$i]}"
   "$SESSION_SH" phase-start "$ph" >/dev/null
@@ -528,7 +528,7 @@ EOF
 "$SESSION_SH" init development >/dev/null
 nodes_before=$(jq -c '.phase_graph | map(.name)' "$NANOSTACK_STORE/session.json")
 assert_eq "before conductor: session phase_graph is the default sprint" \
-  '["think","plan","build","review","security","qa","ship"]' "$nodes_before"
+  '["think","plan","build","review","qa","security","ship"]' "$nodes_before"
 
 "$REPO/conductor/bin/sprint.sh" start --phases \
   '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"license-audit","depends_on":["build"]},{"name":"ship","depends_on":["license-audit"]}]' \
@@ -564,7 +564,7 @@ for ph in plan review; do
   "$SESSION_SH" phase-complete "$ph" >/dev/null
 done
 next_after_review=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
-assert_eq "/feature after review: next_phase != think" "security" "$next_after_review"
+assert_eq "/feature after review: next_phase != think" "qa" "$next_after_review"
 
 # Cell 9j: the guard's phase-gate reads required phases from the
 # session's phase_graph too. A custom workflow stack whose ship

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -94,7 +94,7 @@ echo "[1] session init snapshots the active phase_graph"
 new_project "cell1-default"
 "$SESSION_SH" init development >/dev/null
 nodes=$(jq -r '.phase_graph // [] | map(.name) | join(",")' "$NANOSTACK_STORE/session.json")
-assert_eq "default graph nodes" "think,plan,build,review,qa,security,ship" "$nodes"
+assert_eq "default graph nodes" "think,plan,build,review,security,qa,ship" "$nodes"
 # At init, ready_phases is populated with the graph roots (every node
 # with empty depends_on). For the default sprint that is just `think`.
 # A previous form populated this with []; that was the regression
@@ -112,8 +112,8 @@ assert_eq "next_phase at init = think" "think" "$next_init"
 echo "[2] default sprint walk preserves the historical next_phase order"
 new_project "cell2-default-walk"
 "$SESSION_SH" init development >/dev/null
-declare -a expected_next=("plan" "review" "qa" "security" "ship" "compound")
-declare -a phases_to_complete=("think" "plan" "review" "qa" "security" "ship")
+declare -a expected_next=("plan" "review" "security" "qa" "ship" "compound")
+declare -a phases_to_complete=("think" "plan" "review" "security" "qa" "ship")
 for i in 0 1 2 3 4 5; do
   ph="${phases_to_complete[$i]}"
   "$SESSION_SH" phase-start "$ph" >/dev/null

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -405,6 +405,50 @@ next_after=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
 assert_eq "after starting audit-a: ready drops audit-a" '["audit-b"]' "$ready_after"
 assert_eq "after starting audit-a: next_phase points at audit-b" "audit-b" "$next_after"
 
+# Cell 9d: a legacy session (no phase_graph snapshot, from a pre-PR-4
+# build) must fall back to the artifact-based legacy lookup so an
+# in-progress sprint upgraded mid-flight still advances. Codex flagged
+# the upgrade regression on the PR 4 fifth review pass.
+echo "[9d] legacy session without phase_graph uses artifact fallback"
+new_project "cell9d-legacy"
+cat > "$NANOSTACK_STORE/session.json" <<'EOF'
+{
+  "schema_version": "2",
+  "profile": "professional",
+  "phase_log": [
+    {"phase":"think","status":"completed"},
+    {"phase":"plan","status":"completed"},
+    {"phase":"review","status":"completed"}
+  ]
+}
+EOF
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "legacy session: next_phase = security (artifact fallback)" \
+  "security" "$(echo "$out" | jq -r '.next_phase')"
+assert_eq "legacy session: ready_phases includes qa" \
+  "true" "$(echo "$out" | jq '.ready_phases | any(. == "qa")')"
+assert_eq "legacy session: can_ship still false" \
+  "false" "$(echo "$out" | jq -r '.can_ship')"
+
+# Cell 9e: can_ship is derived from graph dependencies, not from
+# whether NEXT_PHASE happens to be "ship". For the default sprint
+# after review+qa+security complete, ship is ready and can_ship is
+# true regardless of which phase appears as next_phase. Codex flagged
+# the next_phase-vs-required_before_ship mismatch on the PR 4 fifth
+# review pass.
+echo "[9e] can_ship reflects required_before_ship, not next_phase identity"
+new_project "cell9e-canship"
+"$SESSION_SH" init development >/dev/null
+for ph in think plan review qa security; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "after r+q+s: ship is next_phase" "ship" "$(echo "$out" | jq -r '.next_phase')"
+assert_eq "after r+q+s: can_ship = true (deps met)" "true" "$(echo "$out" | jq -r '.can_ship')"
+assert_eq "after r+q+s: ready_phases = [ship]" \
+  '["ship"]' "$(echo "$out" | jq -c '.ready_phases')"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -506,6 +506,46 @@ assert_eq "after plan: can_ship = true (ship is ready)" "true" \
 assert_eq "after plan: next_phase = ship" "ship" \
   "$(echo "$out" | jq -r '.next_phase')"
 
+# Cell 9h: conductor sprint started with --phases (no config.phase_graph)
+# must update the session snapshot so next-step.sh sees the custom
+# graph. Before PR 4 pass 9 this entry point left the session pointing
+# at the default graph and next-step.sh suggested /review even though
+# the conductor had a license-audit chain. Codex caught the missed
+# conductor entry point on the ninth review pass.
+echo "[9h] conductor --phases updates the session phase_graph snapshot"
+new_project "cell9h-conductor"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"]}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit"
+cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: custom
+concurrency: read
+---
+EOF
+"$SESSION_SH" init development >/dev/null
+nodes_before=$(jq -c '.phase_graph | map(.name)' "$NANOSTACK_STORE/session.json")
+assert_eq "before conductor: session phase_graph is the default sprint" \
+  '["think","plan","build","review","security","qa","ship"]' "$nodes_before"
+
+"$REPO/conductor/bin/sprint.sh" start --phases \
+  '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"license-audit","depends_on":["build"]},{"name":"ship","depends_on":["license-audit"]}]' \
+  >/dev/null
+
+nodes_after=$(jq -c '.phase_graph | map(.name)' "$NANOSTACK_STORE/session.json")
+assert_eq "after conductor: session phase_graph is the conductor graph" \
+  '["think","plan","build","license-audit","ship"]' "$nodes_after"
+# Walk to confirm license-audit shows up as next_phase at the right time
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+next_after_plan=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
+assert_eq "after plan in a conductor sprint: next_phase = license-audit" \
+  "license-audit" "$next_after_plan"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -95,8 +95,15 @@ new_project "cell1-default"
 "$SESSION_SH" init development >/dev/null
 nodes=$(jq -r '.phase_graph // [] | map(.name) | join(",")' "$NANOSTACK_STORE/session.json")
 assert_eq "default graph nodes" "think,plan,build,review,qa,security,ship" "$nodes"
+# At init, ready_phases is populated with the graph roots (every node
+# with empty depends_on). For the default sprint that is just `think`.
+# A previous form populated this with []; that was the regression
+# Codex flagged on the PR 4 first review pass (a fresh session
+# falling through to ship+can_ship=true).
 ready_init=$(jq -c '.ready_phases // []' "$NANOSTACK_STORE/session.json")
-assert_eq "ready_phases starts empty" "[]" "$ready_init"
+assert_eq "ready_phases at init = [think] (default sprint root)" '["think"]' "$ready_init"
+next_init=$(jq -r '.next_phase // "null"' "$NANOSTACK_STORE/session.json")
+assert_eq "next_phase at init = think" "think" "$next_init"
 
 # Cell 2: default sprint progression matches the legacy ordering.
 # review/qa/security ARE ready in parallel after plan, but next_phase
@@ -249,9 +256,79 @@ done
 assert_true "guided user_message names the custom phase" \
   bash -c "echo '$msg' | grep -qiF 'privacy-check'"
 
-# Cell 7: default sprint user_message remains exactly the historical
+# Cell 8: a freshly-initialized custom session must report the root
+# of the graph as next_phase, NOT collapse to "ship". Codex caught
+# this on the PR 4 first review pass: a session with next_phase=null
+# and ready_phases=[] used to fall back to ship+can_ship=true even
+# though the required custom phases were still incomplete.
+echo "[8] fresh custom session reports the graph root, not ship"
+new_project "cell8-fresh"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["license-audit"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"license-audit","depends_on":["build"]},
+    {"name":"ship","depends_on":["license-audit"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/license-audit"
+cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
+---
+name: license-audit
+description: custom
+concurrency: read
+---
+EOF
+"$SESSION_SH" init development >/dev/null
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "fresh session next_phase = think (graph root)" "think" \
+  "$(echo "$out" | jq -r '.next_phase')"
+assert_eq "fresh session can_ship = false" "false" \
+  "$(echo "$out" | jq -r '.can_ship')"
+assert_eq "ready_phases at init = [think]" '["think"]' \
+  "$(echo "$out" | jq -c '.ready_phases')"
+
+# Cell 9: a custom graph that keeps the default phase names but
+# rewires the dependencies (review -> qa -> security serialized)
+# must use the graph-aware path. Codex caught the name-only detection
+# regression on the PR 4 first review pass: the previous "compare by
+# names" check treated the rewired graph as the default sprint and
+# the legacy peer logic could suggest security before qa.
+echo "[9] same-name-different-deps graph routes through graph-aware"
+new_project "cell9-rewired"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"review","depends_on":["build"]},
+    {"name":"qa","depends_on":["review"]},
+    {"name":"security","depends_on":["qa"]},
+    {"name":"ship","depends_on":["security"]}
+  ]
+}
+EOF
+"$SESSION_SH" init development >/dev/null
+for ph in think plan review; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+out=$("$NEXT_STEP" --json 2>/dev/null)
+assert_eq "rewired graph: after review, next_phase = qa (not security)" \
+  "qa" "$(echo "$out" | jq -r '.next_phase')"
+assert_eq "rewired graph: ready_phases = [qa]" \
+  '["qa"]' "$(echo "$out" | jq -c '.ready_phases')"
+assert_eq "rewired graph: can_ship still false" \
+  "false" "$(echo "$out" | jq -r '.can_ship')"
+
+# Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
-echo "[7] default sprint user_message is unchanged"
+echo "[10] default sprint user_message is unchanged"
 new_project "cell7-default-msg"
 "$SESSION_SH" init development >/dev/null
 for ph in think plan; do

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -326,6 +326,41 @@ assert_eq "rewired graph: ready_phases = [qa]" \
 assert_eq "rewired graph: can_ship still false" \
   "false" "$(echo "$out" | jq -r '.can_ship')"
 
+# Cell 9b: a graph that keeps the default node names AND dependencies
+# but declares them in a different ORDER (e.g. security before review)
+# is a legitimate custom graph. Codex caught this on the PR 4 second
+# review pass: sorting the outer node array during comparison made
+# next-step.sh suggest /review while session.json had next_phase=
+# security, breaking the single-source-of-truth contract.
+echo "[9b] reordered default graph routes through graph-aware"
+new_project "cell9b-reorder"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"security","depends_on":["build"]},
+    {"name":"review","depends_on":["build"]},
+    {"name":"qa","depends_on":["build"]},
+    {"name":"ship","depends_on":["review","qa","security"]}
+  ]
+}
+EOF
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+out=$("$NEXT_STEP" --json 2>/dev/null)
+# Reordered graph put security first; session.sh's graph-aware logic
+# picks the first declared ready phase. next-step.sh must agree.
+assert_eq "reordered graph: next_phase = security (declared first)" \
+  "security" "$(echo "$out" | jq -r '.next_phase')"
+session_next=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
+assert_eq "next-step agrees with session.json next_phase" \
+  "$session_next" "$(echo "$out" | jq -r '.next_phase')"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -361,6 +361,50 @@ session_next=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
 assert_eq "next-step agrees with session.json next_phase" \
   "$session_next" "$(echo "$out" | jq -r '.next_phase')"
 
+# Cell 9c: starting one of several ready phases drops it from
+# ready_phases so downstream schedulers do not start it twice. Codex
+# flagged the stale cache on the PR 4 third review pass: in a graph
+# where plan unblocks audit-a and audit-b in parallel, starting
+# audit-a used to leave session.json saying both were ready.
+echo "[9c] phase-start removes the active phase from ready_phases"
+new_project "cell9c-parallel"
+cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{
+  "custom_phases": ["audit-a","audit-b"],
+  "phase_graph": [
+    {"name":"think","depends_on":[]},
+    {"name":"plan","depends_on":["think"]},
+    {"name":"build","depends_on":["plan"]},
+    {"name":"audit-a","depends_on":["build"]},
+    {"name":"audit-b","depends_on":["build"]},
+    {"name":"ship","depends_on":["audit-a","audit-b"]}
+  ]
+}
+EOF
+mkdir -p "$NANOSTACK_STORE/skills/audit-a" "$NANOSTACK_STORE/skills/audit-b"
+for skill in audit-a audit-b; do
+  cat > "$NANOSTACK_STORE/skills/$skill/SKILL.md" <<EOF
+---
+name: $skill
+description: custom
+concurrency: read
+---
+EOF
+done
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+ready_before=$(jq -c '.ready_phases | sort' "$NANOSTACK_STORE/session.json")
+assert_eq "after plan: both audits are ready" '["audit-a","audit-b"]' "$ready_before"
+
+"$SESSION_SH" phase-start audit-a >/dev/null
+ready_after=$(jq -c '.ready_phases' "$NANOSTACK_STORE/session.json")
+next_after=$(jq -r '.next_phase' "$NANOSTACK_STORE/session.json")
+assert_eq "after starting audit-a: ready drops audit-a" '["audit-b"]' "$ready_after"
+assert_eq "after starting audit-a: next_phase points at audit-b" "audit-b" "$next_after"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -449,6 +449,29 @@ assert_eq "after r+q+s: can_ship = true (deps met)" "true" "$(echo "$out" | jq -
 assert_eq "after r+q+s: ready_phases = [ship]" \
   '["ship"]' "$(echo "$out" | jq -c '.ready_phases')"
 
+# Cell 9f: build is the conductor's no-artifact stage and is auto-
+# promoted to "satisfied" once its declared deps land, but only when
+# it is not currently in_progress. Codex caught the racy promotion
+# on the PR 4 sixth review pass: a caller that did session.sh
+# phase-start build still unblocked review/qa/security right away.
+echo "[9f] in-progress build does not unblock downstream phases"
+new_project "cell9f-build-running"
+"$SESSION_SH" init development >/dev/null
+for ph in think plan; do
+  "$SESSION_SH" phase-start "$ph" >/dev/null
+  "$SESSION_SH" phase-complete "$ph" >/dev/null
+done
+"$SESSION_SH" phase-start build >/dev/null
+ready_during_build=$(jq -c '.ready_phases' "$NANOSTACK_STORE/session.json")
+assert_eq "build in_progress: ready_phases is empty" '[]' "$ready_during_build"
+# Once build is conceptually done (the user finishes the dev work and
+# the next phase-start lands), review/qa/security come back online.
+# We simulate the dev finishing build by completing it explicitly.
+"$SESSION_SH" phase-complete build >/dev/null
+ready_after_build=$(jq -c '.ready_phases | sort' "$NANOSTACK_STORE/session.json")
+assert_eq "build completed: post-build phases ready" \
+  '["qa","review","security"]' "$ready_after_build"
+
 # Cell 10: default sprint user_message remains exactly the historical
 # wording. No regression for built-in flows.
 echo "[10] default sprint user_message is unchanged"

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -30,15 +30,20 @@ else
 fi
 PROJECT_HASH=$(printf '%s' "$PROJECT" | nano_sha256 | cut -c1-12)
 
-# Default phases and dependency graph
+# Default phases and dependency graph. Node order under review/qa/
+# security and ship.depends_on match bin/lib/phases.sh's default
+# graph so a conductor sprint that mirrors into session.json does
+# not change next_phase ordering vs a session that came from
+# bin/session.sh init alone. Codex caught the drift between the two
+# defaults on the PR 4 tenth review pass.
 DEFAULT_PHASES='[
   {"name":"think","depends_on":[]},
   {"name":"plan","depends_on":["think"]},
   {"name":"build","depends_on":["plan"]},
   {"name":"review","depends_on":["build"]},
-  {"name":"qa","depends_on":["build"]},
   {"name":"security","depends_on":["build"]},
-  {"name":"ship","depends_on":["review","qa","security"]}
+  {"name":"qa","depends_on":["build"]},
+  {"name":"ship","depends_on":["review","security","qa"]}
 ]'
 
 # Detect agent name. Identity must be stable within one process and unique

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -34,16 +34,15 @@ PROJECT_HASH=$(printf '%s' "$PROJECT" | nano_sha256 | cut -c1-12)
 # security and ship.depends_on match bin/lib/phases.sh's default
 # graph so a conductor sprint that mirrors into session.json does
 # not change next_phase ordering vs a session that came from
-# bin/session.sh init alone. Codex caught the drift between the two
-# defaults on the PR 4 tenth review pass.
+# bin/session.sh init alone.
 DEFAULT_PHASES='[
   {"name":"think","depends_on":[]},
   {"name":"plan","depends_on":["think"]},
   {"name":"build","depends_on":["plan"]},
   {"name":"review","depends_on":["build"]},
-  {"name":"security","depends_on":["build"]},
   {"name":"qa","depends_on":["build"]},
-  {"name":"ship","depends_on":["review","security","qa"]}
+  {"name":"security","depends_on":["build"]},
+  {"name":"ship","depends_on":["review","qa","security"]}
 ]'
 
 # Detect agent name. Identity must be stable within one process and unique

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -197,6 +197,35 @@ cmd_start() {
       phases: $phases
     }' > "$sprint_dir/sprint.json"
 
+  # Mirror the active graph into the session snapshot so
+  # bin/session.sh phase-complete and bin/next-step.sh see the same
+  # source of truth. Without this, conductor sprints started with
+  # --phases on the CLI (no project config.phase_graph) left the
+  # session pointing at the default graph and next-step.sh suggested
+  # default-sprint phases even for a custom stack. PR 4 of the
+  # 2026-05-10 architecture audit added the snapshot; Codex caught
+  # the missed conductor entry point on the ninth review pass.
+  local session_file="$NANOSTACK_STORE/session.json"
+  if [ -f "$session_file" ] && [ -n "$phases" ]; then
+    local ready_seed
+    if declare -F nano_phase_ready_from_graph >/dev/null 2>&1; then
+      local completed_seed in_progress_seed
+      completed_seed=$(jq -c '[(.phase_log // [])[] | select(.status == "completed") | .phase] | unique' "$session_file" 2>/dev/null || echo "[]")
+      in_progress_seed=$(jq -c '[(.phase_log // [])[] | select(.status == "in_progress") | .phase] | unique' "$session_file" 2>/dev/null || echo "[]")
+      ready_seed=$(nano_phase_ready_from_graph "$phases" "$completed_seed" "$in_progress_seed" 2>/dev/null \
+        | jq -R . | jq -sc 'map(select(length > 0))')
+    fi
+    [ -z "$ready_seed" ] && ready_seed="[]"
+    local next_seed
+    next_seed=$(echo "$ready_seed" | jq -r '.[0] // "null"')
+    [ "$next_seed" = "null" ] && next_seed='null' || next_seed="\"$next_seed\""
+    jq --argjson graph "$phases" --argjson ready "$ready_seed" --argjson next "$next_seed" \
+      '.phase_graph = $graph
+       | .ready_phases = $ready
+       | .next_phase = (if ($next | type) == "string" then $next else null end)' \
+      "$session_file" > "${session_file}.tmp" && mv "${session_file}.tmp" "$session_file" || true
+  fi
+
   echo "$sprint_dir"
 }
 

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -47,13 +47,17 @@ PROJECT="$(pwd)"
 REQUIRED_PHASES="review security qa"
 if [ -f "$SESSION_FILE" ] && command -v jq >/dev/null 2>&1; then
   # The session-level phase_graph is the source of truth when it
-  # exists. We separate "graph absent" (legacy fallback) from "graph
-  # present but no post-build gates" (a legitimate custom workflow
-  # where nothing must run before ship) by checking the array length
-  # first. Codex flagged the symmetric collapse on the PR 4 twelfth
-  # review pass: an empty filter result used to drop back to the
-  # built-in trio, so a think-plan-build-ship graph could not commit.
-  if jq -e '(.phase_graph // []) | length > 0' "$SESSION_FILE" >/dev/null 2>&1; then
+  # contains a `ship` node. We separate three cases:
+  #   - graph absent             → legacy review/security/qa default
+  #   - graph present + ship in  → graph-derived ancestors of ship
+  #   - graph present + no ship  → legacy review/security/qa default
+  #     (fail closed: the gate exists to protect ship-like actions, so
+  #     a graph without ship cannot loosen the gate. Codex caught the
+  #     ship-absent bypass on the PR 4 fourteenth review pass.)
+  # The middle case may legitimately produce an empty array (a graph
+  # like think -> plan -> build -> ship has no post-build gates), and
+  # the gate honors that.
+  if jq -e '(.phase_graph // []) | map(.name) | any(. == "ship")' "$SESSION_FILE" >/dev/null 2>&1; then
     REQUIRED_PHASES=$(jq -r '
       (.phase_graph // []) as $g
       | def ancestors($name):

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -37,7 +37,31 @@ FIND_ARTIFACT="$NANOSTACK_ROOT/bin/find-artifact.sh"
 SESSION_SH="$NANOSTACK_ROOT/bin/session.sh"
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 PROJECT="$(pwd)"
+
+# Default required phases for the built-in sprint. The session's
+# phase_graph (when present) overrides this with the actual ancestors
+# of ship so a custom workflow stack gates on its own phases instead
+# of the built-in trio. PR 4 of the 2026-05-10 architecture audit
+# made the phase-gate graph-aware; Codex caught the gate-vs-can_ship
+# drift on the eleventh review pass.
 REQUIRED_PHASES="review security qa"
+if [ -f "$SESSION_FILE" ] && command -v jq >/dev/null 2>&1; then
+  graph_required=$(jq -r '
+    (.phase_graph // []) as $g
+    | def ancestors($name):
+        ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
+        | $deps + ($deps | map(ancestors(.)) | add // []);
+      (ancestors("ship")) as $ancs
+      | [$g[].name
+          | select(. as $n | $ancs | any(. == $n))
+          | select(. != "think" and . != "plan" and . != "build")
+        ]
+      | join(" ")
+  ' "$SESSION_FILE" 2>/dev/null)
+  if [ -n "$graph_required" ]; then
+    REQUIRED_PHASES="$graph_required"
+  fi
+fi
 
 # ─── Reference timestamp: latest code change ────────────────
 last_code_timestamp() {

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -140,6 +140,12 @@ print_block() {
       review)   echo "  /review   — Code review" ;;
       security) echo "  /security — Security audit" ;;
       qa)       echo "  /qa       — Testing" ;;
+      # PR 4 of the 2026-05-10 audit made the gate graph-aware, so the
+      # missing list can include custom phases (license-audit, etc).
+      # The default case keeps the remediation actionable for those
+      # users instead of printing a blank section. Codex caught the
+      # empty-section regression on the fifteenth review pass.
+      *)        echo "  /$phase — custom workflow phase (run its skill)" ;;
     esac
   done
   echo ""
@@ -156,6 +162,7 @@ print_warning() {
       review)   echo "  /review   — Code review" ;;
       security) echo "  /security — Security audit" ;;
       qa)       echo "  /qa       — Testing" ;;
+      *)        echo "  /$phase — custom workflow phase (run its skill)" ;;
     esac
   done
   echo ""

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -169,8 +169,15 @@ if [ -f "$SESSION_FILE" ]; then
       exit 0
     fi
 
-    # Skip if no phases have started (session just initialized)
-    PHASES_STARTED=$(jq -r '.phase_log | length' "$SESSION_FILE" 2>/dev/null || echo "0")
+    # Skip if no phases have started (session just initialized). The
+    # filter excludes synthetic entries (source: "feature-skip" or
+    # similar markers) so a /feature session that pre-seeded think as
+    # completed at init does not activate the gate before /plan runs.
+    # Codex caught the premature-block regression on the PR 4
+    # thirteenth review pass.
+    PHASES_STARTED=$(jq -r '
+      [.phase_log[]? | select((.source // "") | startswith("feature-skip") | not)] | length
+    ' "$SESSION_FILE" 2>/dev/null || echo "0")
     if [ "$PHASES_STARTED" -eq 0 ]; then
       exit 0
     fi

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -46,20 +46,26 @@ PROJECT="$(pwd)"
 # drift on the eleventh review pass.
 REQUIRED_PHASES="review security qa"
 if [ -f "$SESSION_FILE" ] && command -v jq >/dev/null 2>&1; then
-  graph_required=$(jq -r '
-    (.phase_graph // []) as $g
-    | def ancestors($name):
-        ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
-        | $deps + ($deps | map(ancestors(.)) | add // []);
-      (ancestors("ship")) as $ancs
-      | [$g[].name
-          | select(. as $n | $ancs | any(. == $n))
-          | select(. != "think" and . != "plan" and . != "build")
-        ]
-      | join(" ")
-  ' "$SESSION_FILE" 2>/dev/null)
-  if [ -n "$graph_required" ]; then
-    REQUIRED_PHASES="$graph_required"
+  # The session-level phase_graph is the source of truth when it
+  # exists. We separate "graph absent" (legacy fallback) from "graph
+  # present but no post-build gates" (a legitimate custom workflow
+  # where nothing must run before ship) by checking the array length
+  # first. Codex flagged the symmetric collapse on the PR 4 twelfth
+  # review pass: an empty filter result used to drop back to the
+  # built-in trio, so a think-plan-build-ship graph could not commit.
+  if jq -e '(.phase_graph // []) | length > 0' "$SESSION_FILE" >/dev/null 2>&1; then
+    REQUIRED_PHASES=$(jq -r '
+      (.phase_graph // []) as $g
+      | def ancestors($name):
+          ($g | map(select(.name == $name)) | first // {depends_on:[]}).depends_on as $deps
+          | $deps + ($deps | map(ancestors(.)) | add // []);
+        (ancestors("ship")) as $ancs
+        | [$g[].name
+            | select(. as $n | $ancs | any(. == $n))
+            | select(. != "think" and . != "plan" and . != "build")
+          ]
+        | join(" ")
+    ' "$SESSION_FILE" 2>/dev/null)
   fi
 fi
 

--- a/reference/session-state-contract.md
+++ b/reference/session-state-contract.md
@@ -63,7 +63,7 @@ Read `.user_message` for the next action and `.next_phase` for the phase name. T
 | `next_phase` | string | The single phase the skill should suggest next. For the default sprint this picks the first phase in graph order. For a custom workflow stack this is the next ready phase from the project's `phase_graph`. |
 | `pending_phases` | array | Every phase that is ready to run right now (the legacy name). Mirrors `ready_phases` for forward compatibility. |
 | `ready_phases` | array | Every phase whose dependencies are met. Use this when the skill wants to surface "you could run any of these in parallel" instead of a single suggestion. |
-| `required_before_ship` | array | The set of phases ship depends on (transitively). For the default sprint it is `["review","security","qa"]`. For a custom graph it reflects the actual chain (for example `["license-audit","privacy-check","release-readiness"]`). |
+| `required_before_ship` | array | The set of phases ship depends on (transitively), emitted in the graph's declared node order. For the default sprint it is `["review","qa","security"]`; for a custom graph it reflects the actual chain (for example `["license-audit","privacy-check","release-readiness"]`). Treat the field as a set; consumers that compare the array exactly should sort before comparing. |
 | `user_message` | string | The next-action prose shaped by profile. For phases the script does not have specific copy for, it falls back to `"I will run the <phase> step next."` (guided) or `"Run /<phase> next."` (professional) and never exposes phase-graph jargon. |
 | `can_ship` | boolean | True when nothing in `required_before_ship` is still pending. |
 

--- a/reference/session-state-contract.md
+++ b/reference/session-state-contract.md
@@ -55,6 +55,30 @@ Stop encoding next-step prose in each skill. Call:
 
 Read `.user_message` for the next action and `.next_phase` for the phase name. The script reads `session.json` first, falls back to fresh artifacts, and chooses wording based on `profile`. Skills must NOT print their own list of pending phases.
 
+`--json` returns these fields (PR 4 of the 2026-05-10 architecture audit made the lifecycle graph-aware):
+
+| Field | Type | What it carries |
+|-------|------|-----------------|
+| `profile` | string | `guided` or `professional`, sourced from the session. |
+| `next_phase` | string | The single phase the skill should suggest next. For the default sprint this picks the first phase in graph order. For a custom workflow stack this is the next ready phase from the project's `phase_graph`. |
+| `pending_phases` | array | Every phase that is ready to run right now (the legacy name). Mirrors `ready_phases` for forward compatibility. |
+| `ready_phases` | array | Every phase whose dependencies are met. Use this when the skill wants to surface "you could run any of these in parallel" instead of a single suggestion. |
+| `required_before_ship` | array | The set of phases ship depends on (transitively). For the default sprint it is `["review","security","qa"]`. For a custom graph it reflects the actual chain (for example `["license-audit","privacy-check","release-readiness"]`). |
+| `user_message` | string | The next-action prose shaped by profile. For phases the script does not have specific copy for, it falls back to `"I will run the <phase> step next."` (guided) or `"Run /<phase> next."` (professional) and never exposes phase-graph jargon. |
+| `can_ship` | boolean | True when nothing in `required_before_ship` is still pending. |
+
+## Graph-aware session fields
+
+When `session.sh init` runs, it snapshots the active `phase_graph` into `session.json` so a mid-sprint edit to `.nanostack/config.json` cannot change the path under the session. `session.sh phase-complete` reads that snapshot and updates `next_phase` plus `ready_phases` after every phase write.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `phase_graph` | array | The snapshot of `{name, depends_on}` pairs taken at session init. Empty array when the host did not have the phase registry library available (legacy fallback). |
+| `next_phase` | string \| null | The first ready phase after the latest `phase-complete`. `compound` after `ship`. `null` when no phase is ready (sprint complete and no custom continuation). |
+| `ready_phases` | array | Every phase whose dependencies are satisfied and which is not yet completed or in progress. May contain multiple entries when a graph runs phases in parallel. |
+
+Skills that need fan-out scheduling read `ready_phases`; skills that just want the next single phase read `next_phase`.
+
 ## report_only guard
 
 Place this near the top of the skill's process section, before any edit/fix step:


### PR DESCRIPTION
## Summary

`bin/session.sh`'s `phase-complete` used a hardcoded case statement that only knew the built-in sprint (think -> plan -> review/qa/security -> ship -> compound). Custom workflow stacks ran through the conductor and the artifact store, then hit the default branch with no match and set `next_phase` to null forever. `bin/next-step.sh` had its own hardcoded peer list. `guard/bin/phase-gate.sh` blocked git commit based on the same hardcoded trio.

This PR makes all three layers graph-aware. They read the active `phase_graph` from `session.json`, walk it with `nano_phase_ready_from_graph`, and surface the next ready phase plus the full ready set. Custom workflow stacks now get native lifecycle support; the default sprint keeps the same progression and the same blocking semantics it always had.

## What changes

`bin/lib/phases.sh`

New `nano_phase_ready_from_graph <graph> <completed> [in_progress]` returns every phase whose `depends_on` is satisfied AND which is neither in `completed` nor `in_progress`. The conductor's `build` stage is auto-promoted when its own deps are satisfied AND it is not currently in_progress (so a session that records `phase-start build` does not falsely unblock the post-build trio).

`bin/session.sh`

- `init` snapshots the active `phase_graph` into `session.json` and seeds `ready_phases` plus `next_phase` from the graph's roots (so a fresh session reports `next_phase = think` instead of falling back to ship).
- `init feature` pre-seeds a completed `think` entry (with `source: "feature-skip"`) because feature/SKILL.md skips `/think` by contract.
- `phase-start` recomputes `ready_phases` so the active phase drops out of the ready set (no double-starting parallel branches).
- `phase-complete` reads the session's graph snapshot, runs the ready-set computation, and writes both `next_phase` and `ready_phases`. The post-ship `compound` hint stays as a tail because compound is not in the canonical graph.

`bin/next-step.sh`

- When the session has a `phase_graph`, it trusts the session-computed `ready_phases` and `next_phase`. No more rebuilding from artifact lookups (which used to leak in-progress phases as ready).
- Legacy sessions without a `phase_graph` snapshot fall back to the artifact-based peer lookup so an upgrade in-flight does not strand the sprint.
- `required_before_ship` is derived from the graph's ship-ancestors (excluding think/plan/build). For the default sprint that yields `["review","qa","security"]` (graph order); for a custom graph it returns the actual chain.
- `can_ship` is derived from "ship is in ready_phases" or "ship has completed". Not from "is NEXT_PHASE = ship".

`guard/bin/phase-gate.sh`

- `REQUIRED_PHASES` reads the same graph snapshot. A custom graph that gates ship on `license-audit` now blocks git commit until `license-audit` completes; the legacy default kicks in only when the session has no `phase_graph` OR when the graph omits a `ship` node (fail-closed: a graph without ship cannot loosen the gate).
- The "phases started" counter filters out synthetic `source: "feature-skip"` entries so a freshly-initialized `/feature` session does not activate the gate before `/plan` runs.
- `print_block` and `print_warning` have a default case that prints `"/$phase — custom workflow phase (run its skill)"` so custom-phase remediation is actionable.

`conductor/bin/sprint.sh`

- `start` mirrors the active `phases` JSON into `session.json` after writing the sprint definition. The conductor's `--phases` CLI entry point now updates the session graph snapshot too, so `next-step.sh` sees the same source of truth.
- `DEFAULT_PHASES` matches `bin/lib/phases.sh`'s default graph (same node order, same `ship.depends_on`) so a bare `sprint.sh start` does not change `next_phase` ordering vs `session.sh init` alone.

`reference/session-state-contract.md`

New "Graph-aware session fields" section documents `phase_graph`, `next_phase`, `ready_phases`, and `required_before_ship`. The required-before-ship field is graph-ordered with set semantics.

`ci/e2e-graph-aware-session.sh` (new)

13 cells, 61 checks. Covers: default sprint progression, parallel fan-out after plan, the spec acceptance walk (build -> license-audit -> privacy-check -> release-readiness -> ship), custom `required_before_ship`, guided wording without graph jargon, fresh session reports graph root, rewired-default-name graph routes graph-aware, parallel phase-start drops from ready, legacy session fallback, can_ship vs next_phase, build-in-progress dependency block, conductor `--phases` mirroring, /feature pre-seeded think, phase-gate graph-aware blocking, no-gate graph allows commit, /feature pre-seed does not activate gate, ship-less graph falls back to legacy. Wired into `.github/workflows/e2e.yml`.

Lint: new `session-graph-aware-wiring` job greps that `session.sh` sources `phases.sh`, calls `nano_phase_ready_from_graph`, and writes `phase_graph` + `ready_phases` at init; and that `next-step.sh` emits `ready_phases` and reads `phase_graph`. Existing `next-step-contract` job was updated to walk past think + plan before asserting the post-build state.

## What does not change

- Default sprint progression is unchanged: after `/plan`, `next_phase = review`; after `/review`, `next_phase = qa`; then `security`; then `ship`; then `compound`.
- `/feature` still skips `/think`. It starts at `/plan`.
- Legacy text-mode `next-step.sh <phase>` still works for the review/security/qa peer callers that pass their own phase.
- Phase-gate's external behavior on the default sprint is unchanged.
- Existing CI E2E suites pass without modification: user-flows, custom-stack-flows, custom-stack-examples, artifact-trust, structured-artifacts, delivery-matrix, examples, think-flows, think-archetypes, onboarding-flows.

## Codex review trail (16 iterations)

Each finding from sixteen Codex review passes lives in its own commit. The full trail covers:

1. Initial graph-aware session + next-step + E2E.
2. Full-graph detection (not name-only) + ready-aware fallback.
3. Preserve declared node order in graph comparison.
4. `phase-start` recomputes ready_phases.
5. `next-step.sh` trusts session.ready_phases (drops the in-progress leak in the default branch).
6. Legacy session fallback when no phase_graph snapshot; can_ship derived from graph not next_phase.
7. `build`-in-progress does not auto-satisfy downstream phases.
8. `required_before_ship` preserves declared order (no jq `unique` sort).
9. `can_ship` gates on ship readiness for graphs with no post-build gates.
10. Conductor sprint start mirrors the active graph into session.json.
11. Conductor `DEFAULT_PHASES` matches `phases.sh` default order.
12. `/feature` pre-seeds completed think; `phase-gate.sh` becomes graph-aware.
13. `phase-gate.sh` respects an empty graph-derived gate set.
14. `phase-gate.sh` ignores `feature-skip` synthetic entries.
15. `phase-gate.sh` fails closed when ship is absent from the graph.
16. Restore the legacy review -> qa -> security default progression (resolves the array-order vs progression tension from earlier passes).
17. `print_block`/`print_warning` have a custom-phase default case; doc updated to match the graph-derived `required_before_ship` order.

Final pass clean: "No discrete, actionable regressions were identified in the diff."

## Tests

All checks green locally (12 suites):

- `ci/e2e-user-flows.sh`: 100 checks.
- `ci/e2e-custom-stack-flows.sh`: 40 checks.
- `ci/e2e-custom-stack-examples.sh`: 51 checks.
- `ci/e2e-artifact-trust.sh`: 29 checks.
- `ci/e2e-structured-artifacts.sh`: 31 checks.
- `ci/e2e-graph-aware-session.sh`: 61 checks (new).
- `ci/e2e-delivery-matrix.sh`: 17 cells.
- `ci/e2e-examples.sh`: 40 checks.
- `ci/e2e-think-flows.sh`: 32 checks.
- `ci/e2e-think-archetypes.sh`: 25 checks.
- `ci/e2e-onboarding-flows.sh`: 34 checks.
- `tests/run.sh` (local-only): 83 tests.
- `tests/e2e-user-flows.sh` (local-only): 5 checks.

Total: 548 checks across 13 suites.

## Spec

PR 4 of the 2026-05-10 Nanostack Architecture Audit vNext. Closes the P1 finding "Session And Next-Step Logic Are Still Hardcoded To The Built-In Sprint". Acceptance criteria from the spec, all met:

- [x] In a graph `build -> license-audit -> privacy-check -> release-readiness -> ship`, completing license-audit sets `next_phase = "privacy-check"` (cell 4).
- [x] When multiple ready phases exist, `next-step.sh --json` returns all ready phases in `pending_phases` (and the new `ready_phases` field).
- [x] Default sprint output remains unchanged (cells 2, 10).
- [x] Guided wording does not expose internal "phase graph" jargon (cell 6).

Next: PR 5 — Custom Routing Contract. Lets custom skills declare context needs (trust level, max_age, solution tags, diarization paths, required vs optional upstreams) via SKILL.md frontmatter or `.nanostack/config.json` so resolve.sh stops being dependency-only for custom phases.

## Test plan

- [ ] `bash ci/e2e-graph-aware-session.sh` reports 61 of 61 checks passed.
- [ ] Default sprint walk: `session.sh init development` -> phase-start/complete think,plan,review,qa,security,ship and confirm `next_phase` advances through the historical order (review -> qa -> security -> ship -> compound).
- [ ] Spec acceptance walk: same with a compliance-release `phase_graph`; completing license-audit lands next_phase on privacy-check.
- [ ] All existing CI E2E suites still pass.
- [ ] New lint job `session-graph-aware-wiring` passes.
- [ ] `next-step-contract` lint job still passes after the think+plan preface.