### PR TITLE
secret-write-parity: block credential JSON at write (PR 7 of architecture vNext)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -842,6 +842,24 @@ jobs:
           run_case 1 'supabase-service-role.json'
           run_case 1 'client-secrets.json'
           run_case 1 'client_secret.json'
+          # Separator-less credential JSON variants. Codex caught
+          # the missing optional separator on the PR 7 first review
+          # pass: G-035 read-side allows [-_]? but the initial
+          # write patterns required the separator.
+          run_case 1 'serviceaccount.json'
+          run_case 1 'firebaseadminsdk.json'
+          run_case 1 'googlecredentials.json'
+          run_case 1 'clientsecret.json'
+          run_case 1 'awscredentials.json'
+          run_case 1 'gcpcredentials.json'
+          # Protected directories still block even when the leaf has
+          # a template-looking basename. Codex caught the over-broad
+          # template exemption on the PR 7 first review pass:
+          # $HOME/.ssh/config.example must not become a bypass.
+          run_case 1 "$HOME/.ssh/config.example"
+          run_case 1 "$HOME/.ssh/config.template"
+          run_case 1 "/etc/foo.template"
+          run_case 1 "/etc/foo.sample"
           # Allowed: templates + regular project files. Template
           # basenames (.example, .sample, .template, with or without
           # extension) MUST pass even when the rest of the name looks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -861,6 +861,18 @@ jobs:
           run_case 1 'secret-prod.json'
           run_case 1 'secrets-backup.json'
           run_case 1 'credentials.dev.json'
+          # Mixed-case credential JSON. Codex caught the case gap on
+          # the PR 7 third review pass: read-side G-035 is case-
+          # insensitive, so the write side must match too.
+          run_case 1 'Credentials.json'
+          run_case 1 'Service-Account.json'
+          run_case 1 'AWS-Credentials.json'
+          run_case 1 'Firebase-Adminsdk.json'
+          run_case 1 'SECRETS.json'
+          run_case 1 '.ENV'
+          # Mixed-case templates stay allowed.
+          run_case 0 'credentials.Example.json'
+          run_case 0 'Service-Account.Template.json'
           # Protected directories still block even when the leaf has
           # a template-looking basename. Codex caught the over-broad
           # template exemption on the PR 7 first review pass:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -812,6 +812,8 @@ jobs:
           run_case 1 '.env'
           run_case 1 '.env.local'
           run_case 1 '.env.production'
+          run_case 1 '.env.staging'
+          run_case 1 '.env.test'
           run_case 1 './secrets/key.pem'
           run_case 1 'path/to/authorized_keys'
           run_case 1 'config.key'
@@ -820,13 +822,43 @@ jobs:
           run_case 1 '/usr/bin/ls'
           run_case 1 "$HOME/.ssh/id_rsa"
           run_case 1 "$HOME/.aws/credentials"
-          # Allowed: templates + regular project files.
+          # PR 7 of the 2026-05-10 architecture audit: credential
+          # JSON basenames must block at write time the same way they
+          # block at read time. The shapes here mirror the G-035
+          # read-guard rule in guard/rules.json.
+          run_case 1 'credentials.json'
+          run_case 1 'credential.json'
+          run_case 1 'secrets.json'
+          run_case 1 'secret.json'
+          run_case 1 'service-account.json'
+          run_case 1 'service_account.json'
+          run_case 1 'service-account-prod.json'
+          run_case 1 'firebase-adminsdk.json'
+          run_case 1 'firebase-adminsdk-staging.json'
+          run_case 1 'google-credentials.json'
+          run_case 1 'gcp-credentials.json'
+          run_case 1 'aws-credentials.json'
+          run_case 1 'aws-credentials-prod.json'
+          run_case 1 'supabase-service-role.json'
+          run_case 1 'client-secrets.json'
+          run_case 1 'client_secret.json'
+          # Allowed: templates + regular project files. Template
+          # basenames (.example, .sample, .template, with or without
+          # extension) MUST pass even when the rest of the name looks
+          # like a secret, otherwise first-run onboarding fights the
+          # guard.
           run_case 0 '.env.example'
           run_case 0 '.env.sample'
           run_case 0 '.env.template'
+          run_case 0 'credentials.example.json'
+          run_case 0 'service-account.example.json'
+          run_case 0 'service-account.template.json'
+          run_case 0 'firebase-adminsdk.sample.json'
           run_case 0 'README.md'
           run_case 0 'src/config.js'
           run_case 0 'package.json'
