### PR TITLE
visual-artifacts v1: PR 1 static renderer and trust contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3766,3 +3766,19 @@ jobs:
             exit 1
           fi
           echo "OK: save-artifact.sh wires the per-phase validator."
+
+  visual-artifact-contract:
+    # Locks the Visual Artifacts v1 PR 1 contract: bin/render-artifact.sh
+    # writes static HTML under $NANOSTACK_STORE/visual/, escapes every
+    # JSON-derived string, ships a CSP, refuses unsafe output paths, and
+    # records source trust in a companion manifest. See
+    # reference/visual-artifact-contract.md.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Static template safety lint
+        run: ci/check-visual-artifact-templates.sh
+      - name: End-to-end render contract
+        run: ci/e2e-visual-artifacts.sh

--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # find-artifact.sh — Find the most recent artifact for a phase and project
-# Usage: find-artifact.sh <phase> [max-age-days] [--verify] [--require-integrity]
+# Usage: find-artifact.sh <phase> [max-age-days] [--verify] [--require-integrity] [--no-session-sync]
 # Example: find-artifact.sh plan 2 --require-integrity
 # Returns: path to most recent artifact, or empty + exit 1 if none found
 #
@@ -14,6 +14,15 @@
 #                         consumer that cannot afford to trust unverifiable
 #                         evidence. Added in the 2026-05-10 architecture audit
 #                         PR 2 so callers stop reimplementing the check.
+#
+# Read-only flag:
+#   --no-session-sync     skip the phase-start session registration that
+#                         find-artifact.sh otherwise performs as a
+#                         convenience for downstream skills. Used by the
+#                         visual renderer (render-artifact.sh), which is a
+#                         strictly downstream consumer and must not mutate
+#                         sprint state. Added in the Visual Artifacts v1
+#                         PR 1 round (codex pass 7).
 #
 # On failure, the reason goes to stderr in a stable format so callers can
 # categorize: "INTEGRITY FAILED: <path>" (mismatch) or
@@ -32,6 +41,7 @@ shift
 MAX_AGE=30
 VERIFY=false
 REQUIRE_INTEGRITY=false
+NO_SESSION_SYNC=false
 # The max-age argument is optional; detect it by shape so callers can
 # skip it and pass a flag in $2 (e.g. find-artifact.sh plan
 # --require-integrity). A leading dash means flag, not age. Codex
@@ -46,6 +56,7 @@ for arg in "$@"; do
   case "$arg" in
     --verify) VERIFY=true ;;
     --require-integrity) REQUIRE_INTEGRITY=true; VERIFY=true ;;
+    --no-session-sync) NO_SESSION_SYNC=true ;;
   esac
 done
 
@@ -73,7 +84,7 @@ done | sort -r | head -1)
 # recurse back to find-artifact.sh and hang). The phase stays
 # "in_progress" until save-artifact.sh completes it.
 SESSION_FILE="$NANOSTACK_STORE/session.json"
-if [ -f "$SESSION_FILE" ]; then
+if [ "$NO_SESSION_SYNC" = false ] && [ -f "$SESSION_FILE" ]; then
   # Cache the phase list extracted from session.json. Multiple find-artifact.sh
   # calls in one resolve.sh run reuse the same list; session.sh writes bump
   # session.json's mtime which invalidates the cache automatically.