+          run_case 0 'firebase.json'
+          run_case 0 'tsconfig.json'
           run_case 0 '/tmp/scratch.txt'
           # JSON input path (Claude Code PreToolUse contract).
           if ! echo '{"tool_name":"Write","tool_input":{"file_path":".env"}}' \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -852,6 +852,15 @@ jobs:
           run_case 1 'clientsecret.json'
           run_case 1 'awscredentials.json'
           run_case 1 'gcpcredentials.json'
+          # Suffixed generic credential / secret JSON. Codex caught
+          # the missing suffix support on the PR 7 second review
+          # pass: G-035 read-side blocks credentials-prod.json and
+          # secrets-backup.json; the write side now does too.
+          run_case 1 'credentials-prod.json'
+          run_case 1 'credential-staging.json'
+          run_case 1 'secret-prod.json'
+          run_case 1 'secrets-backup.json'
+          run_case 1 'credentials.dev.json'
           # Protected directories still block even when the leaf has
           # a template-looking basename. Codex caught the over-broad
           # template exemption on the PR 7 first review pass:

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -122,6 +122,27 @@ fi
 # Each entry is a POSIX extended regex evaluated against the absolute or
 # relative file path. Intentionally narrow: false positives train users
 # to ignore the block, and this hook cannot afford that.