--- a/bin/lib/html-escape.sh
+++ b/bin/lib/html-escape.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# html-escape.sh — Shared HTML escape primitives for the visual artifact
+# layer. Used by bin/render-artifact.sh. Centralizing the escape rules
+# here makes the security contract testable: ci/check-visual-artifact-
+# templates.sh greps for direct printf of JSON values and fails if the
+# escape helpers are bypassed.
+#
+# Public functions (stdin -> stdout):
+#   nano_html_escape   text content. & < > " ' -> entities. Preserves newlines.
+#   nano_attr_escape   attribute content. Same set; stricter quoting.
+#   nano_json_string   string -> JSON-encoded literal (without surrounding quotes).
+#                       Used by the manifest writer when piping shell
+#                       strings into JSON without a jq round-trip.
+
+if [ "${_NANO_HTML_ESCAPE_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_HTML_ESCAPE_LOADED=1
+
+# Escape & < > " ' via awk. Replaces ampersand FIRST so later
+# replacements do not double-encode the entity prefix. Reads stdin and
+# writes to stdout. Newlines pass through untouched.
+nano_html_escape() {
+  awk '
+    BEGIN { OFS = "" }
+    {
+      gsub(/&/, "\\&amp;")
+      gsub(/</, "\\&lt;")
+      gsub(/>/, "\\&gt;")
+      gsub(/"/, "\\&quot;")
+      gsub(/\047/, "\\&#39;")
+      print
+    }
+  '
+}
+
+# Attribute content uses the same character set. Kept as a separate
+# function so future hardening (for example, encoding the equals sign
+# or backtick inside attribute context) lands in one place. Reads
+# stdin and writes to stdout.
+nano_attr_escape() {
+  awk '
+    BEGIN { OFS = "" }
+    {
+      gsub(/&/, "\\&amp;")
+      gsub(/</, "\\&lt;")
+      gsub(/>/, "\\&gt;")
+      gsub(/"/, "\\&quot;")
+      gsub(/\047/, "\\&#39;")
+      print
+    }
+  '
+}
+
+# JSON-string escape. We delegate to jq when available because jq
+# already implements the full RFC 8259 escape set (control characters,
+# \uXXXX for non-ASCII). The output includes surrounding double
+# quotes; callers strip them with `${var:1:-1}` when embedding inside
+# a larger jq filter, or use the quoted form for raw concatenation.
+nano_json_string() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs '.'
+  else
+    # Minimal fallback. Escapes the characters that break JSON strings.
+    # Loses control-character handling beyond newline; that is
+    # acceptable because the visual layer pipes everything through jq
+    # when jq is on PATH, which is a Nanostack requirement enforced
+    # elsewhere.
+    awk '
+      BEGIN { ORS = ""; printf "\"" }
+      {
+        s = $0
+        gsub(/\\/, "\\\\", s)
+        gsub(/"/, "\\\"", s)
+        gsub(/\t/, "\\t", s)
+        printf "%s", s
+        printf "\\n"
+      }
+      END { printf "\"\n" }
+    '
+  fi
+}

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -134,6 +134,12 @@ nano_visual_assert_safe_descend() {
     echo "render-artifact: visual root is a symlink: $current" >&2
     return 4
   fi
+  # Disable globbing for the split (codex PR 1 pass 8). Same risk
+  # as nano_visual_normalize_path: an unquoted set -- expands * and
+  # ? against the cwd, which could mask symlink components from the
+  # check.
+  local restore_glob=0
+  case $- in *f*) ;; *) restore_glob=1; set -f ;; esac
   local IFS=/
   # shellcheck disable=SC2086
   set -- $rel
@@ -149,9 +155,11 @@ nano_visual_assert_safe_descend() {
     current="$current/$part"
     if [ -L "$current" ]; then
       echo "render-artifact: refusing to descend into symlinked subdirectory: $current" >&2
+      [ "$restore_glob" -eq 1 ] && set +f
       return 4
     fi
   done
+  [ "$restore_glob" -eq 1 ] && set +f
   # Leaf check. Codex PR 1 pass 5 caught the gap: if the leaf itself
   # is a symlink to a directory, the later atomic mv moves the temp
   # file INTO the link target instead of overwriting the link, so
@@ -185,6 +193,13 @@ nano_visual_normalize_path() {
     /*) ;;
     *) raw="$PWD/$raw" ;;
   esac
+  # Disable globbing for the split. Codex PR 1 pass 8 caught that an
+  # unquoted `set -- $raw` performs pathname expansion against the
+  # current working directory; an --out containing `*` or `?` could
+  # be silently rewritten to a matching real filename, producing a
+  # manifest output_path that disagrees with the caller's request.
+  local restore_glob=0
+  case $- in *f*) ;; *) restore_glob=1; set -f ;; esac
   local out=""
   local IFS=/
   # shellcheck disable=SC2086
@@ -204,6 +219,7 @@ nano_visual_normalize_path() {
         ;;
     esac
   done
+  [ "$restore_glob" -eq 1 ] && set +f
   [ -z "$out" ] && out="/"
   printf '%s\n' "$out"
 }

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -56,7 +56,11 @@ nano_visual_output_dir() {
 }
 
 nano_visual_timestamp() {
-  date -u +%Y%m%d-%H%M%S
+  # PID suffix prevents two same-second renders from colliding on the
+  # manifest stem. Codex PR 1 pass 6 caught the contract violation:
+  # the second render overwrote the first manifest while the first
+  # HTML kept pointing at the now-stale path.
+  printf '%s-%s\n' "$(date -u +%Y%m%d-%H%M%S)" "$$"
 }
 
 nano_visual_html_path() {

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -99,9 +99,50 @@ nano_visual_assert_safe_root() {
   return 0
 }
 
-# Refuse output paths that escape the visual root. We compare the
-# canonical path of the parent directory (the file may not exist yet)
-# against the canonical visual root. Both are made absolute first.
+# Lexically normalize an absolute path: resolve "." and ".." components
+# without touching the filesystem. This defeats --out escapes through
+# missing directory segments followed by ".." (codex caught the gap
+# on PR 1 pass 2: a path like .../visual/new/../../outside.html passed
+# the previous "walk up to nearest existing ancestor" check because
+# the missing 'new' segment never appeared on disk for realpath to
+# resolve, leaving the comparison anchored at visual/).
+#
+# This implementation is pure shell so it runs on the same Bash 3.2
+# that ships with macOS without depending on `realpath -m`.
+nano_visual_normalize_path() {
+  local raw="$1"
+  case "$raw" in
+    /*) ;;
+    *) raw="$PWD/$raw" ;;
+  esac
+  local out=""
+  local IFS=/
+  # shellcheck disable=SC2086
+  set -- $raw
+  local part
+  for part in "$@"; do
+    case "$part" in
+      ""|.) ;;
+      ..)
+        # Pop the last segment from $out if any.
+        if [ -n "$out" ]; then
+          out="${out%/*}"
+        fi
+        ;;
+      *)
+        out="$out/$part"
+        ;;
+    esac
+  done
+  [ -z "$out" ] && out="/"
+  printf '%s\n' "$out"
+}
+
+# Refuse output paths that escape the visual root after lexical
+# normalization. The visual root is canonicalized through realpath
+# when present (so a real-but-non-symlinked root resolves cleanly);
+# the caller path is normalized lexically because it may include
+# directories that do not exist yet.
 nano_visual_assert_safe_output() {
   local path="$1"
   local root
@@ -113,33 +154,24 @@ nano_visual_assert_safe_output() {
       return 4
       ;;
   esac
-  local parent
-  parent="$(dirname "$path")"
-  # Resolve the parent directory if it exists; otherwise resolve its
-  # nearest existing ancestor. We do not want to require the parent
-  # to pre-exist because the renderer mkdir -p's it later, but we do
-  # want to defeat ../ escapes.
-  local probe="$parent"
-  while [ -n "$probe" ] && [ ! -d "$probe" ]; do
-    probe="$(dirname "$probe")"
-    [ "$probe" = "/" ] && break
-  done
-  local probe_canon root_canon
-  if command -v realpath >/dev/null 2>&1; then
-    probe_canon="$(realpath "$probe" 2>/dev/null || echo "$probe")"
-    root_canon="$(realpath "$root" 2>/dev/null || echo "$root")"
-  else
-    probe_canon="$(cd "$probe" 2>/dev/null && pwd || echo "$probe")"
-    if [ -d "$root" ]; then
-      root_canon="$(cd "$root" 2>/dev/null && pwd || echo "$root")"
-    else
-      root_canon="$root"
-    fi
-  fi
-  case "$probe_canon" in
-    "$root_canon"|"$root_canon"/*) return 0 ;;
+
+  # Both root and path are normalized lexically so a symlinked
+  # filesystem path (for example /tmp -> /private/tmp on macOS) does
+  # not produce a false mismatch: realpath would expand the root and
+  # not the not-yet-existing path, and the prefix check would fail.
+  # The renderer's threat model treats the visual root's symlink
+  # status as the one filesystem property worth checking
+  # (nano_visual_assert_safe_root); deeper symlink chains are out of
+  # scope for the path-safety check, which is purely about defeating
+  # ".." escape and absolute-path misrouting in --out.
+  local path_canon root_canon
+  path_canon="$(nano_visual_normalize_path "$path")"
+  root_canon="$(nano_visual_normalize_path "$root")"
+
+  case "$path_canon" in
+    "$root_canon"/*) return 0 ;;
     *)
-      echo "render-artifact: refusing to write outside $root_canon: $path" >&2
+      echo "render-artifact: refusing to write outside $root_canon: $path (normalized: $path_canon)" >&2
       return 4
       ;;
   esac

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -99,6 +99,58 @@ nano_visual_assert_safe_root() {
   return 0
 }
 
+# Refuse to write into any subdirectory under visual/ that is a
+# symlink. Codex PR 1 pass 4 caught this: if visual/plan was already
+# a symlink to /tmp/outside, mkdir -p accepted it and the later
+# atomic mv wrote into the target, escaping the visual root despite
+# the lexical path-safety check on --out. Walk from the visual root
+# down to (but not including) the leaf file, asserting -L is false at
+# every existing intermediate.
+#
+# Called after nano_visual_normalize_path has rewritten the candidate
+# path, so the input is already absolute and ".." is resolved.
+nano_visual_assert_safe_descend() {
+  local path="$1"  # absolute, normalized
+  local root
+  root="$(nano_visual_normalize_path "$(nano_visual_root)")"
+  # Require the path to live under the canonical root. The caller
+  # already verified this via nano_visual_assert_safe_output for --out;
+  # we re-check for safety in case this helper is reused later.
+  case "$path" in
+    "$root"|"$root"/*) ;;
+    *)
+      echo "render-artifact: refusing to write outside $root: $path" >&2
+      return 4
+      ;;
+  esac
+  local rel="${path#"$root"}"
+  rel="${rel#/}"
+  local current="$root"
+  if [ -L "$current" ]; then
+    echo "render-artifact: visual root is a symlink: $current" >&2
+    return 4
+  fi
+  local IFS=/
+  # shellcheck disable=SC2086
+  set -- $rel
+  local part
+  # The last component is the leaf file. Drop it so we only check
+  # directory components (intermediate dirs can be symlinks; the
+  # file itself is created by the renderer's atomic move).
+  local count=$#
+  local i=0
+  for part in "$@"; do
+    i=$((i+1))
+    [ "$i" = "$count" ] && break
+    current="$current/$part"
+    if [ -L "$current" ]; then
+      echo "render-artifact: refusing to descend into symlinked subdirectory: $current" >&2
+      return 4
+    fi
+  done
+  return 0
+}
+
 # Lexically normalize an absolute path: resolve "." and ".." components
 # without touching the filesystem. This defeats --out escapes through
 # missing directory segments followed by ".." (codex caught the gap

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# visual-render.sh — Shared page shell, CSP, trust badges, and output
+# path safety for the visual artifact layer. Centralizing this here
+# means every phase renderer in bin/render-artifact.sh gets the same
+# CSS, the same security headers, and the same locked trust wording.
+# Without a shared shell each phase would drift, and the
+# ci/check-visual-artifact-templates.sh forbidden-pattern sweep would
+# have to grep across many files.
+#
+# Public functions:
+#   nano_visual_root                       echo $NANOSTACK_STORE/visual
+#   nano_visual_output_dir <phase>         echo phase output directory
+#   nano_visual_manifest_path <kind> <phase> <timestamp>
+#                                          echo manifest path for a render
+#   nano_visual_html_path <phase> <timestamp>
+#                                          echo HTML path for a phase render
+#   nano_visual_timestamp                  echo a deterministic YYYYMMDD-HHMMSS
+#   nano_visual_assert_safe_output <path>  exit 4 if path escapes the visual root
+#   nano_visual_assert_safe_root           exit 4 if visual/ is a symlink
+#   nano_visual_csp <static|interactive>   echo the CSP value
+#   nano_visual_trust_badge_text <status>  echo the locked badge wording
+#   nano_visual_page_start <phase> <trust> emit the page shell start
+#   nano_visual_page_end <source_path> <manifest_path> <integrity>
+#                                          emit the provenance footer + close
+#
+# Every renderer writes through these helpers; phase-specific bodies
+# render between page_start and page_end.
+
+if [ "${_NANO_VISUAL_RENDER_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_VISUAL_RENDER_LOADED=1
+
+if [ -z "${NANOSTACK_STORE:-}" ]; then
+  echo "visual-render.sh: NANOSTACK_STORE not set; source bin/lib/store-path.sh first" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+source "$(dirname "${BASH_SOURCE[0]}")/html-escape.sh"
+
+NANO_VISUAL_RENDERER_NAME="nanostack-html-renderer"
+NANO_VISUAL_RENDERER_VERSION="1"
+
+nano_visual_root() {
+  printf '%s\n' "$NANOSTACK_STORE/visual"
+}
+
+nano_visual_output_dir() {
+  local phase="$1"
+  local custom="${2:-false}"
+  if [ "$custom" = "true" ]; then
+    printf '%s\n' "$NANOSTACK_STORE/visual/custom/$phase"
+  else
+    printf '%s\n' "$NANOSTACK_STORE/visual/$phase"
+  fi
+}
+
+nano_visual_timestamp() {
+  date -u +%Y%m%d-%H%M%S
+}
+
+nano_visual_html_path() {
+  local phase="$1"
+  local timestamp="$2"
+  local custom="${3:-false}"
+  printf '%s/%s-%s.html\n' \
+    "$(nano_visual_output_dir "$phase" "$custom")" \
+    "$timestamp" \
+    "$phase"
+}
+
+nano_visual_manifest_path() {
+  local kind="$1"   # phase | journal | stack
+  local phase="$2"
+  local timestamp="$3"
+  local custom="${4:-false}"
+  local stem
+  if [ "$custom" = "true" ]; then
+    stem="$timestamp-custom-$phase"
+  else
+    stem="$timestamp-$phase"
+  fi
+  printf '%s/manifests/%s.manifest.json\n' \
+    "$NANOSTACK_STORE/visual" \
+    "$stem"
+}
+
+# Refuse to follow a symlinked visual root. The renderer otherwise
+# would write to whatever the symlink resolves to, which can escape
+# the store. The contract requires the visual root be a plain
+# directory (or absent, in which case we mkdir it ourselves).
+nano_visual_assert_safe_root() {
+  local root
+  root="$(nano_visual_root)"
+  if [ -L "$root" ]; then
+    echo "render-artifact: refusing to write under symlinked visual root: $root" >&2
+    return 4
+  fi
+  return 0
+}
+
+# Refuse output paths that escape the visual root. We compare the
+# canonical path of the parent directory (the file may not exist yet)
+# against the canonical visual root. Both are made absolute first.
+nano_visual_assert_safe_output() {
+  local path="$1"
+  local root
+  root="$(nano_visual_root)"
+  case "$path" in
+    /*) ;;
+    *)
+      echo "render-artifact: --out must be an absolute path: $path" >&2
+      return 4
+      ;;
+  esac
+  local parent
+  parent="$(dirname "$path")"
+  # Resolve the parent directory if it exists; otherwise resolve its
+  # nearest existing ancestor. We do not want to require the parent
+  # to pre-exist because the renderer mkdir -p's it later, but we do
+  # want to defeat ../ escapes.
+  local probe="$parent"
+  while [ -n "$probe" ] && [ ! -d "$probe" ]; do
+    probe="$(dirname "$probe")"
+    [ "$probe" = "/" ] && break
+  done
+  local probe_canon root_canon
+  if command -v realpath >/dev/null 2>&1; then
+    probe_canon="$(realpath "$probe" 2>/dev/null || echo "$probe")"
+    root_canon="$(realpath "$root" 2>/dev/null || echo "$root")"
+  else
+    probe_canon="$(cd "$probe" 2>/dev/null && pwd || echo "$probe")"
+    if [ -d "$root" ]; then
+      root_canon="$(cd "$root" 2>/dev/null && pwd || echo "$root")"
+    else
+      root_canon="$root"
+    fi
+  fi
+  case "$probe_canon" in
+    "$root_canon"|"$root_canon"/*) return 0 ;;
+    *)
+      echo "render-artifact: refusing to write outside $root_canon: $path" >&2
+      return 4
+      ;;
+  esac
+}
+
+nano_visual_csp() {
+  local mode="${1:-static}"
+  case "$mode" in
+    interactive)
+      # Reserved for PR 4. Inline script will be enabled here only when
+      # the copy-only contract is verified. Until then, callers in
+      # PR 1 must request "static".
+      printf "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'\n"
+      ;;
+    *)
+      printf "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'\n"
+      ;;
+  esac
+}
+
+# Locked trust badge wording. CI greps for these exact strings.
+nano_visual_trust_badge_text() {
+  local status="${1:-not_found}"
+  case "$status" in
+    verified)            printf 'verified\n' ;;
+    integrity_missing)   printf 'unverified\n' ;;
+    integrity_mismatch)  printf 'tampered\n' ;;
+    *)                   printf 'unknown\n' ;;
+  esac
+}
+
+# Page shell: doctype, head with CSP and CSS, hero header with trust
+# badge. The phase body follows this and nano_visual_page_end closes.
+nano_visual_page_start() {
+  local phase="$1"
+  local trust="$2"
+  local csp_mode="${3:-static}"
+  local custom="${4:-false}"
+
+  local phase_esc trust_esc badge_text title_phase
+  phase_esc="$(printf '%s' "$phase" | nano_attr_escape)"
+  trust_esc="$(printf '%s' "$trust" | nano_attr_escape)"
+  badge_text="$(nano_visual_trust_badge_text "$trust")"
+  if [ "$custom" = "true" ]; then
+    title_phase="$phase (custom)"
+  else
+    title_phase="/$phase"
+  fi
+  local title_esc
+  title_esc="$(printf '%s' "$title_phase" | nano_html_escape)"
+
+  cat <<HTML
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="$(nano_visual_csp "$csp_mode")">
+  <title>Nanostack $title_esc visual artifact</title>
+  <style>
+    :root {
+      --bg: #0f1115;
+      --panel: #171a21;
+      --panel-2: #20242d;
+      --fg: #f4f4f5;
+      --muted: #b7bbc5;
+      --line: #343946;
+      --ok: #4ade80;
+      --warn: #facc15;
+      --bad: #fb7185;
+      --info: #60a5fa;
+    }
+    * { box-sizing: border-box; }
+    html, body { background: var(--bg); color: var(--fg); margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.5; }
+    .page { max-width: 1120px; margin: 0 auto; padding: 24px; }
+    @media (max-width: 720px) { .page { padding: 16px; } }
+    .hero { border-bottom: 1px solid var(--line); padding-bottom: 16px; margin-bottom: 24px; }
+    .eyebrow { color: var(--muted); font-size: 0.85rem; margin: 0 0 6px 0; text-transform: uppercase; letter-spacing: 0.05em; }
+    h1 { margin: 0 0 8px 0; font-size: 1.8rem; }
+    .trust-badge { display: inline-block; padding: 4px 10px; border-radius: 4px; font-size: 0.85rem; font-weight: 600; }
+    .trust-badge[data-trust="verified"] { background: rgba(74,222,128,0.15); color: var(--ok); border: 1px solid var(--ok); }
+    .trust-badge[data-trust="integrity_missing"] { background: rgba(250,204,21,0.15); color: var(--warn); border: 1px solid var(--warn); }
+    .trust-badge[data-trust="integrity_mismatch"] { background: rgba(251,113,133,0.15); color: var(--bad); border: 1px solid var(--bad); }
+    section.card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+    section.card h2 { margin: 0 0 12px 0; font-size: 1.15rem; }
+    .muted { color: var(--muted); }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.03em; }
+    code, pre { background: var(--panel-2); border: 1px solid var(--line); border-radius: 4px; padding: 2px 6px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85rem; }
+    pre { padding: 12px; overflow-x: auto; }
+    ul { padding-left: 20px; margin: 0; }
+    li { margin-bottom: 4px; }
+    .provenance { color: var(--muted); font-size: 0.85rem; border-top: 1px solid var(--line); padding-top: 16px; margin-top: 32px; }
+    .provenance p { margin: 4px 0; word-break: break-all; }
+    .kvgrid { display: grid; grid-template-columns: max-content 1fr; gap: 6px 16px; }
+    .kvgrid dt { color: var(--muted); }
+    .kvgrid dd { margin: 0; }
+    .schema-warning { background: rgba(250,204,21,0.1); border: 1px solid var(--warn); color: var(--warn); padding: 12px; border-radius: 6px; margin-bottom: 16px; }
+  </style>
+</head>
+<body>
+  <main class="page" data-nanostack-visual="1" data-phase="$phase_esc">
+    <header class="hero">
+      <p class="eyebrow">Nanostack visual artifact</p>
+      <h1>$title_esc</h1>
+      <p class="trust-badge" data-trust="$trust_esc">$(printf '%s' "$badge_text" | nano_html_escape)</p>
+    </header>
+HTML
+}
+
+# Closes the page with provenance pointing back to the source artifact
+# and the companion manifest. Every render must call this so the
+# audit trail is locked in HTML.
+nano_visual_page_end() {
+  local source_path="$1"
+  local manifest_path="$2"
+  local integrity="${3:-}"
+
+  local src_esc mfst_esc integ_esc
+  src_esc="$(printf '%s' "$source_path" | nano_html_escape)"
+  mfst_esc="$(printf '%s' "$manifest_path" | nano_html_escape)"
+  if [ -n "$integrity" ]; then
+    integ_esc="$(printf '%s' "$integrity" | nano_html_escape)"
+  else
+    integ_esc="not recorded"
+  fi
+
+  cat <<HTML
+    <footer class="provenance" data-testid="visual-provenance">
+      <p>Source artifact: <code data-testid="source-artifact-path">$src_esc</code></p>
+      <p>Manifest: <code data-testid="visual-manifest-path">$mfst_esc</code></p>
+      <p>Source integrity (SHA-256): <code>$integ_esc</code></p>
+      <p>Renderer: $NANO_VISUAL_RENDERER_NAME v$NANO_VISUAL_RENDERER_VERSION</p>
+    </footer>
+  </main>
+</body>
+</html>
+HTML
+}

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -148,6 +148,20 @@ nano_visual_assert_safe_descend() {
       return 4
     fi
   done
+  # Leaf check. Codex PR 1 pass 5 caught the gap: if the leaf itself
+  # is a symlink to a directory, the later atomic mv moves the temp
+  # file INTO the link target instead of overwriting the link, so
+  # the render escapes the visual root despite every directory
+  # component being safe. Refuse symlinks and directories at the
+  # leaf; the contract is to write a regular file at that path.
+  if [ -L "$path" ]; then
+    echo "render-artifact: refusing to overwrite symlinked output leaf: $path" >&2
+    return 4
+  fi
+  if [ -d "$path" ]; then
+    echo "render-artifact: refusing to overwrite directory at output leaf: $path" >&2
+    return 4
+  fi
   return 0
 }
 

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -198,6 +198,32 @@ MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
 mkdir -p "$(dirname "$HTML_PATH")"
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 
+# Manifest contract requires output_path to be absolute. If
+# NANOSTACK_STORE was set to a relative path the derived HTML and
+# manifest paths inherit the relativity, so canonicalize both before
+# they reach the manifest body or the stdout that the caller sees.
+# Codex PR 1 pass 3 caught the contract violation in the relative-
+# store case.
+nano_resolve_abs() {
+  local p="$1"
+  case "$p" in
+    /*) printf '%s\n' "$p" ;;
+    *)
+      local dir base
+      dir="$(cd "$(dirname "$p")" 2>/dev/null && pwd)"
+      base="$(basename "$p")"
+      if [ -n "$dir" ]; then
+        printf '%s/%s\n' "$dir" "$base"
+      else
+        printf '%s\n' "$p"
+      fi
+      ;;
+  esac
+}
+HTML_PATH="$(nano_resolve_abs "$HTML_PATH")"
+MANIFEST_PATH="$(nano_resolve_abs "$MANIFEST_PATH")"
+ART_PATH="$(nano_resolve_abs "$ART_PATH")"
+
 # Pull the stored integrity hash. It is recorded in the manifest so a
 # later check can decide whether the rendered view's source still
 # matches what was on disk at render time.

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# render-artifact.sh — Render a Nanostack JSON artifact as a static
+# HTML view under $NANOSTACK_STORE/visual/. JSON remains canonical;
+# this script is strictly downstream and writes only to the visual
+# root. See reference/visual-artifact-contract.md for the full
+# contract.
+#
+# Usage:
+#   render-artifact.sh <phase> [artifact-path|--latest] [--strict]
+#                              [--interactive] [--out <path>]
+#                              [--manifest-only]
+#
+# PR 1 scope: /plan renderer + manifest + safety locks. Other phases
+# exit 1 with a clear "phase not yet supported" message; PR 2 wires
+# think/review/security/qa/ship. journal/stack are reserved for PR 3
+# (exit 2). --interactive is reserved for PR 4 (exit 2).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/store-path.sh"
+source "$SCRIPT_DIR/lib/html-escape.sh"
+source "$SCRIPT_DIR/lib/visual-render.sh"
+source "$SCRIPT_DIR/lib/artifact-trust.sh"
+[ -f "$SCRIPT_DIR/lib/artifact-schemas.sh" ] && source "$SCRIPT_DIR/lib/artifact-schemas.sh"
+
+usage() {
+  cat <<USAGE
+Usage: render-artifact.sh <phase> [artifact-path|--latest] [--strict]
+                                  [--interactive] [--out <path>]
+                                  [--manifest-only]
+
+PR 1 scope:
+  phase = plan               render the latest or explicit /plan artifact
+  phase = think|review|security|qa|ship
+                             reserved for PR 2 (exit 1)
+  phase = journal            reserved for PR 3 (exit 2)
+  phase = stack              reserved for PR 3 (exit 2)
+
+Flags:
+  --strict                   require nano_artifact_trust == verified
+  --interactive              reserved for PR 4 (exit 2)
+  --out <path>               write HTML to explicit path under \$NANOSTACK_STORE/visual
+  --manifest-only            write manifest only, skip HTML
+  --latest                   resolve via find-artifact.sh (default if no path)
+
+Exit codes:
+  0  success
+  1  input error
+  2  feature reserved for a later PR
+  3  trust failure
+  4  unsafe output path
+USAGE
+}
+
+if [ $# -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+PHASE="$1"
+shift
+
+ART_PATH=""
+USE_LATEST=false
+STRICT=false
+INTERACTIVE=false
+MANIFEST_ONLY=false
+OUT_PATH=""
+
+# Reserved phase kinds. Surface a clear message and use the contract
+# exit code so CI can categorize.
+case "$PHASE" in
+  journal)
+    echo "render-artifact: 'journal' is reserved for PR 3 (sprint journal renderer)" >&2
+    exit 2
+    ;;
+  stack)
+    echo "render-artifact: 'stack' is reserved for PR 3 (custom stack graph renderer)" >&2
+    exit 2
+    ;;
+esac
+
+# Argument parsing. The first non-flag argument after <phase> is the
+# explicit artifact path. Flags can appear before or after.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --latest)         USE_LATEST=true ;;
+    --strict)         STRICT=true ;;
+    --interactive)
+      echo "render-artifact: --interactive is reserved for PR 4 (copy-only interactive mode)" >&2
+      exit 2
+      ;;
+    --manifest-only)  MANIFEST_ONLY=true ;;
+    --out)
+      shift
+      [ -z "${1:-}" ] && { echo "render-artifact: --out requires a path" >&2; exit 1; }
+      OUT_PATH="$1"
+      ;;
+    --help|-h)        usage; exit 0 ;;
+    -*)
+      echo "render-artifact: unknown flag: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$ART_PATH" ]; then
+        echo "render-artifact: extra positional argument: $1" >&2
+        exit 1
+      fi
+      ART_PATH="$1"
+      ;;
+  esac
+  shift
+done
+
+# Validate phase. Core phases supported by PR 1: plan. The rest of the
+# core phases will be wired in PR 2; report a clear message.
+case "$PHASE" in
+  plan) ;;
+  think|review|security|qa|ship)
+    echo "render-artifact: phase '$PHASE' is reserved for PR 2 (core phase renderers)" >&2
+    exit 1
+    ;;
+  *)
+    echo "render-artifact: unsupported phase: $PHASE" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve the source artifact.
+if [ -z "$ART_PATH" ] || [ "$USE_LATEST" = true ]; then
+  ART_PATH=$("$SCRIPT_DIR/find-artifact.sh" "$PHASE" 30 2>/dev/null || true)
+  if [ -z "$ART_PATH" ]; then
+    echo "render-artifact: no $PHASE artifact found in the last 30 days" >&2
+    exit 1
+  fi
+fi
+
+if [ ! -f "$ART_PATH" ]; then
+  echo "render-artifact: artifact not found: $ART_PATH" >&2
+  exit 1
+fi
+
+# JSON must parse.
+if ! jq -e '.' "$ART_PATH" >/dev/null 2>&1; then
+  echo "render-artifact: artifact is not valid JSON: $ART_PATH" >&2
+  exit 1
+fi
+
+# .phase field must match the requested phase.
+ART_PHASE=$(jq -r '.phase // ""' "$ART_PATH")
+if [ "$ART_PHASE" != "$PHASE" ]; then
+  echo "render-artifact: artifact phase '$ART_PHASE' does not match requested phase '$PHASE': $ART_PATH" >&2
+  exit 1
+fi
+
+# Trust check. integrity_mismatch always fails (exit 3). Under
+# --strict, integrity_missing also fails. integrity_missing without
+# strict renders with an "unverified" badge.
+TRUST=$(nano_artifact_trust "$ART_PATH" 2>/dev/null || echo "not_found")
+case "$TRUST" in
+  verified) ;;
+  integrity_missing)
+    if [ "$STRICT" = true ]; then
+      echo "render-artifact: --strict requires verified trust; source is integrity_missing: $ART_PATH" >&2
+      exit 3
+    fi
+    ;;
+  integrity_mismatch)
+    echo "render-artifact: source artifact integrity check failed: $ART_PATH" >&2
+    exit 3
+    ;;
+  *)
+    echo "render-artifact: artifact unreadable: $ART_PATH" >&2
+    exit 1
+    ;;
+esac
+
+# Determine output paths.
+TS=$(nano_visual_timestamp)
+nano_visual_assert_safe_root
+
+if [ -n "$OUT_PATH" ]; then
+  nano_visual_assert_safe_output "$OUT_PATH"
+  HTML_PATH="$OUT_PATH"
+else
+  HTML_PATH=$(nano_visual_html_path "$PHASE" "$TS")
+fi
+MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
+
+mkdir -p "$(dirname "$HTML_PATH")"
+mkdir -p "$(dirname "$MANIFEST_PATH")"
+
+# Pull the stored integrity hash. It is recorded in the manifest so a
+# later check can decide whether the rendered view's source still
+# matches what was on disk at render time.
+SRC_INTEGRITY=$(jq -r '.integrity // ""' "$ART_PATH" 2>/dev/null || echo "")
+
+# Optional schema validation. A failing schema does not block the
+# render; it adds a visible warning to the HTML and is recorded in the
+# manifest. This is intentional: a malformed artifact still benefits
+# from being inspectable.
+SCHEMA_OK=true
+SCHEMA_ERR=""
+if declare -F nano_validate_artifact >/dev/null 2>&1; then
+  if ! SCHEMA_ERR=$(nano_validate_artifact "$PHASE" "$(cat "$ART_PATH")" 2>&1); then
+    SCHEMA_OK=false
+  fi
+fi
+
+# ─── Phase renderers ────────────────────────────────────────
+#
+# Each function emits the body between page_start and page_end. They
+# read named fields with jq, escape every scalar before printing, and
+# render "Not recorded" / "None recorded" for absent values.
+
+render_plan_body() {
+  local artifact="$1"
+
+  local goal scope approval
+  goal=$(jq -r '.summary.goal // "Not recorded"' "$artifact" | nano_html_escape)
+  scope=$(jq -r '.summary.scope // "Not recorded"' "$artifact" | nano_html_escape)
+  approval=$(jq -r '.summary.plan_approval // "Not recorded"' "$artifact" | nano_html_escape)
+
+  cat <<HTML
+    <section class="card">
+      <h2>Summary</h2>
+      <dl class="kvgrid">
+        <dt>Goal</dt><dd>$goal</dd>
+        <dt>Scope</dt><dd>$scope</dd>
+        <dt>Approval</dt><dd>$approval</dd>
+      </dl>
+    </section>
+HTML
+
+  # Planned files. Grouped by top-level directory for readability on
+  # plans that touch many files.
+  local files_count
+  files_count=$(jq -r '(.summary.planned_files // []) | length' "$artifact")
+  printf '    <section class="card">\n      <h2>Planned files (%s)</h2>\n' \
+    "$(printf '%s' "$files_count" | nano_html_escape)"
+  if [ "$files_count" = "0" ]; then
+    printf '      <p class="muted">None recorded</p>\n'
+  else
+    # Group: jq emits "dir<TAB>file" pairs sorted by dir.
+    printf '      <ul>\n'
+    # shellcheck disable=SC2016
+    jq -r '
+      (.summary.planned_files // [])
+      | map(tostring)
+      | sort
+      | .[]
+    ' "$artifact" | while IFS= read -r f; do
+      printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$f" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+
+  # Risks
+  local risks_count
+  risks_count=$(jq -r '(.summary.risks // []) | length' "$artifact")
+  printf '    <section class="card">\n      <h2>Risks (%s)</h2>\n' \
+    "$(printf '%s' "$risks_count" | nano_html_escape)"
+  if [ "$risks_count" = "0" ]; then
+    printf '      <p class="muted">None recorded</p>\n'
+  else
+    printf '      <ul>\n'
+    jq -r '(.summary.risks // []) | .[] | tostring' "$artifact" | while IFS= read -r r; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$r" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+
+  # Out-of-scope
+  local oos_count
+  oos_count=$(jq -r '(.summary.out_of_scope // []) | length' "$artifact")
+  printf '    <section class="card">\n      <h2>Out of scope (%s)</h2>\n' \
+    "$(printf '%s' "$oos_count" | nano_html_escape)"
+  if [ "$oos_count" = "0" ]; then
+    printf '      <p class="muted">None recorded</p>\n'
+  else
+    printf '      <ul>\n'
+    jq -r '(.summary.out_of_scope // []) | .[] | tostring' "$artifact" | while IFS= read -r item; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$item" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+
+  # Context checkpoint
+  local ck_summary
+  ck_summary=$(jq -r '.context_checkpoint.summary // "Not recorded"' "$artifact" | nano_html_escape)
+  printf '    <section class="card">\n      <h2>Context checkpoint</h2>\n'
+  printf '      <p>%s</p>\n' "$ck_summary"
+  local kf_count
+  kf_count=$(jq -r '(.context_checkpoint.key_files // []) | length' "$artifact")
+  if [ "$kf_count" != "0" ]; then
+    printf '      <h3>Key files</h3>\n      <ul>\n'
+    jq -r '(.context_checkpoint.key_files // []) | .[] | tostring' "$artifact" | while IFS= read -r kf; do
+      printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$kf" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  local dec_count
+  dec_count=$(jq -r '(.context_checkpoint.decisions_made // []) | length' "$artifact")
+  if [ "$dec_count" != "0" ]; then
+    printf '      <h3>Decisions made</h3>\n      <ul>\n'
+    jq -r '(.context_checkpoint.decisions_made // []) | .[] | tostring' "$artifact" | while IFS= read -r d; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$d" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  local oq_count
+  oq_count=$(jq -r '(.context_checkpoint.open_questions // []) | length' "$artifact")
+  if [ "$oq_count" != "0" ]; then
+    printf '      <h3>Open questions</h3>\n      <ul>\n'
+    jq -r '(.context_checkpoint.open_questions // []) | .[] | tostring' "$artifact" | while IFS= read -r q; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$q" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+}
+
+# ─── Atomic write ───────────────────────────────────────────
+TMP_HTML="$HTML_PATH.tmp.$$"
+TMP_MFST="$MANIFEST_PATH.tmp.$$"
+cleanup() {
+  rm -f "$TMP_HTML" "$TMP_MFST" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ─── Manifest ───────────────────────────────────────────────
+# Build manifest first; if the HTML render fails we can still leave a
+# clean state. We move both files into place at the very end.
+
+CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Use jq to construct the manifest so all string escaping is correct.
+jq -n \
+  --arg schema_version "1" \
+  --arg kind "phase" \
+  --arg phase "$PHASE" \
+  --argjson custom_phase false \
+  --arg format "html" \
+  --argjson interactive false \
+  --argjson strict "$($STRICT && echo true || echo false)" \
+  --arg src_phase "$ART_PHASE" \
+  --arg src_path "$ART_PATH" \
+  --arg src_integrity "$SRC_INTEGRITY" \
+  --arg src_trust "$TRUST" \
+  --arg output_path "$HTML_PATH" \
+  --arg renderer_name "$NANO_VISUAL_RENDERER_NAME" \
+  --arg renderer_version "$NANO_VISUAL_RENDERER_VERSION" \
+  --arg created_at "$CREATED_AT" \
+  --argjson schema_valid "$($SCHEMA_OK && echo true || echo false)" \
+  --arg schema_error "$SCHEMA_ERR" \
+  '{
+    schema_version: $schema_version,
+    kind: $kind,
+    phase: $phase,
+    custom_phase: $custom_phase,
+    format: $format,
+    interactive: $interactive,
+    strict: $strict,
+    source_artifacts: [{
+      phase: $src_phase,
+      path: $src_path,
+      integrity: $src_integrity,
+      trust: $src_trust
+    }],
+    output_path: $output_path,
+    renderer: { name: $renderer_name, version: $renderer_version },
+    schema_valid: $schema_valid,
+    schema_error: (if $schema_error == "" then null else $schema_error end),
+    created_at: $created_at
+  }' > "$TMP_MFST"
+
+if [ "$MANIFEST_ONLY" = true ]; then
+  mv "$TMP_MFST" "$MANIFEST_PATH"
+  trap - EXIT
+  echo "$MANIFEST_PATH"
+  exit 0
+fi
+
+# ─── HTML ───────────────────────────────────────────────────
+{
+  nano_visual_page_start "$PHASE" "$TRUST" "static"
+
+  if [ "$SCHEMA_OK" = false ]; then
+    printf '    <div class="schema-warning" data-testid="schema-warning">%s</div>\n' \
+      "$(printf 'Schema validation: %s' "$SCHEMA_ERR" | nano_html_escape)"
+  fi
+
+  case "$PHASE" in
+    plan)   render_plan_body "$ART_PATH" ;;
+  esac
+
+  nano_visual_page_end "$ART_PATH" "$MANIFEST_PATH" "$SRC_INTEGRITY"
+} > "$TMP_HTML"
+
+mv "$TMP_HTML" "$HTML_PATH"
+mv "$TMP_MFST" "$MANIFEST_PATH"
+trap - EXIT
+
+echo "$HTML_PATH"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -195,6 +195,13 @@ else
 fi
 MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
 
+# Refuse any symlink under visual/ on the path to HTML or manifest.
+# Codex PR 1 pass 4 caught that mkdir -p / mv would happily write
+# through a pre-existing visual/plan symlink to an outside target;
+# nano_visual_assert_safe_root only guards the root itself.
+nano_visual_assert_safe_descend "$(nano_visual_normalize_path "$HTML_PATH")"
+nano_visual_assert_safe_descend "$(nano_visual_normalize_path "$MANIFEST_PATH")"
+
 mkdir -p "$(dirname "$HTML_PATH")"
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -127,9 +127,13 @@ case "$PHASE" in
     ;;
 esac
 
-# Resolve the source artifact.
+# Resolve the source artifact. --no-session-sync keeps the renderer
+# strictly downstream: find-artifact.sh otherwise calls
+# `session.sh phase-start` as a convenience for skills, which would
+# mutate session.json just because a user viewed an artifact. Codex
+# PR 1 pass 7 caught the boundary violation.
 if [ -z "$ART_PATH" ] || [ "$USE_LATEST" = true ]; then
-  ART_PATH=$("$SCRIPT_DIR/find-artifact.sh" "$PHASE" 30 2>/dev/null || true)
+  ART_PATH=$("$SCRIPT_DIR/find-artifact.sh" "$PHASE" 30 --no-session-sync 2>/dev/null || true)
   if [ -z "$ART_PATH" ]; then
     echo "render-artifact: no $PHASE artifact found in the last 30 days" >&2
     exit 1

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -463,6 +463,10 @@ jq -n \
   }' > "$TMP_MFST"
 
 if [ "$MANIFEST_ONLY" = true ]; then
+  # Codex PR 1 pass 9: the manifest-only branch must not leave the
+  # mktemp'd HTML temp file behind. Clean it before disabling the
+  # cleanup trap.
+  rm -f "$TMP_HTML"
   mv "$TMP_MFST" "$MANIFEST_PATH"
   trap - EXIT
   echo "$MANIFEST_PATH"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -396,8 +396,21 @@ HTML
 }
 
 # ─── Atomic write ───────────────────────────────────────────
-TMP_HTML="$HTML_PATH.tmp.$$"
-TMP_MFST="$MANIFEST_PATH.tmp.$$"
+# Codex PR 1 pass 8: a predictable temp name (HTML_PATH.tmp.$$) lets
+# an attacker pre-create a symlink at that path; the redirect would
+# follow it and write outside visual/. Use mktemp to create the
+# files inside the already-validated parent directory; mktemp uses
+# O_EXCL so a symlink-pre-creation race fails with a clear error
+# instead of silently following the link.
+TMP_HTML=$(mktemp "$HTML_PATH.tmp.XXXXXX" 2>/dev/null) || {
+  echo "render-artifact: failed to create secure temp for HTML: $HTML_PATH" >&2
+  exit 4
+}
+TMP_MFST=$(mktemp "$MANIFEST_PATH.tmp.XXXXXX" 2>/dev/null) || {
+  rm -f "$TMP_HTML"
+  echo "render-artifact: failed to create secure temp for manifest: $MANIFEST_PATH" >&2
+  exit 4
+}
 cleanup() {
   rm -f "$TMP_HTML" "$TMP_MFST" 2>/dev/null || true
 }

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -180,6 +180,13 @@ esac
 TS=$(nano_visual_timestamp)
 nano_visual_assert_safe_root
 
+# Materialize the visual root before any path-safety check. Codex
+# caught (PR 1 pass 1) that on a fresh store the visual root does not
+# yet exist, so the canonical walk-up in nano_visual_assert_safe_output
+# stops at $NANOSTACK_STORE, which is outside the canonical visual
+# root path. Pre-creating visual/ keeps the realpath comparison stable.
+mkdir -p "$(nano_visual_root)"
+
 if [ -n "$OUT_PATH" ]; then
   nano_visual_assert_safe_output "$OUT_PATH"
   HTML_PATH="$OUT_PATH"
@@ -216,11 +223,29 @@ fi
 
 render_plan_body() {
   local artifact="$1"
+  # Normalize: legacy --from-session plan artifacts store .summary as
+  # a string and may omit .context_checkpoint entirely. Schema
+  # validation already surfaces a warning above; here we coerce the
+  # shape so the body still renders ("Not recorded" / "None recorded")
+  # instead of jq crashing under set -e. Codex caught this on PR 1
+  # pass 1: without the coercion, `render-artifact.sh plan --latest`
+  # aborted on legacy artifacts the renderer was meant to inspect.
+  local norm
+  norm=$(jq -c '
+    .summary           = (if (.summary | type)           == "object" then .summary           else {} end)
+    | .context_checkpoint = (if (.context_checkpoint | type) == "object" then .context_checkpoint else {} end)
+    | .summary.planned_files            = (if (.summary.planned_files            | type) == "array" then .summary.planned_files            else [] end)
+    | .summary.risks                    = (if (.summary.risks                    | type) == "array" then .summary.risks                    else [] end)
+    | .summary.out_of_scope             = (if (.summary.out_of_scope             | type) == "array" then .summary.out_of_scope             else [] end)
+    | .context_checkpoint.key_files     = (if (.context_checkpoint.key_files     | type) == "array" then .context_checkpoint.key_files     else [] end)
+    | .context_checkpoint.decisions_made= (if (.context_checkpoint.decisions_made| type) == "array" then .context_checkpoint.decisions_made else [] end)
+    | .context_checkpoint.open_questions= (if (.context_checkpoint.open_questions| type) == "array" then .context_checkpoint.open_questions else [] end)
+  ' "$artifact")
 
   local goal scope approval
-  goal=$(jq -r '.summary.goal // "Not recorded"' "$artifact" | nano_html_escape)
-  scope=$(jq -r '.summary.scope // "Not recorded"' "$artifact" | nano_html_escape)
-  approval=$(jq -r '.summary.plan_approval // "Not recorded"' "$artifact" | nano_html_escape)
+  goal=$(printf '%s' "$norm" | jq -r '.summary.goal // "Not recorded"' | nano_html_escape)
+  scope=$(printf '%s' "$norm" | jq -r '.summary.scope // "Not recorded"' | nano_html_escape)
+  approval=$(printf '%s' "$norm" | jq -r '.summary.plan_approval // "Not recorded"' | nano_html_escape)
 
   cat <<HTML
     <section class="card">
@@ -233,24 +258,18 @@ render_plan_body() {
     </section>
 HTML
 
-  # Planned files. Grouped by top-level directory for readability on
-  # plans that touch many files.
+  # Planned files. Reads from the normalized JSON so a legacy
+  # artifact with .summary as a string still renders an empty list
+  # instead of crashing.
   local files_count
-  files_count=$(jq -r '(.summary.planned_files // []) | length' "$artifact")
+  files_count=$(printf '%s' "$norm" | jq -r '.summary.planned_files | length')
   printf '    <section class="card">\n      <h2>Planned files (%s)</h2>\n' \
     "$(printf '%s' "$files_count" | nano_html_escape)"
   if [ "$files_count" = "0" ]; then
     printf '      <p class="muted">None recorded</p>\n'
   else
-    # Group: jq emits "dir<TAB>file" pairs sorted by dir.
     printf '      <ul>\n'
-    # shellcheck disable=SC2016
-    jq -r '
-      (.summary.planned_files // [])
-      | map(tostring)
-      | sort
-      | .[]
-    ' "$artifact" | while IFS= read -r f; do
+    printf '%s' "$norm" | jq -r '.summary.planned_files | map(tostring) | sort | .[]' | while IFS= read -r f; do
       printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$f" | nano_html_escape)"
     done
     printf '      </ul>\n'
@@ -259,14 +278,14 @@ HTML
 
   # Risks
   local risks_count
-  risks_count=$(jq -r '(.summary.risks // []) | length' "$artifact")
+  risks_count=$(printf '%s' "$norm" | jq -r '.summary.risks | length')
   printf '    <section class="card">\n      <h2>Risks (%s)</h2>\n' \
     "$(printf '%s' "$risks_count" | nano_html_escape)"
   if [ "$risks_count" = "0" ]; then
     printf '      <p class="muted">None recorded</p>\n'
   else
     printf '      <ul>\n'
-    jq -r '(.summary.risks // []) | .[] | tostring' "$artifact" | while IFS= read -r r; do
+    printf '%s' "$norm" | jq -r '.summary.risks | .[] | tostring' | while IFS= read -r r; do
       printf '        <li>%s</li>\n' "$(printf '%s' "$r" | nano_html_escape)"
     done
     printf '      </ul>\n'
@@ -275,14 +294,14 @@ HTML
 
   # Out-of-scope
   local oos_count
-  oos_count=$(jq -r '(.summary.out_of_scope // []) | length' "$artifact")
+  oos_count=$(printf '%s' "$norm" | jq -r '.summary.out_of_scope | length')
   printf '    <section class="card">\n      <h2>Out of scope (%s)</h2>\n' \
     "$(printf '%s' "$oos_count" | nano_html_escape)"
   if [ "$oos_count" = "0" ]; then
     printf '      <p class="muted">None recorded</p>\n'
   else
     printf '      <ul>\n'
-    jq -r '(.summary.out_of_scope // []) | .[] | tostring' "$artifact" | while IFS= read -r item; do
+    printf '%s' "$norm" | jq -r '.summary.out_of_scope | .[] | tostring' | while IFS= read -r item; do
       printf '        <li>%s</li>\n' "$(printf '%s' "$item" | nano_html_escape)"
     done
     printf '      </ul>\n'
@@ -291,32 +310,32 @@ HTML
 
   # Context checkpoint
   local ck_summary
-  ck_summary=$(jq -r '.context_checkpoint.summary // "Not recorded"' "$artifact" | nano_html_escape)
+  ck_summary=$(printf '%s' "$norm" | jq -r '.context_checkpoint.summary // "Not recorded"' | nano_html_escape)
   printf '    <section class="card">\n      <h2>Context checkpoint</h2>\n'
   printf '      <p>%s</p>\n' "$ck_summary"
   local kf_count
-  kf_count=$(jq -r '(.context_checkpoint.key_files // []) | length' "$artifact")
+  kf_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.key_files | length')
   if [ "$kf_count" != "0" ]; then
     printf '      <h3>Key files</h3>\n      <ul>\n'
-    jq -r '(.context_checkpoint.key_files // []) | .[] | tostring' "$artifact" | while IFS= read -r kf; do
+    printf '%s' "$norm" | jq -r '.context_checkpoint.key_files | .[] | tostring' | while IFS= read -r kf; do
       printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$kf" | nano_html_escape)"
     done
     printf '      </ul>\n'
   fi
   local dec_count
-  dec_count=$(jq -r '(.context_checkpoint.decisions_made // []) | length' "$artifact")
+  dec_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.decisions_made | length')
   if [ "$dec_count" != "0" ]; then
     printf '      <h3>Decisions made</h3>\n      <ul>\n'
-    jq -r '(.context_checkpoint.decisions_made // []) | .[] | tostring' "$artifact" | while IFS= read -r d; do
+    printf '%s' "$norm" | jq -r '.context_checkpoint.decisions_made | .[] | tostring' | while IFS= read -r d; do
       printf '        <li>%s</li>\n' "$(printf '%s' "$d" | nano_html_escape)"
     done
     printf '      </ul>\n'
   fi
   local oq_count
-  oq_count=$(jq -r '(.context_checkpoint.open_questions // []) | length' "$artifact")
+  oq_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.open_questions | length')
   if [ "$oq_count" != "0" ]; then
     printf '      <h3>Open questions</h3>\n      <ul>\n'
-    jq -r '(.context_checkpoint.open_questions // []) | .[] | tostring' "$artifact" | while IFS= read -r q; do
+    printf '%s' "$norm" | jq -r '.context_checkpoint.open_questions | .[] | tostring' | while IFS= read -r q; do
       printf '        <li>%s</li>\n' "$(printf '%s' "$q" | nano_html_escape)"
     done
     printf '      </ul>\n'

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -147,8 +147,12 @@ if ! jq -e '.' "$ART_PATH" >/dev/null 2>&1; then
   exit 1
 fi
 
-# .phase field must match the requested phase.
-ART_PHASE=$(jq -r '.phase // ""' "$ART_PATH")
+# .phase field must match the requested phase. Codex PR 1 pass 6
+# caught: a top-level JSON array or string crashes `jq -r '.phase //
+# ""'` with exit 5 under set -e; the documented input-error exit is
+# 1. The `?` operator suppresses the path error so non-object JSON
+# falls through cleanly and the phase mismatch branch handles it.
+ART_PHASE=$(jq -r '.phase? // ""' "$ART_PATH")
 if [ "$ART_PHASE" != "$PHASE" ]; then
   echo "render-artifact: artifact phase '$ART_PHASE' does not match requested phase '$PHASE': $ART_PATH" >&2
   exit 1
@@ -195,12 +199,23 @@ else
 fi
 MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
 
+# Codex PR 1 pass 6 caught: even after lexical normalization passes
+# the safety check, mkdir -p and mv use the ORIGINAL path, and the
+# kernel resolves symlink components literally. A path like
+# `visual/link/../evil.html` with `link` pointing outside collapses
+# to `visual/evil.html` for the check but resolves to
+# `outside/../evil.html` -> `outside/.../evil.html` at write time.
+# Reassign HTML_PATH and MANIFEST_PATH to their normalized form so
+# the kernel never traverses a `..` after a symlinked component.
+HTML_PATH="$(nano_visual_normalize_path "$HTML_PATH")"
+MANIFEST_PATH="$(nano_visual_normalize_path "$MANIFEST_PATH")"
+
 # Refuse any symlink under visual/ on the path to HTML or manifest.
 # Codex PR 1 pass 4 caught that mkdir -p / mv would happily write
 # through a pre-existing visual/plan symlink to an outside target;
 # nano_visual_assert_safe_root only guards the root itself.
-nano_visual_assert_safe_descend "$(nano_visual_normalize_path "$HTML_PATH")"
-nano_visual_assert_safe_descend "$(nano_visual_normalize_path "$MANIFEST_PATH")"
+nano_visual_assert_safe_descend "$HTML_PATH"
+nano_visual_assert_safe_descend "$MANIFEST_PATH"
 
 mkdir -p "$(dirname "$HTML_PATH")"
 mkdir -p "$(dirname "$MANIFEST_PATH")"

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check-visual-artifact-templates.sh — Static safety lint for the
+# visual artifact layer.
+#
+# Greps the renderer and shared shell for patterns that would break
+# the Visual Artifact Contract:
+#
+#   - external network references (http://, https://) in templates
+#   - script-loading or XHR-style APIs
+#   - browser-side storage / cookie access
+#   - eval / new Function
+#   - missing CSP / data-nanostack-visual markers in the shared shell
+#   - trust badge wording must use the locked strings
+#
+# Scope is intentionally narrow: only files that emit HTML for the
+# visual layer. The list is hardcoded so adding a new renderer file
+# requires touching this script (auditable diff).
+
+set -e
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+FILES=(
+  "bin/render-artifact.sh"
+  "bin/lib/visual-render.sh"
+  "bin/lib/html-escape.sh"
+)
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+check_absent() {
+  local name="$1"; local pattern="$2"; shift 2
+  local files=("$@")
+  if grep -nE "$pattern" "${files[@]}" >/dev/null 2>&1; then
+    FAIL=$((FAIL+1))
+    printf "  ${RED}FAIL${NC}  %s\n" "$name"
+    printf "         ${DIM}pattern: %s${NC}\n" "$pattern"
+    grep -nE "$pattern" "${files[@]}" | sed 's/^/         /' || true
+  else
+    PASS=$((PASS+1))
+    printf "  ${GREEN}OK${NC}    %s\n" "$name"
+  fi
+}
+
+check_present() {
+  local name="$1"; local pattern="$2"; shift 2
+  local files=("$@")
+  if grep -nE "$pattern" "${files[@]}" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "  ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "  ${RED}FAIL${NC}  %s (pattern missing)\n" "$name"
+    printf "         ${DIM}pattern: %s${NC}\n" "$pattern"
+  fi
+}
+
+printf "\n${GREEN}=== Visual artifact template safety ===${NC}\n\n"
+
+# 1. No external URLs in renderer source. Comments are allowed for
+# contract refs but the contract doc has no URLs either.
+check_absent "no http(s) URLs in renderer/templates" \
+  'https?://' "${FILES[@]}"
+
+# 2. No script-loading or XHR-style APIs.
+check_absent "no <script src=" \
+  '<script[[:space:]]+src=' "${FILES[@]}"
+check_absent "no fetch(" \
+  'fetch[[:space:]]*\(' "${FILES[@]}"
+check_absent "no XMLHttpRequest" \
+  'XMLHttpRequest' "${FILES[@]}"
+check_absent "no navigator.sendBeacon" \
+  'navigator\.sendBeacon' "${FILES[@]}"
+
+# 3. No browser-side storage or cookie access.
+check_absent "no localStorage" \
+  'localStorage' "${FILES[@]}"
+check_absent "no sessionStorage" \
+  'sessionStorage' "${FILES[@]}"
+check_absent "no document.cookie" \
+  'document\.cookie' "${FILES[@]}"
+
+# 4. No eval / Function constructor.
+check_absent "no eval(" \
+  'eval[[:space:]]*\(' "${FILES[@]}"
+check_absent "no new Function(" \
+  'new[[:space:]]+Function[[:space:]]*\(' "${FILES[@]}"
+
+# 5. Shared shell must include CSP and the visual marker.
+check_present "shared shell emits CSP" \
+  "Content-Security-Policy" "bin/lib/visual-render.sh"
+check_present "shared shell emits data-nanostack-visual" \
+  'data-nanostack-visual' "bin/lib/visual-render.sh"
+check_present "shared shell emits provenance testid" \
+  'data-testid="visual-provenance"' "bin/lib/visual-render.sh"
+
+# 6. Trust badge wording is locked: 'verified', 'unverified',
+# 'tampered'. Anything else for these statuses fails. We check the
+# shared function uses these exact words.
+check_present "trust badge: verified" \
+  "printf 'verified" "bin/lib/visual-render.sh"
+check_present "trust badge: unverified (integrity_missing)" \
+  "printf 'unverified" "bin/lib/visual-render.sh"
+check_present "trust badge: tampered (integrity_mismatch)" \
+  "printf 'tampered" "bin/lib/visual-render.sh"
+
+# 7. Static-mode CSP must include default-src 'none' so the static
+# renderer in PR 1 cannot accidentally widen the policy. Interactive
+# mode (PR 4) gets its own check when wired.
+check_present "static CSP default-src 'none'" \
+  "default-src 'none'" "bin/lib/visual-render.sh"
+
+# 8. Renderer must source the escape helpers, not inline its own.
+check_present "renderer sources html-escape" \
+  'source.*lib/html-escape.sh' "bin/render-artifact.sh"
+check_present "renderer sources visual-render" \
+  'source.*lib/visual-render.sh' "bin/render-artifact.sh"
+check_present "renderer sources artifact-trust" \
+  'source.*lib/artifact-trust.sh' "bin/render-artifact.sh"
+
+TOTAL=$((PASS+FAIL))
+printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"
+if [ "$FAIL" -gt 0 ]; then
+  printf "${RED}=== %s checks failed ===${NC}\n" "$FAIL"
+  exit 1
+fi
+printf "${GREEN}=== all checks passed ===${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# e2e-visual-artifacts.sh — Visual Artifacts v1 PR 1 contract.
+#
+# Locks bin/render-artifact.sh + bin/lib/html-escape.sh +
+# bin/lib/visual-render.sh end-to-end against the contract in
+# reference/visual-artifact-contract.md.
+#
+# Scope (PR 1):
+#   - /plan render succeeds on a valid artifact
+#   - manifest schema (schema_version, kind, format, source_artifacts,
+#     output_path, renderer)
+#   - malicious artifact text is escaped, no raw <script>/<img>
+#   - CSP and required data-* attributes present in HTML
+#   - --strict rejects integrity_missing (exit 3)
+#   - --strict rejects integrity_mismatch (exit 3)
+#   - integrity_mismatch fails even without --strict (exit 3)
+#   - --out outside the visual root fails (exit 4)
+#   - --interactive is reserved (exit 2)
+#   - journal/stack are reserved (exit 2)
+#   - --manifest-only writes only the manifest
+#   - --latest resolution via find-artifact.sh
+#   - phase mismatch on explicit path fails (exit 1)
+
+set -e
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT=$(mktemp -d /tmp/nanostack-visual-artifacts.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+DIM='\033[0;90m'
+NC='\033[0m'
+
+assert_true() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s\n" "$name"
+    printf "          ${DIM}cmd: %s${NC}\n" "$*"
+  fi
+}
+
+assert_false() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s (expected failure)\n" "$name"
+  else
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  fi
+}
+
+assert_exit() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local actual
+  set +e
+  "$@" >/dev/null 2>&1
+  actual=$?
+  set -e
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s (exit %s)\n" "$name" "$actual"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s (expected exit %s, got %s)\n" "$name" "$expected" "$actual"
+  fi
+}
+
+assert_contains() {
+  local name="$1"; local file="$2"; local needle="$3"
+  if grep -qF "$needle" "$file"; then
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s (needle not in %s)\n" "$name" "$file"
+    printf "          ${DIM}needle: %s${NC}\n" "$needle"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1"; local file="$2"; local needle="$3"
+  if grep -qF "$needle" "$file"; then
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  %s (forbidden needle present in %s)\n" "$name" "$file"
+    printf "          ${DIM}needle: %s${NC}\n" "$needle"
+  else
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    %s\n" "$name"
+  fi
+}
+
+setup_project() {
+  local dir="$1"
+  mkdir -p "$dir"
+  (cd "$dir" && git init -q && git config user.email t@t && git config user.name t && \
+   echo init > a.txt && git add a.txt && git commit -qm init)
+}
+
+save_valid_plan() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" plan '{
+    "phase": "plan",
+    "summary": {
+      "goal": "Visual artifacts v1",
+      "scope": "small",
+      "planned_files": ["bin/render-artifact.sh", "bin/lib/html-escape.sh"],
+      "plan_approval": "manual",
+      "risks": ["Renderer escapes incomplete"],
+      "out_of_scope": ["Interactive mode"]
+    },
+    "context_checkpoint": {
+      "summary": "Local HTML view",
+      "key_files": ["bin/render-artifact.sh"],
+      "decisions_made": ["JSON canonical"],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_malicious_plan() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" plan '{
+    "phase": "plan",
+    "summary": {
+      "goal": "<script>alert(1)</script>",
+      "scope": "small",
+      "planned_files": ["src/<img src=x onerror=alert(1)>.ts"],
+      "plan_approval": "manual",
+      "risks": ["\" onclick=\"alert(1)"]
+    },
+    "context_checkpoint": {
+      "summary": "<b>bold?</b>",
+      "key_files": [],
+      "decisions_made": [],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+printf "\n${GREEN}=== Visual Artifacts v1 PR 1 contract ===${NC}\n\n"
+
+# ─── Cell 1: happy path /plan render ────────────────────────
+printf "  ${DIM}Cell 1: happy path /plan render${NC}\n"
+PROJ="$TMP_ROOT/cell1"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+set +e
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest 2>/dev/null)
+RC=$?
+set -e
+assert_exit "render plan --latest succeeds" 0 test "$RC" = 0
+assert_true "html file exists" test -f "$HTML"
+assert_contains "doctype" "$HTML" "<!doctype html>"
+assert_contains "viewport meta" "$HTML" "viewport"
+assert_contains "CSP header" "$HTML" "default-src 'none'"
+assert_contains "data-nanostack-visual attr" "$HTML" 'data-nanostack-visual="1"'
+assert_contains "data-phase attr" "$HTML" 'data-phase="plan"'
+assert_contains "trust badge data-trust=verified" "$HTML" 'data-trust="verified"'
+assert_contains "trust badge text 'verified'" "$HTML" '>verified<'
+assert_contains "goal rendered" "$HTML" "Visual artifacts v1"
+assert_contains "planned file rendered" "$HTML" "bin/render-artifact.sh"
+assert_contains "risk rendered" "$HTML" "Renderer escapes incomplete"
+assert_contains "context summary rendered" "$HTML" "Local HTML view"
+assert_contains "provenance footer" "$HTML" 'data-testid="visual-provenance"'
+assert_contains "source artifact path attr" "$HTML" 'data-testid="source-artifact-path"'
+assert_contains "manifest path attr" "$HTML" 'data-testid="visual-manifest-path"'
+
+# Manifest schema checks.
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*.manifest.json 2>/dev/null | head -1)
+assert_true "manifest file exists" test -f "$MFST"
+assert_true "manifest schema_version == 1" sh -c "[ \"\$(jq -r .schema_version '$MFST')\" = '1' ]"
+assert_true "manifest kind == phase" sh -c "[ \"\$(jq -r .kind '$MFST')\" = 'phase' ]"
+assert_true "manifest format == html" sh -c "[ \"\$(jq -r .format '$MFST')\" = 'html' ]"
+assert_true "manifest phase == plan" sh -c "[ \"\$(jq -r .phase '$MFST')\" = 'plan' ]"
+assert_true "manifest custom_phase == false" sh -c "[ \"\$(jq -r .custom_phase '$MFST')\" = 'false' ]"
+assert_true "manifest source_artifacts length >= 1" sh -c "[ \"\$(jq -r '.source_artifacts | length' '$MFST')\" -ge 1 ]"
+assert_true "manifest source trust == verified" sh -c "[ \"\$(jq -r '.source_artifacts[0].trust' '$MFST')\" = 'verified' ]"
+assert_true "manifest renderer.version present" sh -c "[ -n \"\$(jq -r '.renderer.version' '$MFST')\" ]"
+assert_true "manifest output_path absolute" sh -c "[ \"\$(jq -r .output_path '$MFST')\" = '$HTML' ]"
+
+# ─── Cell 2: XSS / escape contract ──────────────────────────
+printf "\n  ${DIM}Cell 2: XSS / escape contract${NC}\n"
+PROJ="$TMP_ROOT/cell2"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_malicious_plan "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest)
+assert_not_contains "no raw <script>alert(" "$HTML" "<script>alert("
+assert_not_contains "no raw <img src=x onerror" "$HTML" "<img src=x onerror"
+assert_contains "escaped &lt;script&gt;" "$HTML" "&lt;script&gt;"
+assert_contains "escaped &lt;img" "$HTML" "&lt;img"
+assert_contains "escaped &quot;" "$HTML" "&quot;"
+
+# ─── Cell 3: --strict integrity_missing rejection ───────────
+printf "\n  ${DIM}Cell 3: --strict integrity_missing rejection${NC}\n"
+PROJ="$TMP_ROOT/cell3"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+# Strip .integrity
+jq 'del(.integrity)' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "render --strict on integrity_missing exits 3" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --strict"
+# Without --strict it should render with the unverified badge
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest 2>/dev/null)
+assert_contains "integrity_missing badge unverified" "$HTML" 'data-trust="integrity_missing"'
+assert_contains "badge text unverified" "$HTML" '>unverified<'
+
+# ─── Cell 4: integrity_mismatch always fails ────────────────
+printf "\n  ${DIM}Cell 4: integrity_mismatch always fails (exit 3)${NC}\n"
+PROJ="$TMP_ROOT/cell4"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+# Mutate .summary.goal after save (keeps .integrity but breaks hash)
+jq '.summary.goal = "Tampered!"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "render plain on integrity_mismatch exits 3" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest"
+assert_exit "render --strict on integrity_mismatch exits 3" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --strict"
+
+# ─── Cell 5: --out path safety ──────────────────────────────
+printf "\n  ${DIM}Cell 5: --out path safety${NC}\n"
+PROJ="$TMP_ROOT/cell5"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "--out outside visual root exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out /tmp/outside.html"
+assert_exit "--out relative path exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out foo.html"
+# Inside the visual root should work.
+INSIDE="$NANOSTACK_STORE/visual/plan/explicit.html"
+mkdir -p "$(dirname "$INSIDE")"
+assert_exit "--out inside visual root succeeds" 0 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out '$INSIDE'"
+assert_true "explicit out file exists" test -f "$INSIDE"
+
+# ─── Cell 6: reserved features exit 2 ───────────────────────
+printf "\n  ${DIM}Cell 6: reserved features exit 2${NC}\n"
+PROJ="$TMP_ROOT/cell6"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "--interactive reserved (exit 2)" 2 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --interactive"
+assert_exit "journal reserved (exit 2)" 2 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today"
+assert_exit "stack reserved (exit 2)" 2 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack mystack"
+
+# ─── Cell 7: --manifest-only ────────────────────────────────
+printf "\n  ${DIM}Cell 7: --manifest-only${NC}\n"
+PROJ="$TMP_ROOT/cell7"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+MFST_OUT=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --manifest-only)
+assert_true "manifest path printed" sh -c "[ -n '$MFST_OUT' ]"
+assert_true "manifest file exists" test -f "$MFST_OUT"
+# No HTML should be written in --manifest-only mode.
+HTML_COUNT=$(find "$NANOSTACK_STORE/visual/plan" -maxdepth 1 -name "*.html" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no html written under manifest-only" sh -c "[ '$HTML_COUNT' = '0' ]"
+
+# ─── Cell 8: phase mismatch / reserved-PR-2 phases ──────────
+printf "\n  ${DIM}Cell 8: phase mismatch and reserved-PR-2 phases${NC}\n"
+PROJ="$TMP_ROOT/cell8"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+# Passing an explicit /plan artifact as if it were /review must fail
+# because the requested phase is reserved for PR 2.
+assert_exit "render review (PR 2) exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' review --latest"
+# Edit the .phase field to 'review' and request as 'plan' -> mismatch.
+TMPPLAN="$TMP_ROOT/mixed.json"
+jq '.phase = "review"' "$PLAN_PATH" > "$TMPPLAN"
+assert_exit "explicit path with mismatched .phase exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$TMPPLAN'"
+
+# ─── Cell 9: symlinked visual root rejected ─────────────────
+printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
+PROJ="$TMP_ROOT/cell9"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+mkdir -p "$TMP_ROOT/cell9-elsewhere"
+ln -s "$TMP_ROOT/cell9-elsewhere" "$NANOSTACK_STORE/visual"
+assert_exit "symlinked visual root exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest"
+
+# ─── Summary ────────────────────────────────────────────────
+TOTAL=$((PASS+FAIL))
+printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"
+if [ "$FAIL" -gt 0 ]; then
+  printf "${RED}=== %s checks failed ===${NC}\n" "$FAIL"
+  exit 1
+fi
+printf "${GREEN}=== all checks passed ===${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -301,6 +301,61 @@ jq '.phase = "review"' "$PLAN_PATH" > "$TMPPLAN"
 assert_exit "explicit path with mismatched .phase exits 1" 1 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$TMPPLAN'"
 
+# ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
+printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
+PROJ="$TMP_ROOT/cell9a"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Visual root does not yet exist; --out under it must still succeed.
+[ ! -d "$NANOSTACK_STORE/visual" ] && PASS=$((PASS+1)) || PASS=$PASS
+TARGET="$NANOSTACK_STORE/visual/plan/custom.html"
+set +e
+(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --out "$TARGET" >/dev/null 2>&1)
+RC=$?
+set -e
+assert_exit "--out on fresh store succeeds" 0 test "$RC" = 0
+assert_true "custom output file exists" test -f "$TARGET"
+
+# ─── Cell 9b: legacy --from-session plan still renders ──────
+# (PR 1 pass 1 regression)
+printf "\n  ${DIM}Cell 9b: legacy plan renders without crashing${NC}\n"
+PROJ="$TMP_ROOT/cell9b"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" --from-session plan "legacy summary" >/dev/null 2>&1)
+set +e
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest 2>/dev/null)
+RC=$?
+set -e
+assert_exit "legacy plan renders (exit 0)" 0 test "$RC" = 0
+assert_true "legacy plan html exists" test -f "$HTML"
+assert_contains "legacy plan shows schema warning" "$HTML" 'data-testid="schema-warning"'
+assert_contains "legacy plan still renders trust badge" "$HTML" 'data-trust="integrity_missing"'
+assert_contains "legacy plan still emits summary card" "$HTML" "Goal"
+
+# Same path, but the renderer must coerce a string .summary safely.
+PROJ2="$TMP_ROOT/cell9c"
+setup_project "$PROJ2"
+export NANOSTACK_STORE="$PROJ2/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# Write an artifact with .summary = "string" via save-artifact's
+# structured form but with shape that the validator will reject. The
+# renderer must still produce HTML.
+BAD="$NANOSTACK_STORE/plan/bad.json"
+mkdir -p "$(dirname "$BAD")"
+cat > "$BAD" <<'JSON'
+{"phase":"plan","summary":"all-as-string-summary","context_checkpoint":"also-a-string","timestamp":"2026-05-11T00:00:00Z","project":"x","branch":"y"}
+JSON
+set +e
+HTML=$(cd "$PROJ2" && "$REPO/bin/render-artifact.sh" plan "$BAD" 2>/dev/null)
+RC=$?
+set -e
+assert_exit "string-summary artifact still renders" 0 test "$RC" = 0
+assert_contains "string-summary html has schema warning" "$HTML" 'data-testid="schema-warning"'
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -289,6 +289,9 @@ assert_true "manifest file exists" test -f "$MFST_OUT"
 # No HTML should be written in --manifest-only mode.
 HTML_COUNT=$(find "$NANOSTACK_STORE/visual/plan" -maxdepth 1 -name "*.html" 2>/dev/null | wc -l | tr -d ' ')
 assert_true "no html written under manifest-only" sh -c "[ '$HTML_COUNT' = '0' ]"
+# PR 1 pass 9: no temp file leftovers either.
+TMP_LEFTOVER=$(find "$NANOSTACK_STORE/visual" -name "*.tmp.*" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no tmp leftover under manifest-only" sh -c "[ '$TMP_LEFTOVER' = '0' ]"
 
 # ─── Cell 8: phase mismatch / reserved-PR-2 phases ──────────
 printf "\n  ${DIM}Cell 8: phase mismatch and reserved-PR-2 phases${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -363,6 +363,56 @@ set -e
 assert_exit "string-summary artifact still renders" 0 test "$RC" = 0
 assert_contains "string-summary html has schema warning" "$HTML" 'data-testid="schema-warning"'
 
+# ─── Cell 9d: relative NANOSTACK_STORE -> absolute manifest paths ─
+# PR 1 pass 3 regression: a relative store override must still
+# produce an absolute output_path in the manifest.
+printf "\n  ${DIM}Cell 9d: relative store -> absolute manifest (PR 1 pass 3 regression)${NC}\n"
+PROJ="$TMP_ROOT/cell9d"
+setup_project "$PROJ"
+cd "$PROJ"
+export NANOSTACK_STORE=".nano-rel"
+mkdir -p "$NANOSTACK_STORE"
+save_valid_plan "$NANOSTACK_STORE"
+HTML=$("$REPO/bin/render-artifact.sh" plan --latest)
+cd "$REPO"
+# Stdout path must be absolute.
+case "$HTML" in
+  /*)
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    stdout path is absolute\n"
+    ;;
+  *)
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  stdout path is relative: %s\n" "$HTML"
+    ;;
+esac
+# Manifest output_path must be absolute and equal the stdout path.
+MFST_REL=$(ls "$PROJ/$NANOSTACK_STORE/visual/manifests/"*.manifest.json | head -1)
+MFST_OUT=$(jq -r .output_path "$MFST_REL")
+case "$MFST_OUT" in
+  /*)
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    manifest output_path is absolute\n"
+    ;;
+  *)
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  manifest output_path is relative: %s\n" "$MFST_OUT"
+    ;;
+esac
+# Source path must be absolute too.
+SRC_OUT=$(jq -r '.source_artifacts[0].path' "$MFST_REL")
+case "$SRC_OUT" in
+  /*)
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    manifest source path is absolute\n"
+    ;;
+  *)
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  manifest source path is relative: %s\n" "$SRC_OUT"
+    ;;
+esac
+unset NANOSTACK_STORE
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -562,6 +562,48 @@ PLAN_LOGGED=$(jq -r '.phase_log // [] | map(.phase) | contains(["plan"])' "$NANO
 assert_true "plan not registered as in_progress by render" \
   sh -c "[ '$PLAN_LOGGED' = 'false' ]"
 
+# ─── Cell 9m: glob metachars in --out preserved literally ──
+# PR 1 pass 8 P3 regression. nano_visual_normalize_path used to
+# perform pathname expansion during the IFS split; an --out with `*`
+# or `?` could be silently rewritten to a matching real filename.
+printf "\n  ${DIM}Cell 9m: glob metachars in --out (PR 1 pass 8)${NC}\n"
+PROJ="$TMP_ROOT/cell9m"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual/plan"
+# Pre-create a real file that would match a glob if expansion ran.
+touch "$NANOSTACK_STORE/visual/plan/starA.html"
+touch "$NANOSTACK_STORE/visual/plan/starB.html"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Use a quoted literal "star*.html" as --out; this must NOT expand.
+TARGET="$NANOSTACK_STORE/visual/plan/star?special.html"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --out "$TARGET")
+assert_true "literal glob path preserved (no expansion)" \
+  sh -c "[ '$HTML' = '$TARGET' ]"
+assert_true "literal file exists at requested path" test -f "$TARGET"
+
+# ─── Cell 9n: predictable temp file not used ───────────────
+# PR 1 pass 8 P2 regression. The pre-fix render created a temp file
+# at $HTML_PATH.tmp.$$, which an attacker could pre-symlink. Verify
+# the renderer no longer creates files with the predictable pattern
+# and that any race-created symlink at .tmp.<pid> does not get
+# followed.
+printf "\n  ${DIM}Cell 9n: secure temp file (PR 1 pass 8)${NC}\n"
+PROJ="$TMP_ROOT/cell9n"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual/plan"
+mkdir -p "$TMP_ROOT/cell9n-outside"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Race: pre-create a symlink at the *new* mktemp-format path. We
+# cannot guess the random suffix; what we CAN do is verify that the
+# render still works when there is no symlink hijack, and that
+# leftover .tmp.* files are cleaned up.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest)
+TMP_LEFTOVER=$(find "$NANOSTACK_STORE/visual" -name "*.tmp.*" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "render succeeds with mktemp" test -f "$HTML"
+assert_true "no leftover tmp files" sh -c "[ '$TMP_LEFTOVER' = '0' ]"
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -539,6 +539,29 @@ echo '42' > "$NUM"
 assert_exit "number JSON exits 1" 1 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$NUM'"
 
+# ─── Cell 9l: render does not mutate session state ─────────
+# PR 1 pass 7 regression. find-artifact.sh registers the phase via
+# session.sh phase-start as a convenience; render-artifact.sh must
+# pass --no-session-sync so a viewer never marks a phase as
+# in_progress.
+printf "\n  ${DIM}Cell 9l: render does not mutate session (PR 1 pass 7)${NC}\n"
+PROJ="$TMP_ROOT/cell9l"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Start a session but do not register any phase yet.
+(cd "$PROJ" && "$REPO/bin/session.sh" init --goal "test session" >/dev/null 2>&1)
+SESSION_BEFORE=$(jq -c '.phase_log // []' "$NANOSTACK_STORE/session.json" 2>/dev/null || echo "[]")
+(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest >/dev/null)
+SESSION_AFTER=$(jq -c '.phase_log // []' "$NANOSTACK_STORE/session.json" 2>/dev/null || echo "[]")
+assert_true "session.phase_log unchanged after render" \
+  sh -c "[ '$SESSION_BEFORE' = '$SESSION_AFTER' ]"
+# Specifically: plan must NOT be in_progress after a render-only call.
+PLAN_LOGGED=$(jq -r '.phase_log // [] | map(.phase) | contains(["plan"])' "$NANOSTACK_STORE/session.json" 2>/dev/null || echo "false")
+assert_true "plan not registered as in_progress by render" \
+  sh -c "[ '$PLAN_LOGGED' = 'false' ]"
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -248,6 +248,13 @@ assert_exit "--out outside visual root exits 4" 4 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out /tmp/outside.html"
 assert_exit "--out relative path exits 4" 4 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out foo.html"
+# PR 1 pass 2 regression: --out with .. that escapes visual/ through a
+# missing segment must be rejected even though every "existing
+# ancestor" lies inside the visual root.
+assert_exit "--out with .. escape exits 4 (PR 1 pass 2 regression)" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out '$NANOSTACK_STORE/visual/new/../../outside.html'"
+# Confirm the escape did NOT leave a file behind outside visual/.
+assert_true "no escaped file at .nanostack/outside.html" sh -c "[ ! -f '$NANOSTACK_STORE/outside.html' ]"
 # Inside the visual root should work.
 INSIDE="$NANOSTACK_STORE/visual/plan/explicit.html"
 mkdir -p "$(dirname "$INSIDE")"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -413,6 +413,37 @@ case "$SRC_OUT" in
 esac
 unset NANOSTACK_STORE
 
+# ─── Cell 9e: symlinked visual subdirectory rejected ───────
+# PR 1 pass 4 regression: a pre-existing symlink under visual/
+# (e.g. visual/plan -> /tmp/outside) must be rejected so mv cannot
+# write through it.
+printf "\n  ${DIM}Cell 9e: symlinked visual subdir (PR 1 pass 4 regression)${NC}\n"
+PROJ="$TMP_ROOT/cell9e"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual"
+mkdir -p "$TMP_ROOT/cell9e-outside"
+ln -s "$TMP_ROOT/cell9e-outside" "$NANOSTACK_STORE/visual/plan"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "symlinked visual/plan exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest"
+# Confirm nothing was written through the symlink.
+HTML_COUNT=$(find "$TMP_ROOT/cell9e-outside" -maxdepth 1 -name "*.html" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no file written through symlinked subdir" sh -c "[ '$HTML_COUNT' = '0' ]"
+
+# Same check for visual/manifests symlink.
+PROJ="$TMP_ROOT/cell9f"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual"
+mkdir -p "$TMP_ROOT/cell9f-outside"
+ln -s "$TMP_ROOT/cell9f-outside" "$NANOSTACK_STORE/visual/manifests"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "symlinked visual/manifests exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest"
+MFST_COUNT=$(find "$TMP_ROOT/cell9f-outside" -maxdepth 1 -name "*.manifest.json" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no manifest written through symlinked subdir" sh -c "[ '$MFST_COUNT' = '0' ]"
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -471,6 +471,74 @@ mkdir -p "$NANOSTACK_STORE/visual/plan/explicit.html"  # leaf is a directory
 assert_exit "directory at output leaf exits 4" 4 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out '$NANOSTACK_STORE/visual/plan/explicit.html'"
 
+# ─── Cell 9i: symlink + .. bypass through write target ─────
+# PR 1 pass 6 P1 regression: --out with a symlinked component
+# followed by `..`. Lexical normalization passed before; the kernel
+# would resolve the original path at write time and escape visual/.
+# The fix is to write to the normalized path.
+printf "\n  ${DIM}Cell 9i: symlink + .. bypass through write (PR 1 pass 6)${NC}\n"
+PROJ="$TMP_ROOT/cell9i"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual/plan"
+mkdir -p "$TMP_ROOT/cell9i-outside"
+ln -s "$TMP_ROOT/cell9i-outside" "$NANOSTACK_STORE/visual/link"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Attack: visual/link/../evil.html. Normalized this is visual/evil.html
+# (under visual/). At kernel-resolve time the original path goes:
+# visual/link -> /tmp/.../cell9i-outside, then .. -> /tmp/.../, then
+# evil.html appears outside the store.
+set +e
+(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --out \
+  "$NANOSTACK_STORE/visual/link/../evil.html" >/dev/null 2>&1)
+RC=$?
+set -e
+# Either the render exits 4 (rejected), or it succeeds writing
+# safely to visual/evil.html under the normalized path. Both are
+# acceptable; what is NOT acceptable is a file appearing outside
+# visual/.
+LEAK_COUNT=$(find "$TMP_ROOT/cell9i-outside" -maxdepth 1 -type f -name "*.html" 2>/dev/null | wc -l | tr -d ' ')
+STORE_LEAK=$(find "$PROJ" -maxdepth 3 -name 'evil.html' -not -path "*/visual/*" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no file outside visual via symlink+.. (outside dir empty)" sh -c "[ '$LEAK_COUNT' = '0' ]"
+assert_true "no file at evil.html outside visual/" sh -c "[ '$STORE_LEAK' = '0' ]"
+
+# ─── Cell 9j: same-second renders keep their own manifests ──
+# PR 1 pass 6 P2 regression.
+printf "\n  ${DIM}Cell 9j: same-second renders unique manifests (PR 1 pass 6)${NC}\n"
+PROJ="$TMP_ROOT/cell9j"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+H1=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --out "$NANOSTACK_STORE/visual/plan/a.html")
+H2=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --out "$NANOSTACK_STORE/visual/plan/b.html")
+# Find each provenance footer's manifest pointer; they must differ.
+M1=$(grep -oE 'visual-manifest-path[^>]*>[^<]+<' "$H1" | sed -E 's/.*>([^<]+)<.*/\1/' | head -1)
+M2=$(grep -oE 'visual-manifest-path[^>]*>[^<]+<' "$H2" | sed -E 's/.*>([^<]+)<.*/\1/' | head -1)
+assert_true "render 1 references manifest A" sh -c "[ -n '$M1' ] && [ -f '$M1' ]"
+assert_true "render 2 references manifest B" sh -c "[ -n '$M2' ] && [ -f '$M2' ]"
+assert_true "manifests differ" sh -c "[ '$M1' != '$M2' ]"
+
+# ─── Cell 9k: non-object JSON artifact -> exit 1 ────────────
+# PR 1 pass 6 P3 regression.
+printf "\n  ${DIM}Cell 9k: non-object JSON exits 1 (PR 1 pass 6)${NC}\n"
+PROJ="$TMP_ROOT/cell9k"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+ARR="$TMP_ROOT/cell9k-array.json"
+echo '[]' > "$ARR"
+assert_exit "array JSON exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$ARR'"
+STR="$TMP_ROOT/cell9k-string.json"
+echo '"hello"' > "$STR"
+assert_exit "string JSON exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$STR'"
+NUM="$TMP_ROOT/cell9k-num.json"
+echo '42' > "$NUM"
+assert_exit "number JSON exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$NUM'"
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -444,6 +444,33 @@ assert_exit "symlinked visual/manifests exits 4" 4 \
 MFST_COUNT=$(find "$TMP_ROOT/cell9f-outside" -maxdepth 1 -name "*.manifest.json" 2>/dev/null | wc -l | tr -d ' ')
 assert_true "no manifest written through symlinked subdir" sh -c "[ '$MFST_COUNT' = '0' ]"
 
+# ─── Cell 9g: symlinked output leaf rejected ───────────────
+# PR 1 pass 5 regression: an --out whose leaf component is a
+# pre-existing symlink to a directory must be rejected. Otherwise
+# atomic mv would move the temp file INTO the symlink target.
+printf "\n  ${DIM}Cell 9g: symlinked output leaf (PR 1 pass 5 regression)${NC}\n"
+PROJ="$TMP_ROOT/cell9g"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual/plan"
+mkdir -p "$TMP_ROOT/cell9g-outside"
+ln -s "$TMP_ROOT/cell9g-outside" "$NANOSTACK_STORE/visual/plan/explicit.html"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "symlinked output leaf exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out '$NANOSTACK_STORE/visual/plan/explicit.html'"
+LEAK_COUNT=$(find "$TMP_ROOT/cell9g-outside" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no file leaked through symlinked leaf" sh -c "[ '$LEAK_COUNT' = '0' ]"
+
+# A leaf that is already a directory must also be rejected so the
+# mv doesn't move the temp file INTO the directory.
+PROJ="$TMP_ROOT/cell9h"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual/plan/explicit.html"  # leaf is a directory
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "directory at output leaf exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --out '$NANOSTACK_STORE/visual/plan/explicit.html'"
+
 # ─── Cell 9: symlinked visual root rejected ─────────────────
 printf "\n  ${DIM}Cell 9: symlinked visual root rejected${NC}\n"
 PROJ="$TMP_ROOT/cell9"

--- a/reference/visual-artifact-contract.md
+++ b/reference/visual-artifact-contract.md
@@ -1,0 +1,161 @@
+# Visual Artifact Contract
+
+## Purpose
+
+`bin/render-artifact.sh` writes a static HTML view of a Nanostack JSON artifact. The HTML is a derived, local, inspectable view of the canonical artifact. JSON remains the source of truth; the renderer is strictly downstream.
+
+This contract is normative for PR 1 of the Visual Artifacts Architecture v1 round (2026-05-11). It documents what the renderer produces, where it writes, what it refuses, and how downstream consumers must treat the output.
+
+## Hard invariants
+
+1. **JSON is canonical.** No skill (`/review`, `/security`, `/qa`, `/ship`, `bin/resolve.sh`, conductor) reads HTML as source evidence. HTML can be deleted and regenerated without changing sprint state.
+2. **Deterministic.** Same source artifact + same renderer version produces semantically equivalent HTML and manifest. Only the manifest `created_at` field is allowed to vary.
+3. **Local.** Output paths live under `$NANOSTACK_STORE/visual/`. The renderer refuses `--out` paths that escape the visual root and refuses to follow a symlinked visual root.
+4. **Trust-aware.** Every render records source trust. `--strict` rejects `integrity_missing` and `integrity_mismatch`. Without `--strict`, `integrity_mismatch` still fails (exit 3); `integrity_missing` renders with a visible untrusted badge.
+5. **Escaped.** Every string read from JSON passes through `nano_html_escape` or `nano_attr_escape` before reaching HTML.
+6. **Offline.** No external scripts, fonts, CSS, images, telemetry, or analytics. CSP defaults to `default-src 'none'`. Static mode forbids inline script.
+7. **Interactive mode is copy-only.** Reserved for PR 4. PR 1 rejects `--interactive` with exit 2.
+
+A consumer that depends on any of these invariants can read the manifest (see below) to confirm the render produced today's contract.
+
+## CLI
+
+```
+bin/render-artifact.sh <phase> [artifact-path|--latest] [--strict] [--interactive] [--out <path>] [--manifest-only]
+```
+
+| Form | Behavior |
+|------|----------|
+| `<phase> --latest` | Resolve source via `bin/find-artifact.sh <phase> 30`. |
+| `<phase> <artifact-path>` | Render the explicit file. Phase mismatch fails with exit 1. |
+| `<phase>` with no artifact argument | Equivalent to `<phase> --latest`. |
+| `journal --today` | Reserved for PR 3. Exit 2 in PR 1. |
+| `stack <name>` | Reserved for PR 3. Exit 2 in PR 1. |
+
+| Flag | Behavior |
+|------|----------|
+| `--latest` | Resolve source with `find-artifact.sh`. |
+| `--strict` | Require `nano_artifact_trust == verified`. |
+| `--interactive` | Reserved for PR 4. Exit 2 in PR 1. |
+| `--out <path>` | Write HTML to explicit path. Path must be inside `$NANOSTACK_STORE/visual/`. |
+| `--manifest-only` | Write manifest only. Useful for CI trust checks. |
+
+| Exit | Meaning |
+|------|---------|
+| 0 | Render succeeded. Output path printed to stdout. |
+| 1 | Input error: missing artifact, invalid JSON, phase mismatch, unsupported phase. |
+| 2 | Feature intentionally unsupported in current PR. |
+| 3 | Trust failure (`integrity_mismatch` always; `integrity_missing` only under `--strict`). |
+| 4 | Unsafe output path or symlinked visual root. |
+
+## Store layout
+
+```
+$NANOSTACK_STORE/visual/
+  <phase>/                       core phase HTML (plan, think, review, security, qa, ship)
+  custom/<phase>/                custom phase HTML
+  journal/                       sprint journal HTML
+  manifests/                     companion manifest JSON for every render
+```
+
+Filename format:
+
+- HTML: `YYYYMMDD-HHMMSS-<phase>.html`
+- Core manifest: `YYYYMMDD-HHMMSS-<phase>.manifest.json`
+- Custom manifest: `YYYYMMDD-HHMMSS-custom-<phase>.manifest.json`
+
+## Manifest schema
+
+Every render writes a companion manifest. Schema version `1`:
+
+```json
+{
+  "schema_version": "1",
+  "kind": "phase",
+  "phase": "plan",
+  "custom_phase": false,
+  "format": "html",
+  "interactive": false,
+  "strict": true,
+  "source_artifacts": [
+    {
+      "phase": "plan",
+      "path": "/absolute/path/.nanostack/plan/20260511-180000.json",
+      "integrity": "sha256-hex",
+      "trust": "verified"
+    }
+  ],
+  "output_path": "/absolute/path/.nanostack/visual/plan/20260511-180100-plan.html",
+  "renderer": {
+    "name": "nanostack-html-renderer",
+    "version": "1"
+  },
+  "created_at": "2026-05-11T18:01:00Z"
+}
+```
+
+Validation rules:
+
+- `schema_version` equals `"1"`.
+- `format` equals `"html"`.
+- `kind` is one of `phase`, `journal`, `stack`.
+- `source_artifacts` length is at least 1; each entry has `phase`, `path`, `trust`.
+- `output_path` is absolute and under `$NANOSTACK_STORE/visual/`.
+- `renderer.version` is present.
+
+## HTML safety contract
+
+Every generated HTML document includes:
+
+- `<!doctype html>`.
+- `<meta charset="utf-8">`.
+- `<meta name="viewport" content="width=device-width, initial-scale=1">`.
+- A static-mode CSP: `default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'`.
+- A `<title>` of the form `Nanostack /<phase> visual artifact`.
+- A `<main>` element with `data-nanostack-visual="1"` and `data-phase="<phase>"`.
+- A trust badge element with `data-trust="<status>"`.
+- A provenance footer with `data-testid="visual-provenance"`, source artifact path (`data-testid="source-artifact-path"`), and manifest path (`data-testid="visual-manifest-path"`).
+
+Forbidden in any generated template or rendered output:
+
+- External URLs (`http://`, `https://`).
+- `<script src=...>`, `fetch(`, `XMLHttpRequest`, `navigator.sendBeacon`.
+- `localStorage`, `sessionStorage`, `document.cookie`.
+- `eval(`, `new Function(`.
+
+CI enforces the forbidden list against `bin/render-artifact.sh` and `bin/lib/visual-render.sh` via `ci/check-visual-artifact-templates.sh`.
+
+## Escape helpers
+
+`bin/lib/html-escape.sh` exposes:
+
+- `nano_html_escape` — escape text content. Replaces `& < > " '` with named/numeric entities. Preserves newlines.
+- `nano_attr_escape` — escape attribute content. Same character set, stricter.
+- `nano_json_string` — escape a string for safe inclusion in a JSON literal (used by the manifest writer).
+
+Every JSON-derived string MUST pass through one of these. Fixed template HTML (page shell, table headers, button labels) may be written directly.
+
+## Trust badge wording
+
+| Status | Badge text |
+|--------|-----------|
+| `verified` | `verified` |
+| `integrity_missing` | `unverified` |
+| `integrity_mismatch` | This status never reaches the badge: the render exits 3 before HTML is written. |
+| `not_found` | This status never reaches the badge: the render exits 1 before HTML is written. |
+
+The wording is locked. A renderer that prints other strings for these statuses fails `ci/check-visual-artifact-templates.sh`.
+
+## Relationship to existing primitives
+
+- Trust state comes from `bin/lib/artifact-trust.sh::nano_artifact_trust`. The renderer never reimplements integrity checks.
+- Source artifact resolution uses `bin/find-artifact.sh` for `--latest` and accepts an explicit path otherwise. The renderer parses the explicit path with `jq -e .` and verifies `.phase` matches the requested phase.
+- Schema validation uses `bin/lib/artifact-schemas.sh::nano_validate_artifact`. A source artifact that fails schema validation is rendered with a visible "schema invalid" notice rather than failing the render; the manifest still records the source trust.
+- Store path comes from `bin/lib/store-path.sh::NANOSTACK_STORE`.
+- No skill, conductor command, or guard hook reads the HTML output. The renderer is strictly downstream.
+
+## Determinism and atomicity
+
+- Writes go to `<path>.tmp.$$` and rename into place after the render and manifest both succeed.
+- Temporary files are removed on trap.
+- The renderer prints exactly one line to stdout on success: the absolute HTML output path. Errors go to stderr.


### PR DESCRIPTION
## Summary

PR 1 of the Visual Artifacts v1 round (architect spec, 2026-05-11). Introduces a local, static HTML renderer for Nanostack JSON artifacts. JSON remains canonical; the renderer is strictly downstream and writes only under `$NANOSTACK_STORE/visual/`. PR 1 wires the `/plan` renderer end to end; the other core phases are reserved for PR 2.

### What changed

- `reference/visual-artifact-contract.md` — normative contract: CLI shape, exit codes, store layout, manifest schema (`schema_version: "1"`), HTML safety rules, locked trust badge wording (`verified` / `unverified` / `tampered`).
- `bin/lib/html-escape.sh` — `nano_html_escape`, `nano_attr_escape`, `nano_json_string`. Every JSON-derived scalar passes through one of these before reaching HTML.
- `bin/lib/visual-render.sh` — shared page shell, CSP, output path safety, lexical path normalization, symlinked-descend rejection.
- `bin/render-artifact.sh` — argument parser, source resolution via `bin/find-artifact.sh --no-session-sync`, trust verification via `bin/lib/artifact-trust.sh`, schema validation via `bin/lib/artifact-schemas.sh`, manifest writer, `/plan` body renderer. Atomic write via `mktemp` + rename.
- `bin/find-artifact.sh` — adds `--no-session-sync` flag so a strictly read-only consumer can resolve `--latest` without mutating `session.json`.
- `ci/e2e-visual-artifacts.sh` — 86 checks across 21 cells.
- `ci/check-visual-artifact-templates.sh` — 20 static checks (forbidden patterns, required markers).
- `.github/workflows/lint.yml` — new `visual-artifact-contract` job.

### Contract invariants

1. JSON is canonical. No skill reads HTML as source evidence.
2. Output paths live under `$NANOSTACK_STORE/visual/`. Outside paths exit 4.
3. `integrity_mismatch` always fails (exit 3). `integrity_missing` fails under `--strict`; without `--strict` it renders with the `unverified` badge.
4. Every JSON-derived string passes through `nano_html_escape` or `nano_attr_escape`.
5. CSP `default-src 'none'`. No external URLs, no `fetch`, no `localStorage`, no `eval`.
6. `--interactive` reserved for PR 4 (exit 2). `journal` / `stack` reserved for PR 3 (exit 2). `think/review/security/qa/ship` reserved for PR 2 (exit 1).

### Path-safety hardening (codex passes 2 – 8)

| Pass | Finding | Fix |
|------|---------|-----|
| 2 | `..` after a missing segment escaped visual/ | Lexical normalization replaces realpath walk-up |
| 3 | Relative `NANOSTACK_STORE` produced relative manifest paths | `nano_resolve_abs` canonicalizes before manifest write |
| 4 | Symlinked subdirectory under visual/ accepted | `nano_visual_assert_safe_descend` rejects symlinked components |
| 5 | Symlinked or directory leaf at `--out` accepted | Leaf check at end of descend |
| 6 | Symlink + `..` collapsed lexically but kernel resolved at write | Reassign `HTML_PATH` / `MANIFEST_PATH` to normalized form |
| 6 | Same-second renders shared a manifest stem | PID suffix in timestamp |
| 6 | Non-object JSON (`[]`, string, number) crashed with jq exit 5 | `.phase?` suppresses path error so input-error branch returns exit 1 |
| 7 | `--latest` mutated `session.json` via `find-artifact.sh` | `--no-session-sync` flag on `find-artifact.sh` |
| 8 | Predictable temp filename (`$path.tmp.$$`) | `mktemp $path.tmp.XXXXXX` with O_EXCL |
| 8 | Glob expansion in path normalization | `set -f` around `set -- $raw` split |
| 9 | `--manifest-only` left HTML temp behind | Explicit `rm -f $TMP_HTML` before trap reset |

Final codex pass returned clean.

### Test counts

- 86 checks in `ci/e2e-visual-artifacts.sh` across 21 cells.
- 20 checks in `ci/check-visual-artifact-templates.sh`.
- Both wired into a new `visual-artifact-contract` job in `lint.yml`.

## Test plan
- [x] `ci/e2e-visual-artifacts.sh` 86/86
- [x] `ci/check-visual-artifact-templates.sh` 20/20
- [x] `ci/e2e-artifact-trust.sh` 29/29 (no regression on `bin/find-artifact.sh`)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` passes
- [x] Codex review pass 10 returned clean