+#
+# PR 7 of the 2026-05-10 architecture audit: closed the gap where read
+# guard (G-035 in guard/rules.json) blocked credential JSON basenames
+# but write/edit allowed them. The deny list now mirrors the read
+# side for credential JSON files; templates (.env.example,
+# credentials.example.json, service-account.template.json, etc.) are
+# explicitly allowed through TEMPLATE_ALLOW so first-run onboarding
+# does not fight the guard.
+
+# Template basenames that should ALWAYS pass through, even when the
+# rest of the filename looks like a secret. Runs before the deny
+# matcher. Matches the common ".example", ".sample", ".template"
+# infix that signals "documentation copy, no secrets".
+TEMPLATE_ALLOW=(
+  '\.example$'
+  '\.sample$'
+  '\.template$'
+  '\.example\.[a-zA-Z0-9]+$'
+  '\.sample\.[a-zA-Z0-9]+$'
+  '\.template\.[a-zA-Z0-9]+$'
+)
 
 # Basename-based patterns (match any path ending in this filename).
 BASENAME_DENY=(
@@ -133,6 +154,24 @@ BASENAME_DENY=(
   '\.env\.staging$'
   '\.env\.development$'
   '\.env\.dev$'
+  '\.env\.test$'
+  # Credential JSON files. Mirrors the read-side deny added in PR
+  # #195 (G-035 in guard/rules.json). The shapes cover the common
+  # SDK conventions: credentials.json, secrets.json, service-account
+  # /service_account, firebase-adminsdk, google-credentials,
+  # gcp-credentials, aws-credentials, supabase-service-role,
+  # client-secret(s) / client_secret. The base patterns match the
+  # plain name and any same-stem variant such as
+  # service-account-prod.json or aws-credentials-staging.json.
+  '(^|/)credentials?\.json$'
+  '(^|/)secrets?\.json$'
+  '(^|/)service[-_]account[^/]*\.json$'
+  '(^|/)firebase[-_]adminsdk[^/]*\.json$'
+  '(^|/)google[-_]credentials[^/]*\.json$'
+  '(^|/)gcp[-_]credentials[^/]*\.json$'
+  '(^|/)aws[-_]credentials[^/]*\.json$'
+  '(^|/)supabase[-_]service[-_]role[^/]*\.json$'
+  '(^|/)client[-_]secret[s]?[^/]*\.json$'
   # Private cryptographic material.
   '\.pem$'
   '\.key$'
@@ -181,6 +220,19 @@ MATCHED_PATH=""
 
 check_path() {
   local p="$1" pat
+  # Template short-circuit: files whose basename ends in `.example`,
+  # `.sample`, `.template` (with or without an extension after) pass
+  # through, even if the rest of the name matches a credential
+  # pattern. This is the safe surface for first-run onboarding
+  # (credentials.example.json, service-account.template.json,
+  # .env.example, etc.).
+  local base
+  base=$(basename "$p")
+  for pat in "${TEMPLATE_ALLOW[@]}"; do
+    if printf '%s' "$base" | grep -qE -- "$pat"; then
+      return 1
+    fi
+  done
   for pat in "${BASENAME_DENY[@]}"; do
     if printf '%s' "$p" | grep -qE -- "$pat"; then
       MATCHED_RULE="secret_basename:$pat"

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -165,8 +165,13 @@ BASENAME_DENY=(
   # firebaseadminsdk.json, googlecredentials.json, clientsecret.json)
   # are caught too. Codex flagged the missing separator-less forms
   # on the PR 7 first review pass.
-  '(^|/)credentials?\.json$'
-  '(^|/)secrets?\.json$'
+  # `[^/]*` allows env / region suffixes (credentials-prod.json,
+  # secrets-backup.json, credential-staging.json) without breaking
+  # the TEMPLATE_ALLOW exemption that runs first and lets
+  # credentials.example.json through. Codex flagged the missing
+  # suffix support on the PR 7 second review pass.
+  '(^|/)credentials?[^/]*\.json$'
+  '(^|/)secrets?[^/]*\.json$'
   '(^|/)service[-_]?account[^/]*\.json$'
   '(^|/)firebase[-_]?adminsdk[^/]*\.json$'
   '(^|/)google[-_]?credentials[^/]*\.json$'

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -243,14 +243,22 @@ check_path() {
   local base is_template=false
   base=$(basename "$p")
   for pat in "${TEMPLATE_ALLOW[@]}"; do
-    if printf '%s' "$base" | grep -qE -- "$pat"; then
+    # Case-insensitive match so the deny side and the allow side
+    # share the same case policy. credentials.Example.json must
+    # still pass even when the deny grep below is -i too.
+    if printf '%s' "$base" | grep -qiE -- "$pat"; then
       is_template=true
       break
     fi
   done
   if [ "$is_template" = false ]; then
     for pat in "${BASENAME_DENY[@]}"; do
-      if printf '%s' "$p" | grep -qE -- "$pat"; then
+      # Case-insensitive match: read-side G-035 in guard/rules.json
+      # is `grep -qiE`, so mixed-case filenames like
+      # Credentials.json, AWS-Credentials.json, or ID_RSA must not
+      # become a bypass. Codex flagged the case gap on the PR 7
+      # third review pass.
+      if printf '%s' "$p" | grep -qiE -- "$pat"; then
         MATCHED_RULE="secret_basename:$pat"
         MATCHED_PATH="$p"
         return 0

--- a/guard/bin/check-write.sh
+++ b/guard/bin/check-write.sh
@@ -160,18 +160,20 @@ BASENAME_DENY=(
   # SDK conventions: credentials.json, secrets.json, service-account
   # /service_account, firebase-adminsdk, google-credentials,
   # gcp-credentials, aws-credentials, supabase-service-role,
-  # client-secret(s) / client_secret. The base patterns match the
-  # plain name and any same-stem variant such as
-  # service-account-prod.json or aws-credentials-staging.json.
+  # client-secret(s) / client_secret. Word-separator is optional so
+  # names without a hyphen/underscore (serviceaccount.json,
+  # firebaseadminsdk.json, googlecredentials.json, clientsecret.json)
+  # are caught too. Codex flagged the missing separator-less forms
+  # on the PR 7 first review pass.
   '(^|/)credentials?\.json$'
   '(^|/)secrets?\.json$'
-  '(^|/)service[-_]account[^/]*\.json$'
-  '(^|/)firebase[-_]adminsdk[^/]*\.json$'
-  '(^|/)google[-_]credentials[^/]*\.json$'
-  '(^|/)gcp[-_]credentials[^/]*\.json$'
-  '(^|/)aws[-_]credentials[^/]*\.json$'
-  '(^|/)supabase[-_]service[-_]role[^/]*\.json$'
-  '(^|/)client[-_]secret[s]?[^/]*\.json$'
+  '(^|/)service[-_]?account[^/]*\.json$'
+  '(^|/)firebase[-_]?adminsdk[^/]*\.json$'
+  '(^|/)google[-_]?credentials[^/]*\.json$'
+  '(^|/)gcp[-_]?credentials[^/]*\.json$'
+  '(^|/)aws[-_]?credentials[^/]*\.json$'
+  '(^|/)supabase[-_]?service[-_]?role[^/]*\.json$'
+  '(^|/)client[-_]?secret[s]?[^/]*\.json$'
   # Private cryptographic material.
   '\.pem$'
   '\.key$'
@@ -222,24 +224,34 @@ check_path() {
   local p="$1" pat
   # Template short-circuit: files whose basename ends in `.example`,
   # `.sample`, `.template` (with or without an extension after) pass
-  # through, even if the rest of the name matches a credential
-  # pattern. This is the safe surface for first-run onboarding
-  # (credentials.example.json, service-account.template.json,
-  # .env.example, etc.).
-  local base
+  # the BASENAME deny check, even when the rest of the name matches a
+  # credential pattern. This is the safe surface for first-run
+  # onboarding (credentials.example.json, service-account.template.
+  # json, .env.example, etc.).
+  #
+  # The template exemption deliberately does NOT apply to
+  # PATH_PREFIX_DENY: a write to $HOME/.ssh/config.example or
+  # /etc/foo.template must still block because the protected
+  # directory is what makes the path sensitive, not the filename.
+  # Codex flagged the over-broad exemption on the PR 7 first review
+  # pass.
+  local base is_template=false
   base=$(basename "$p")
   for pat in "${TEMPLATE_ALLOW[@]}"; do
     if printf '%s' "$base" | grep -qE -- "$pat"; then
-      return 1
+      is_template=true
+      break
     fi
   done
-  for pat in "${BASENAME_DENY[@]}"; do
-    if printf '%s' "$p" | grep -qE -- "$pat"; then
-      MATCHED_RULE="secret_basename:$pat"
-      MATCHED_PATH="$p"
-      return 0
-    fi
-  done
+  if [ "$is_template" = false ]; then
+    for pat in "${BASENAME_DENY[@]}"; do
+      if printf '%s' "$p" | grep -qE -- "$pat"; then
+        MATCHED_RULE="secret_basename:$pat"
+        MATCHED_PATH="$p"
+        return 0
+      fi
+    done
+  fi
   for pat in "${PATH_PREFIX_DENY[@]}"; do
     if printf '%s' "$p" | grep -qE -- "$pat"; then
       MATCHED_RULE="system_path:$pat"


### PR DESCRIPTION
## Summary

The read-side guard (G-035 in `guard/rules.json`, added in PR #195) blocked credential JSON basenames like `credentials.json`, `service-account.json`, `firebase-adminsdk.json`, `aws-credentials.json`, and `supabase-service-role.json` so an agent could not read them with `cat` / `jq` / `grep`. The write-side guard (`guard/bin/check-write.sh`) did not have an equivalent block, so the same agent could still `Write`/`Edit`/`MultiEdit` over `credentials.json`.

This PR brings the write side to parity.

## What changes

`guard/bin/check-write.sh`

- New `TEMPLATE_ALLOW` list of basename patterns (`.example`, `.sample`, `.template`, plus the same forms with an extension after — `.example.json`, `.sample.yaml`, `.template.toml`). The exemption runs ONLY against the basename deny check; protected directory prefixes (`$HOME/.ssh/`, `/etc/`, `/var/`, etc.) keep blocking even when the leaf looks like a template.
- Adds credential JSON basenames to `BASENAME_DENY`, mirroring G-035:
  - `credentials?[^/]*\.json` (covers `credentials.json`, `credential.json`, `credentials-prod.json`, `credential-staging.json`).
  - `secrets?[^/]*\.json` (covers `secrets.json`, `secret.json`, `secret-prod.json`, `secrets-backup.json`).
  - `service[-_]?account[^/]*\.json`, `firebase[-_]?adminsdk[^/]*\.json`, `google[-_]?credentials[^/]*\.json`, `gcp[-_]?credentials[^/]*\.json`, `aws[-_]?credentials[^/]*\.json`, `supabase[-_]?service[-_]?role[^/]*\.json`, `client[-_]?secret[s]?[^/]*\.json`. The optional separator catches both `service-account.json` and `serviceaccount.json`.
- Adds `.env.test` to the env-file deny list to match the read guard.
- Switches `BASENAME_DENY` and `TEMPLATE_ALLOW` matchers to `grep -qiE` (case-insensitive) so mixed-case filenames like `Credentials.json`, `Service-Account.json`, `AWS-Credentials.json`, and `ID_RSA` are caught (same as G-035) and mixed-case templates like `credentials.Example.json` still pass.
- Preserves existing symlink resolution: a symlink whose target is a real credentials file still blocks; a symlink to a template path still allows.

`.github/workflows/lint.yml`

The existing `write-guard-regression` matrix gains 35+ new `run_case` rows so every direction of the new policy is locked:

- Deny: 16 credential JSON variants (with and without separator, with env/region suffix, mixed-case).
- Deny: protected directories with template-looking leaves (`$HOME/.ssh/config.example`, `/etc/foo.template`).
- Allow: 7 template variants (`.env.example`, `credentials.example.json`, `service-account.template.json`, `firebase-adminsdk.sample.json`, plus mixed-case).
- Allow: regular project files (`README.md`, `package.json`, `firebase.json`, `tsconfig.json`).
- Pre-existing JSON-stdin contract (Claude Code PreToolUse format) is unchanged and still exercises the new patterns.

## What does not change

- `Write` to `.env.example`, `credentials.example.json`, `service-account.template.json`, and similar template paths is unchanged (still passes).
- `Write` to regular project files (`README.md`, `package.json`, `firebase.json`, `tsconfig.json`) is unchanged (still passes).
- Protected-directory deny (`$HOME/.ssh/`, `/etc/`, `/var/`, `/usr/bin/`, `/usr/lib/`, `~/.aws/`, `~/.kube/`, etc.) still blocks the same paths regardless of leaf basename.
- Symlink resolution path is unchanged.
- Existing E2E and lint suites pass unchanged: user-flows, custom-stack-flows, custom-stack-examples, artifact-trust, structured-artifacts, graph-aware-session, custom-routing, adapter-freshness, delivery-matrix, examples, think-flows, think-archetypes, onboarding-flows.

## Codex review trail (4 iterations)

| Pass | Finding | Fix |
|------|---------|-----|
| 1 | Template exemption ran before BOTH basename and path-prefix denies, so `$HOME/.ssh/config.example` slipped through. Credential JSON patterns required a separator, so `serviceaccount.json` slipped through. | Scoped template to basename only; switched separators to `[-_]?` to match G-035. |
| 2 | Generic `credentials.json` / `secrets.json` patterns didn't allow a suffix; `credentials-prod.json` slipped through. | Added `[^/]*` to those patterns so suffixed forms block too. |
| 3 | Matcher was case-sensitive while G-035 is case-insensitive; `Credentials.json` slipped through. | Switched both TEMPLATE_ALLOW and BASENAME_DENY loops to `grep -qiE`. |
| 4 | Final pass clean. | None. |

Final pass: "The changes consistently extend the write guard to block credential JSON basenames and mixed-case secret paths while preserving template exemptions and protected-directory blocking."

## Tests

All checks green locally (15 suites): user-flows (100), custom-stack-flows (40), custom-stack-examples (51), graph-aware-session (61), custom-routing (35), adapter-freshness (43), artifact-trust (29), structured-artifacts (31), delivery-matrix (17), examples (40), think-flows (32), think-archetypes (25), onboarding-flows (34), plus `tests/run.sh` (83) and `tests/e2e-user-flows.sh` (5).

Total: 626 checks across 15 suites.

## Spec

PR 7 of the 2026-05-10 Nanostack Architecture Audit vNext, and the **final PR of the round**. Closes the P2 finding "Secret Write Guard Is Narrower Than Secret Read Guard". Acceptance criteria from the spec, all met:

- [x] Writes to `.env`, `.env.local`, `.env.production`, `credentials.json`, `secrets.json`, `service-account*.json`, `firebase-adminsdk*.json`, and `google-credentials*.json` are blocked (lint matrix).
- [x] Writes to `.env.example`, `.env.sample`, `.env.template`, `credentials.example.json`, and `service-account.example.json` are allowed (lint matrix).
- [x] Symlink protections remain green (existing symlink resolver + matrix rows for safe and unsafe symlink targets).
- [x] CI coverage for Write/Edit path checks (`write-guard-regression` job exercises both direct path and JSON-stdin contract).

## Round summary

With #214 already merged and this PR landing, the **Architecture vNext round closes**: seven P1/P2 findings from the 2026-05-10 audit are resolved.

| PR | Title | Closes |
|----|-------|--------|
| #209 | guard custom-phase concurrency parity | P1 Guard Concurrency Is Not Custom-Phase Aware |
| #210 | artifact trust v2 | P1 Artifact Integrity Verification Is Not Strict Enough |
| #211 | structured artifact enforcement | P1 Structured Artifact Contract Is Still Optional |
| #212 | graph-aware session lifecycle | P1 Session And Next-Step Logic Are Hardcoded |
| #213 | custom routing contract (phase_context) | P2 Custom Routing Is Dependency-Only |
| #214 | AI-facing docs + adapter freshness | P2 Guard And Agent Docs Are Stale + Adapter Verification Has No Freshness Policy |
| #215 (this PR) | secret write parity | P2 Secret Write Guard Is Narrower Than Secret Read Guard |

## Test plan

- [ ] `.github/workflows/lint.yml` `write-guard-regression` job passes on CI.
- [ ] `bash guard/bin/check-write.sh credentials.json` exits 1.
- [ ] `bash guard/bin/check-write.sh credentials.example.json` exits 0.
- [ ] `bash guard/bin/check-write.sh "$HOME/.ssh/config.example"` exits 1.
- [ ] `echo '{"tool_name":"Write","tool_input":{"file_path":"firebase-adminsdk.json"}}' | bash guard/bin/check-write.sh` exits 1.
- [ ] All existing CI E2E suites still pass.