### PR TITLE
visual-artifacts v1: PR 2 core phase renderers (think/review/security/qa/ship)

### DIFF
--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -358,6 +358,28 @@ nano_visual_page_start() {
     .kvgrid dt { color: var(--muted); }
     .kvgrid dd { margin: 0; }
     .schema-warning { background: rgba(250,204,21,0.1); border: 1px solid var(--warn); color: var(--warn); padding: 12px; border-radius: 6px; margin-bottom: 16px; }
+    .counters { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; }
+    .counter { background: var(--panel-2); border: 1px solid var(--line); border-radius: 6px; padding: 12px; text-align: center; }
+    .counter .num { font-size: 1.8rem; font-weight: 700; display: block; }
+    .counter .label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.03em; }
+    .counter[data-tone="bad"] .num { color: var(--bad); }
+    .counter[data-tone="warn"] .num { color: var(--warn); }
+    .counter[data-tone="ok"] .num { color: var(--ok); }
+    .counter[data-tone="info"] .num { color: var(--info); }
+    .finding { border-left: 4px solid var(--info); background: var(--panel-2); border-radius: 0 6px 6px 0; padding: 10px 12px; margin-bottom: 10px; }
+    .finding.sev-bad { border-left-color: var(--bad); }
+    .finding.sev-warn { border-left-color: var(--warn); }
+    .finding.sev-info { border-left-color: var(--info); }
+    .finding.sev-ok { border-left-color: var(--ok); }
+    .finding .meta { font-size: 0.8rem; color: var(--muted); margin-bottom: 4px; }
+    .finding .meta .id { font-family: "SFMono-Regular", Consolas, monospace; }
+    .chip { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.75rem; background: var(--panel); border: 1px solid var(--line); margin-right: 4px; }
+    .chip.sev-bad { color: var(--bad); border-color: var(--bad); }
+    .chip.sev-warn { color: var(--warn); border-color: var(--warn); }
+    .chip.sev-info { color: var(--info); border-color: var(--info); }
+    .chip.sev-ok { color: var(--ok); border-color: var(--ok); }
+    .pr-link { color: var(--info); }
+    .unsafe-url { color: var(--bad); font-family: monospace; }
   </style>
 </head>
 <body>
@@ -368,6 +390,98 @@ nano_visual_page_start() {
       <p class="trust-badge" data-trust="$trust_esc">$(printf '%s' "$badge_text" | nano_html_escape)</p>
     </header>
 HTML
+}
+
+# Generic JSON normalizer for phase body renderers. Coerces every
+# field referenced by the core renderers to a sane type so a legacy
+# or malformed artifact (e.g. .summary as a string from
+# --from-session) does not crash jq under set -e. Reads from the
+# given artifact path; echoes the normalized JSON as a single line.
+#
+# Coercions:
+#   .summary, .context_checkpoint, .scope_drift, .summary.search_summary,
+#   .summary.manual_delivery_test, .summary.example_reference,
+#   .summary.archetype_*, .conflicts -> object/array as appropriate
+#   .findings, .context_checkpoint.{key_files,decisions_made,open_questions},
+#   .summary.{planned_files,risks,out_of_scope,steps,conflicts}        -> arrays
+nano_visual_normalize_artifact() {
+  local path="$1"
+  jq -c '
+    . as $orig
+    | (if (.summary | type)            == "object" then .summary            else {} end) as $s
+    | (if (.context_checkpoint | type) == "object" then .context_checkpoint else {} end) as $c
+    | (if (.scope_drift | type)        == "object" then .scope_drift        else {} end) as $sd
+    | (if (.findings | type)           == "array"  then .findings           else [] end) as $f
+    | (if (.conflicts | type)          == "array"  then .conflicts          else [] end) as $cf
+    | $orig
+    | .summary           = $s
+    | .context_checkpoint = $c
+    | .scope_drift       = $sd
+    | .findings          = $f
+    | .conflicts         = $cf
+    | .summary.planned_files = (if (.summary.planned_files | type) == "array" then .summary.planned_files else [] end)
+    | .summary.risks         = (if (.summary.risks         | type) == "array" then .summary.risks         else [] end)
+    | .summary.out_of_scope  = (if (.summary.out_of_scope  | type) == "array" then .summary.out_of_scope  else [] end)
+    | .context_checkpoint.key_files      = (if (.context_checkpoint.key_files      | type) == "array" then .context_checkpoint.key_files      else [] end)
+    | .context_checkpoint.decisions_made = (if (.context_checkpoint.decisions_made | type) == "array" then .context_checkpoint.decisions_made else [] end)
+    | .context_checkpoint.open_questions = (if (.context_checkpoint.open_questions | type) == "array" then .context_checkpoint.open_questions else [] end)
+    | .scope_drift.planned_files     = (if (.scope_drift.planned_files     | type) == "array" then .scope_drift.planned_files     else [] end)
+    | .scope_drift.actual_files      = (if (.scope_drift.actual_files      | type) == "array" then .scope_drift.actual_files      else [] end)
+    | .scope_drift.out_of_scope_files = (if (.scope_drift.out_of_scope_files | type) == "array" then .scope_drift.out_of_scope_files else [] end)
+    | .scope_drift.missing_files     = (if (.scope_drift.missing_files     | type) == "array" then .scope_drift.missing_files     else [] end)
+  ' "$path"
+}
+
+# Severity -> CSS class for finding cards. Stays in the shared shell
+# so review/security/qa all agree on the color and styling.
+nano_visual_severity_class() {
+  case "${1:-}" in
+    critical|blocking) printf 'sev-bad\n' ;;
+    high|should_fix)   printf 'sev-warn\n' ;;
+    medium|nitpick)    printf 'sev-info\n' ;;
+    low|positive)      printf 'sev-ok\n' ;;
+    *)                 printf 'sev-info\n' ;;
+  esac
+}
+
+# Decide whether a /ship PR URL is safe to render as a link. Only
+# explicit GitHub URLs over https are treated as link targets; every
+# other URL renders as escaped text so a malicious PR URL cannot be
+# used to redirect the human reader. CSP would block navigation on
+# many surfaces, but the policy is to keep the visual surface
+# defensive in depth.
+nano_visual_safe_pr_url() {
+  local url="${1:-}"
+  # url-allowlist: literal patterns live in a code-level case to
+  # validate inbound PR URLs. They are not template output, so the
+  # template safety lint excludes lines with the url-allowlist
+  # marker.
+  case "$url" in
+    https://github.com/*) printf 'safe\n' ;;  # url-allowlist
+    *)                    printf 'unsafe\n' ;;
+  esac
+}
+
+# Decide whether a screenshot path is safe to render as an <img>.
+# Allowed: absolute paths under the project or the NANOSTACK_STORE,
+# and relative paths starting with a known prefix (no ".." segments).
+# Returns "safe" or "unsafe". Used by render_qa_body so a malicious
+# screenshot URL never reaches the page as an <img src>.
+nano_visual_safe_screenshot_path() {
+  local p="${1:-}" project="${2:-$PWD}"
+  case "$p" in
+    "")                printf 'unsafe\n'; return ;;
+    *..*|*"\\"*)       printf 'unsafe\n'; return ;;
+    http://*|https://*|//*|data:*|javascript:*|file://*|*\<*|*\>*|*\"*)
+                       printf 'unsafe\n'; return ;;
+  esac
+  case "$p" in
+    "$project"/*|"$NANOSTACK_STORE"/*) printf 'safe\n'; return ;;
+    /*)                                printf 'unsafe\n'; return ;;
+  esac
+  # Relative paths: accept only when they stay within the project.
+  # Reject any path that resolves above the project root.
+  printf 'safe\n'
 }
 
 # Closes the page with provenance pointing back to the source artifact

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -30,10 +30,9 @@ Usage: render-artifact.sh <phase> [artifact-path|--latest] [--strict]
                                   [--interactive] [--out <path>]
                                   [--manifest-only]
 
-PR 1 scope:
-  phase = plan               render the latest or explicit /plan artifact
-  phase = think|review|security|qa|ship
-                             reserved for PR 2 (exit 1)
+PR 1+2 scope:
+  phase = plan|think|review|security|qa|ship
+                             render the latest or explicit artifact
   phase = journal            reserved for PR 3 (exit 2)
   phase = stack              reserved for PR 3 (exit 2)
 
@@ -113,14 +112,10 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# Validate phase. Core phases supported by PR 1: plan. The rest of the
-# core phases will be wired in PR 2; report a clear message.
+# Validate phase. Core phases supported by PR 1+2: plan/think/review/
+# security/qa/ship.
 case "$PHASE" in
-  plan) ;;
-  think|review|security|qa|ship)
-    echo "render-artifact: phase '$PHASE' is reserved for PR 2 (core phase renderers)" >&2
-    exit 1
-    ;;
+  plan|think|review|security|qa|ship) ;;
   *)
     echo "render-artifact: unsupported phase: $PHASE" >&2
     exit 1
@@ -395,6 +390,377 @@ HTML
   printf '    </section>\n'
 }
 
+render_think_body() {
+  local artifact="$1"
+  local norm
+  norm=$(nano_visual_normalize_artifact "$artifact")
+
+  local vp tu wedge risk scope_mode premise archetype arch_conf
+  vp=$(printf '%s' "$norm" | jq -r '.summary.value_proposition // "Not recorded"' | nano_html_escape)
+  tu=$(printf '%s' "$norm" | jq -r '.summary.target_user // "Not recorded"' | nano_html_escape)
+  wedge=$(printf '%s' "$norm" | jq -r '.summary.narrowest_wedge // "Not recorded"' | nano_html_escape)
+  risk=$(printf '%s' "$norm" | jq -r '.summary.key_risk // "Not recorded"' | nano_html_escape)
+  scope_mode=$(printf '%s' "$norm" | jq -r '.summary.scope_mode // "Not recorded"' | nano_html_escape)
+  premise=$(printf '%s' "$norm" | jq -r '.summary.premise_validated // false' | nano_html_escape)
+  archetype=$(printf '%s' "$norm" | jq -r '.summary.archetype // "Not recorded"' | nano_html_escape)
+  arch_conf=$(printf '%s' "$norm" | jq -r '.summary.archetype_confidence // "Not recorded"' | nano_html_escape)
+
+  cat <<HTML
+    <section class="card">
+      <h2>Decision brief</h2>
+      <dl class="kvgrid">
+        <dt>Value proposition</dt><dd>$vp</dd>
+        <dt>Target user</dt><dd>$tu</dd>
+        <dt>Narrowest wedge</dt><dd>$wedge</dd>
+        <dt>Key risk</dt><dd>$risk</dd>
+        <dt>Scope mode</dt><dd><span class="chip">$scope_mode</span></dd>
+        <dt>Premise validated</dt><dd>$premise</dd>
+      </dl>
+    </section>
+    <section class="card">
+      <h2>Archetype</h2>
+      <dl class="kvgrid">
+        <dt>Archetype</dt><dd><span class="chip">$archetype</span></dd>
+        <dt>Confidence</dt><dd>$arch_conf</dd>
+      </dl>
+HTML
+  # Example reference (only when present).
+  local ex_name ex_path ex_why
+  ex_name=$(printf '%s' "$norm" | jq -r '.summary.example_reference.name // ""' | nano_html_escape)
+  if [ -n "$ex_name" ] && [ "$ex_name" != "null" ]; then
+    ex_path=$(printf '%s' "$norm" | jq -r '.summary.example_reference.path // ""' | nano_html_escape)
+    ex_why=$(printf '%s' "$norm" | jq -r '.summary.example_reference.why_relevant // ""' | nano_html_escape)
+    cat <<HTML
+      <h3>Example reference</h3>
+      <p><code>$ex_name</code> — <code>$ex_path</code></p>
+      <p class="muted">$ex_why</p>
+HTML
+  fi
+  printf '    </section>\n'
+
+  # Out of scope
+  local oos_count
+  oos_count=$(printf '%s' "$norm" | jq -r '.summary.out_of_scope | length')
+  printf '    <section class="card">\n      <h2>Out of scope (%s)</h2>\n' \
+    "$(printf '%s' "$oos_count" | nano_html_escape)"
+  if [ "$oos_count" = "0" ]; then
+    printf '      <p class="muted">None recorded</p>\n'
+  else
+    printf '      <ul>\n'
+    printf '%s' "$norm" | jq -r '.summary.out_of_scope | .[] | tostring' | while IFS= read -r item; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$item" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+
+  render_context_checkpoint "$norm"
+}
+
+render_review_body() {
+  local artifact="$1"
+  local norm
+  norm=$(nano_visual_normalize_artifact "$artifact")
+
+  # Counts
+  local blocking should_fix nitpicks positive
+  blocking=$(printf '%s' "$norm" | jq -r '.summary.blocking // 0')
+  should_fix=$(printf '%s' "$norm" | jq -r '.summary.should_fix // 0')
+  nitpicks=$(printf '%s' "$norm" | jq -r '.summary.nitpicks // 0')
+  positive=$(printf '%s' "$norm" | jq -r '.summary.positive // 0')
+
+  cat <<HTML
+    <section class="card">
+      <h2>Review summary</h2>
+      <div class="counters">
+        <div class="counter" data-tone="bad"><span class="num">$(printf '%s' "$blocking" | nano_html_escape)</span><span class="label">Blocking</span></div>
+        <div class="counter" data-tone="warn"><span class="num">$(printf '%s' "$should_fix" | nano_html_escape)</span><span class="label">Should fix</span></div>
+        <div class="counter" data-tone="info"><span class="num">$(printf '%s' "$nitpicks" | nano_html_escape)</span><span class="label">Nitpicks</span></div>
+        <div class="counter" data-tone="ok"><span class="num">$(printf '%s' "$positive" | nano_html_escape)</span><span class="label">Positive</span></div>
+      </div>
+    </section>
+HTML
+
+  # Scope drift
+  local drift_status drift_count_oos drift_count_missing
+  drift_status=$(printf '%s' "$norm" | jq -r '.scope_drift.status // "Not recorded"' | nano_html_escape)
+  drift_count_oos=$(printf '%s' "$norm" | jq -r '.scope_drift.out_of_scope_files | length')
+  drift_count_missing=$(printf '%s' "$norm" | jq -r '.scope_drift.missing_files | length')
+  printf '    <section class="card">\n      <h2>Scope drift</h2>\n      <p>Status: <span class="chip">%s</span></p>\n' "$drift_status"
+  if [ "$drift_count_oos" != "0" ]; then
+    printf '      <h3>Out-of-scope files (%s)</h3>\n      <ul>\n' "$(printf '%s' "$drift_count_oos" | nano_html_escape)"
+    printf '%s' "$norm" | jq -r '.scope_drift.out_of_scope_files | .[] | tostring' | while IFS= read -r f; do
+      printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$f" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  if [ "$drift_count_missing" != "0" ]; then
+    printf '      <h3>Missing files (%s)</h3>\n      <ul>\n' "$(printf '%s' "$drift_count_missing" | nano_html_escape)"
+    printf '%s' "$norm" | jq -r '.scope_drift.missing_files | .[] | tostring' | while IFS= read -r f; do
+      printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$f" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+
+  # Findings
+  render_findings_section "$norm" "Review findings"
+
+  render_context_checkpoint "$norm"
+}
+
+render_security_body() {
+  local artifact="$1"
+  local norm
+  norm=$(nano_visual_normalize_artifact "$artifact")
+
+  local critical high medium low total
+  critical=$(printf '%s' "$norm" | jq -r '.summary.critical // 0')
+  high=$(printf '%s' "$norm" | jq -r '.summary.high // 0')
+  medium=$(printf '%s' "$norm" | jq -r '.summary.medium // 0')
+  low=$(printf '%s' "$norm" | jq -r '.summary.low // 0')
+  total=$(printf '%s' "$norm" | jq -r '.summary.total_findings // 0')
+
+  cat <<HTML
+    <section class="card">
+      <h2>Security summary</h2>
+      <div class="counters">
+        <div class="counter" data-tone="bad"><span class="num">$(printf '%s' "$critical" | nano_html_escape)</span><span class="label">Critical</span></div>
+        <div class="counter" data-tone="warn"><span class="num">$(printf '%s' "$high" | nano_html_escape)</span><span class="label">High</span></div>
+        <div class="counter" data-tone="info"><span class="num">$(printf '%s' "$medium" | nano_html_escape)</span><span class="label">Medium</span></div>
+        <div class="counter" data-tone="ok"><span class="num">$(printf '%s' "$low" | nano_html_escape)</span><span class="label">Low</span></div>
+        <div class="counter"><span class="num">$(printf '%s' "$total" | nano_html_escape)</span><span class="label">Total</span></div>
+      </div>
+    </section>
+HTML
+
+  render_findings_section "$norm" "Security findings"
+
+  render_context_checkpoint "$norm"
+}
+
+render_qa_body() {
+  local artifact="$1"
+  local norm
+  norm=$(nano_visual_normalize_artifact "$artifact")
+
+  local mode status tests_run tests_passed tests_failed bugs_found bugs_fixed wtf
+  mode=$(printf '%s' "$norm" | jq -r '.summary.mode // "Not recorded"' | nano_html_escape)
+  status=$(printf '%s' "$norm" | jq -r '.summary.status // "Not recorded"' | nano_html_escape)
+  tests_run=$(printf '%s' "$norm" | jq -r '.summary.tests_run // 0')
+  tests_passed=$(printf '%s' "$norm" | jq -r '.summary.tests_passed // 0')
+  tests_failed=$(printf '%s' "$norm" | jq -r '.summary.tests_failed // 0')
+  bugs_found=$(printf '%s' "$norm" | jq -r '.summary.bugs_found // 0')
+  bugs_fixed=$(printf '%s' "$norm" | jq -r '.summary.bugs_fixed // 0')
+  wtf=$(printf '%s' "$norm" | jq -r '.summary.wtf_likelihood // "Not recorded"' | nano_html_escape)
+
+  cat <<HTML
+    <section class="card">
+      <h2>QA summary</h2>
+      <dl class="kvgrid">
+        <dt>Mode</dt><dd><span class="chip">$mode</span></dd>
+        <dt>Status</dt><dd><span class="chip">$status</span></dd>
+        <dt>WTF likelihood</dt><dd>$wtf</dd>
+      </dl>
+      <div class="counters">
+        <div class="counter"><span class="num">$(printf '%s' "$tests_run" | nano_html_escape)</span><span class="label">Tests run</span></div>
+        <div class="counter" data-tone="ok"><span class="num">$(printf '%s' "$tests_passed" | nano_html_escape)</span><span class="label">Passed</span></div>
+        <div class="counter" data-tone="bad"><span class="num">$(printf '%s' "$tests_failed" | nano_html_escape)</span><span class="label">Failed</span></div>
+        <div class="counter" data-tone="warn"><span class="num">$(printf '%s' "$bugs_found" | nano_html_escape)</span><span class="label">Bugs found</span></div>
+        <div class="counter" data-tone="ok"><span class="num">$(printf '%s' "$bugs_fixed" | nano_html_escape)</span><span class="label">Bugs fixed</span></div>
+      </div>
+    </section>
+HTML
+
+  render_findings_section "$norm" "QA findings"
+
+  render_context_checkpoint "$norm"
+}
+
+render_ship_body() {
+  local artifact="$1"
+
+  # /ship has two modes: normal (object summary with pr_* fields) and
+  # report_only (summary may be a string). Detect run_mode early.
+  local run_mode
+  run_mode=$(jq -r '.run_mode // (.summary.run_mode? // "normal")' "$artifact")
+
+  if [ "$run_mode" = "report_only" ]; then
+    # Report-only render: short, no release-packet styling.
+    local rep
+    rep=$(jq -r '
+      if (.summary | type) == "string" then .summary
+      else (.summary | tostring) end
+    ' "$artifact" | nano_html_escape)
+    cat <<HTML
+    <section class="card">
+      <h2>Ship report (run_mode = report_only)</h2>
+      <p class="muted">This is a report of what would have shipped. No PR was created.</p>
+      <pre>$rep</pre>
+    </section>
+HTML
+    return 0
+  fi
+
+  # Normal ship artifact.
+  local norm
+  norm=$(nano_visual_normalize_artifact "$artifact")
+
+  local pr_num pr_url title status ci_passed pr_url_raw url_safety
+  pr_num=$(printf '%s' "$norm" | jq -r '.summary.pr_number // "Not recorded"' | nano_html_escape)
+  pr_url_raw=$(printf '%s' "$norm" | jq -r '.summary.pr_url // ""')
+  title=$(printf '%s' "$norm" | jq -r '.summary.title // "Not recorded"' | nano_html_escape)
+  status=$(printf '%s' "$norm" | jq -r '.summary.status // "Not recorded"' | nano_html_escape)
+  ci_passed=$(printf '%s' "$norm" | jq -r '.summary.ci_passed // false')
+
+  url_safety=$(nano_visual_safe_pr_url "$pr_url_raw")
+
+  cat <<HTML
+    <section class="card">
+      <h2>Release packet</h2>
+      <dl class="kvgrid">
+        <dt>Title</dt><dd>$title</dd>
+        <dt>PR number</dt><dd>$pr_num</dd>
+        <dt>PR URL</dt><dd>
+HTML
+  if [ "$url_safety" = "safe" ] && [ -n "$pr_url_raw" ]; then
+    # Already validated as https://github.com/<owner>/<repo>... but
+    # still escape both href and visible text. CSP allows form-action
+    # 'none' and base-uri 'none', so the link cannot break out of the
+    # local origin even if a parser quirk slipped through.
+    local href_esc text_esc
+    href_esc=$(printf '%s' "$pr_url_raw" | nano_attr_escape)
+    text_esc=$(printf '%s' "$pr_url_raw" | nano_html_escape)
+    printf '          <a class="pr-link" href="%s" rel="noopener noreferrer">%s</a>\n' "$href_esc" "$text_esc"
+  elif [ -n "$pr_url_raw" ]; then
+    # Unsafe URL: render as escaped text only, do NOT make it a link.
+    printf '          <span class="unsafe-url" data-testid="unsafe-pr-url">%s</span>\n' \
+      "$(printf '%s' "$pr_url_raw" | nano_html_escape)"
+    printf '          <p class="muted">URL host not in the allowlist; rendered as text.</p>\n'
+  else
+    printf '          <span class="muted">Not recorded</span>\n'
+  fi
+  cat <<HTML
+        </dd>
+        <dt>Status</dt><dd><span class="chip">$status</span></dd>
+        <dt>CI passed</dt><dd>$ci_passed</dd>
+      </dl>
+    </section>
+HTML
+
+  render_context_checkpoint "$norm"
+}
+
+# Shared helper for review/security/qa findings rendering. Reads
+# .findings from the normalized JSON, escapes every scalar, groups by
+# severity using nano_visual_severity_class. proof_of_concept (when
+# present) renders inside <pre> so multi-line content stays readable
+# without breaking the safety contract.
+render_findings_section() {
+  local norm="$1" title="$2"
+  local count
+  count=$(printf '%s' "$norm" | jq -r '.findings | length')
+  printf '    <section class="card">\n      <h2>%s (%s)</h2>\n' \
+    "$(printf '%s' "$title" | nano_html_escape)" \
+    "$(printf '%s' "$count" | nano_html_escape)"
+  if [ "$count" = "0" ]; then
+    printf '      <p class="muted">None recorded</p>\n'
+    printf '    </section>\n'
+    return 0
+  fi
+  # Iterate findings with a single jq pass that emits NUL-delimited
+  # records to keep multi-line description fields intact.
+  printf '%s' "$norm" | jq -c '.findings[]' | while IFS= read -r f; do
+    local fid sev cat desc file line poc fix conf reproduce root_cause fixed
+    fid=$(printf '%s' "$f" | jq -r '.id // ""' | nano_html_escape)
+    sev=$(printf '%s' "$f" | jq -r '.severity // "info"' | nano_html_escape)
+    cat=$(printf '%s' "$f" | jq -r '.category // ""' | nano_html_escape)
+    desc=$(printf '%s' "$f" | jq -r '.description // "(no description)"' | nano_html_escape)
+    file=$(printf '%s' "$f" | jq -r '.file // ""' | nano_html_escape)
+    line=$(printf '%s' "$f" | jq -r '.line // ""' | nano_html_escape)
+    poc=$(printf '%s' "$f" | jq -r '.proof_of_concept // ""' | nano_html_escape)
+    fix=$(printf '%s' "$f" | jq -r '.fix // ""' | nano_html_escape)
+    conf=$(printf '%s' "$f" | jq -r '.confidence // ""' | nano_html_escape)
+    reproduce=$(printf '%s' "$f" | jq -r '.reproduce // ""' | nano_html_escape)
+    root_cause=$(printf '%s' "$f" | jq -r '.root_cause // ""' | nano_html_escape)
+    fixed=$(printf '%s' "$f" | jq -r '.fixed // ""' | nano_html_escape)
+
+    local sev_class
+    sev_class=$(nano_visual_severity_class "$(printf '%s' "$f" | jq -r '.severity // "info"')")
+
+    printf '      <div class="finding %s" data-severity="%s">\n' "$sev_class" "$sev"
+    printf '        <div class="meta">'
+    [ -n "$fid" ] && printf '<span class="id">%s</span> · ' "$fid"
+    printf '<span class="chip %s">%s</span>' "$sev_class" "$sev"
+    [ -n "$cat" ] && printf ' · <span class="chip">%s</span>' "$cat"
+    if [ -n "$file" ]; then
+      if [ -n "$line" ]; then
+        printf ' · <code>%s:%s</code>' "$file" "$line"
+      else
+        printf ' · <code>%s</code>' "$file"
+      fi
+    fi
+    [ -n "$conf" ] && printf ' · confidence %s' "$conf"
+    printf '</div>\n'
+    printf '        <p>%s</p>\n' "$desc"
+    if [ -n "$poc" ]; then
+      printf '        <details><summary>Proof of concept</summary><pre>%s</pre></details>\n' "$poc"
+    fi
+    if [ -n "$fix" ]; then
+      printf '        <p><strong>Fix:</strong> %s</p>\n' "$fix"
+    fi
+    if [ -n "$reproduce" ]; then
+      printf '        <details><summary>Reproduce</summary><pre>%s</pre></details>\n' "$reproduce"
+    fi
+    if [ -n "$root_cause" ]; then
+      printf '        <p><strong>Root cause:</strong> %s</p>\n' "$root_cause"
+    fi
+    [ -n "$fixed" ] && [ "$fixed" != "false" ] && \
+      printf '        <p class="muted">Fixed: %s</p>\n' "$fixed"
+    printf '      </div>\n'
+  done
+  printf '    </section>\n'
+}
+
+# Shared helper for the context checkpoint card. Every core phase has
+# the same checkpoint shape; centralizing keeps the visual identity
+# consistent.
+render_context_checkpoint() {
+  local norm="$1"
+  local ck_summary
+  ck_summary=$(printf '%s' "$norm" | jq -r '.context_checkpoint.summary // "Not recorded"' | nano_html_escape)
+  printf '    <section class="card">\n      <h2>Context checkpoint</h2>\n'
+  printf '      <p>%s</p>\n' "$ck_summary"
+  local kf_count
+  kf_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.key_files | length')
+  if [ "$kf_count" != "0" ]; then
+    printf '      <h3>Key files</h3>\n      <ul>\n'
+    printf '%s' "$norm" | jq -r '.context_checkpoint.key_files | .[] | tostring' | while IFS= read -r kf; do
+      printf '        <li><code>%s</code></li>\n' "$(printf '%s' "$kf" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  local dec_count
+  dec_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.decisions_made | length')
+  if [ "$dec_count" != "0" ]; then
+    printf '      <h3>Decisions made</h3>\n      <ul>\n'
+    printf '%s' "$norm" | jq -r '.context_checkpoint.decisions_made | .[] | tostring' | while IFS= read -r d; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$d" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  local oq_count
+  oq_count=$(printf '%s' "$norm" | jq -r '.context_checkpoint.open_questions | length')
+  if [ "$oq_count" != "0" ]; then
+    printf '      <h3>Open questions</h3>\n      <ul>\n'
+    printf '%s' "$norm" | jq -r '.context_checkpoint.open_questions | .[] | tostring' | while IFS= read -r q; do
+      printf '        <li>%s</li>\n' "$(printf '%s' "$q" | nano_html_escape)"
+    done
+    printf '      </ul>\n'
+  fi
+  printf '    </section>\n'
+}
+
 # ─── Atomic write ───────────────────────────────────────────
 # Codex PR 1 pass 8: a predictable temp name (HTML_PATH.tmp.$$) lets
 # an attacker pre-create a symlink at that path; the redirect would
@@ -483,7 +849,12 @@ fi
   fi
 
   case "$PHASE" in
-    plan)   render_plan_body "$ART_PATH" ;;
+    plan)     render_plan_body "$ART_PATH" ;;
+    think)    render_think_body "$ART_PATH" ;;
+    review)   render_review_body "$ART_PATH" ;;
+    security) render_security_body "$ART_PATH" ;;
+    qa)       render_qa_body "$ART_PATH" ;;
+    ship)     render_ship_body "$ART_PATH" ;;
   esac
 
   nano_visual_page_end "$ART_PATH" "$MANIFEST_PATH" "$SRC_INTEGRITY"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -611,7 +611,11 @@ HTML
   pr_url_raw=$(printf '%s' "$norm" | jq -r '.summary.pr_url // ""')
   title=$(printf '%s' "$norm" | jq -r '.summary.title // "Not recorded"' | nano_html_escape)
   status=$(printf '%s' "$norm" | jq -r '.summary.status // "Not recorded"' | nano_html_escape)
-  ci_passed=$(printf '%s' "$norm" | jq -r '.summary.ci_passed // false')
+  # Escape ci_passed even though the schema documents it as a
+  # boolean. /ship's validator only requires summary to be an object,
+  # so a malformed artifact with ci_passed as a string would inject
+  # raw HTML otherwise. Codex PR 2 pass 1 caught the gap.
+  ci_passed=$(printf '%s' "$norm" | jq -r '.summary.ci_passed // false' | nano_html_escape)
 
   url_safety=$(nano_visual_safe_pr_url "$pr_url_raw")
 

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -63,9 +63,34 @@ check_present() {
 
 printf "\n${GREEN}=== Visual artifact template safety ===${NC}\n\n"
 
-# 1. No external URLs in renderer source. Comments are allowed for
-# contract refs but the contract doc has no URLs either.
-check_absent "no http(s) URLs in renderer/templates" \
+# 1. No external URLs in template emission lines. We allow URLs to
+# appear inside the source as case-pattern allowlists (PR 2 added
+# nano_visual_safe_pr_url to validate ship pr_url strings), but they
+# must never appear as literal HTML emitted by the renderer. The
+# grep filter excludes lines that are case patterns, comments, or
+# expansion sentinels for the URL allowlist itself.
+check_absent_no_allowlist() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  local files=("$@")
+  local hits
+  hits=$(grep -nE "$pattern" "${files[@]}" 2>/dev/null \
+    | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' \
+    | grep -vE '# url-allowlist' \
+    | grep -vE 'http://\*\|https://\*' \
+    || true)
+  if [ -n "$hits" ]; then
+    FAIL=$((FAIL+1))
+    printf "  ${RED}FAIL${NC}  %s\n" "$name"
+    printf "         ${DIM}pattern: %s${NC}\n" "$pattern"
+    printf '%s\n' "$hits" | sed 's/^/         /'
+  else
+    PASS=$((PASS+1))
+    printf "  ${GREEN}OK${NC}    %s\n" "$name"
+  fi
+}
+check_absent_no_allowlist "no http(s) URLs in renderer/templates (allowlist excepted)" \
   'https?://' "${FILES[@]}"
 
 # 2. No script-loading or XHR-style APIs.
@@ -123,6 +148,24 @@ check_present "renderer sources visual-render" \
   'source.*lib/visual-render.sh' "bin/render-artifact.sh"
 check_present "renderer sources artifact-trust" \
   'source.*lib/artifact-trust.sh' "bin/render-artifact.sh"
+
+# 9. PR 2: ship renderer must escape PR URLs and use the allowlist.
+check_present "ship renderer calls nano_visual_safe_pr_url" \
+  'nano_visual_safe_pr_url' "bin/render-artifact.sh"
+check_present "ship renderer wraps URL with rel='noopener noreferrer'" \
+  'noopener noreferrer' "bin/render-artifact.sh"
+
+# 10. PR 2: severity classes must come from the shared helper, not be
+# inlined. Lets PR 3 / 4 keep them consistent.
+check_present "renderer uses nano_visual_severity_class" \
+  'nano_visual_severity_class' "bin/render-artifact.sh"
+
+# 11. PR 2: shared CSS must include severity finding styles so every
+# core phase shares the visual identity.
+check_present "shared CSS defines .finding.sev-bad" \
+  '\.finding\.sev-bad' "bin/lib/visual-render.sh"
+check_present "shared CSS defines .counter" \
+  '\.counter' "bin/lib/visual-render.sh"
 
 TOTAL=$((PASS+FAIL))
 printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -637,6 +637,18 @@ assert_not_contains "security fix no raw <img" "$HTML" '<img src=x onerror=alert
 assert_contains "security PoC escaped" "$HTML" '&lt;script&gt;'
 assert_contains "security PoC stays in <pre>" "$HTML" '<details><summary>Proof of concept</summary><pre>'
 
+# Malicious ship.ci_passed (PR 2 pass 1 regression: ci_passed was
+# interpolated unescaped because the schema documents it as a
+# boolean; a malformed artifact stored it as a string).
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" ship '{
+  "phase":"ship",
+  "summary":{"pr_number":1,"pr_url":"https://github.com/x/y/pull/1","title":"t","status":"created","ci_passed":"<script>alert(\"ci\")</script>"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" ship --latest)
+assert_not_contains "ship ci_passed no raw script" "$HTML" '<script>alert("ci")</script>'
+assert_contains "ship ci_passed escaped" "$HTML" '&lt;script&gt;alert(&quot;ci&quot;)&lt;/script&gt;'
+
 # Malicious qa (reproduce + root_cause)
 (cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" qa '{
   "phase":"qa","summary":{"mode":"browser","status":"fail","tests_run":1,"tests_passed":0,"tests_failed":1,"bugs_found":1,"bugs_fixed":0},

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -128,6 +128,171 @@ save_valid_plan() {
   }' >/dev/null
 }
 
+save_valid_think() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" think '{
+    "phase": "think",
+    "summary": {
+      "value_proposition": "Make Nanostack renders inspectable",
+      "scope_mode": "selective_expand",
+      "target_user": "Devs reviewing AI work",
+      "narrowest_wedge": "Static /plan HTML view",
+      "key_risk": "XSS via unescaped artifact text",
+      "premise_validated": true,
+      "out_of_scope": ["Interactive editing"],
+      "archetype": "cli_tooling",
+      "archetype_confidence": "high"
+    },
+    "context_checkpoint": {
+      "summary": "Decision brief signed off",
+      "key_files": [],
+      "decisions_made": ["JSON canonical, HTML derived"],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_valid_review() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" review '{
+    "phase": "review",
+    "summary": {"blocking": 1, "should_fix": 2, "nitpicks": 3, "positive": 1},
+    "scope_drift": {
+      "status": "drift_detected",
+      "planned_files": ["a.ts","b.ts"],
+      "actual_files": ["a.ts","b.ts","c.ts"],
+      "out_of_scope_files": ["c.ts"],
+      "missing_files": []
+    },
+    "findings": [
+      {"id": "REV-001", "severity": "blocking", "description": "Unbounded loop", "file": "src/loop.ts", "line": 42},
+      {"id": "REV-002", "severity": "should_fix", "description": "Missing error handling", "file": "src/api.ts", "line": 10},
+      {"id": "REV-003", "severity": "nitpick", "description": "Inconsistent naming", "file": "src/utils.ts", "line": 5}
+    ],
+    "context_checkpoint": {
+      "summary": "One blocker, two should-fixes",
+      "key_files": ["src/loop.ts:42"],
+      "decisions_made": [],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_valid_security() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" security '{
+    "phase": "security",
+    "summary": {"critical": 1, "high": 1, "medium": 0, "low": 0, "total_findings": 2},
+    "findings": [
+      {
+        "id": "SEC-001",
+        "severity": "critical",
+        "category": "A03",
+        "description": "SQL injection in login",
+        "file": "src/auth.ts",
+        "line": 17,
+        "proof_of_concept": "curl -d user=admin /login",
+        "fix": "Use parameterized queries",
+        "confidence": 9
+      },
+      {
+        "id": "SEC-002",
+        "severity": "high",
+        "category": "STRIDE",
+        "description": "Session fixation",
+        "file": "src/session.ts",
+        "line": 88,
+        "proof_of_concept": "Replay session cookie",
+        "fix": "Rotate session on login",
+        "confidence": 7
+      }
+    ],
+    "context_checkpoint": {
+      "summary": "Two findings: SQLi critical, session fixation high",
+      "key_files": [],
+      "decisions_made": [],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_valid_qa() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" qa '{
+    "phase": "qa",
+    "summary": {
+      "mode": "browser",
+      "status": "partial",
+      "tests_run": 12,
+      "tests_passed": 11,
+      "tests_failed": 1,
+      "bugs_found": 1,
+      "bugs_fixed": 0,
+      "wtf_likelihood": 15
+    },
+    "findings": [
+      {
+        "id": "QA-001",
+        "severity": "high",
+        "description": "Login redirect loops on Safari",
+        "reproduce": "Open /login in Safari",
+        "root_cause": "Service worker cache",
+        "fixed": false
+      }
+    ],
+    "context_checkpoint": {
+      "summary": "One Safari-specific bug",
+      "key_files": [],
+      "decisions_made": [],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_valid_ship() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" ship '{
+    "phase": "ship",
+    "summary": {
+      "pr_number": 217,
+      "pr_url": "https://github.com/garagon/nanostack/pull/217",
+      "title": "Visual artifacts PR 1",
+      "status": "merged",
+      "ci_passed": true
+    },
+    "context_checkpoint": {
+      "summary": "Merged after 10 codex passes",
+      "key_files": [],
+      "decisions_made": [],
+      "open_questions": []
+    }
+  }' >/dev/null
+}
+
+save_ship_report_only() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" ship '{
+    "phase": "ship",
+    "run_mode": "report_only",
+    "summary": "Would have shipped if approved"
+  }' >/dev/null
+}
+
+save_ship_malicious_url() {
+  local store="$1"
+  NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" ship '{
+    "phase": "ship",
+    "summary": {
+      "pr_number": 99,
+      "pr_url": "javascript:alert(1)",
+      "title": "<script>evil</script>",
+      "status": "created",
+      "ci_passed": false
+    },
+    "context_checkpoint": {"summary": "x", "key_files": [], "decisions_made": [], "open_questions": []}
+  }' >/dev/null
+}
+
 save_malicious_plan() {
   local store="$1"
   NANOSTACK_STORE="$store" "$REPO/bin/save-artifact.sh" plan '{
@@ -310,6 +475,177 @@ TMPPLAN="$TMP_ROOT/mixed.json"
 jq '.phase = "review"' "$PLAN_PATH" > "$TMPPLAN"
 assert_exit "explicit path with mismatched .phase exits 1" 1 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan '$TMPPLAN'"
+
+# ─── Cell 10: /think renderer ───────────────────────────────
+printf "\n  ${DIM}Cell 10: /think renderer${NC}\n"
+PROJ="$TMP_ROOT/cell10"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_think "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" think --latest)
+assert_true "think html exists" test -f "$HTML"
+assert_contains "think value_proposition" "$HTML" "Make Nanostack renders inspectable"
+assert_contains "think scope_mode chip" "$HTML" "selective_expand"
+assert_contains "think narrowest_wedge" "$HTML" "Static /plan HTML view"
+assert_contains "think key_risk" "$HTML" "XSS via unescaped artifact text"
+assert_contains "think target_user" "$HTML" "Devs reviewing AI work"
+assert_contains "think archetype chip" "$HTML" "cli_tooling"
+assert_contains "think out_of_scope" "$HTML" "Interactive editing"
+assert_contains "think context_checkpoint" "$HTML" "Decision brief signed off"
+assert_contains "think data-phase=think" "$HTML" 'data-phase="think"'
+
+# ─── Cell 11: /review renderer ──────────────────────────────
+printf "\n  ${DIM}Cell 11: /review renderer${NC}\n"
+PROJ="$TMP_ROOT/cell11"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_review "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest)
+assert_true "review html exists" test -f "$HTML"
+assert_contains "review blocking counter" "$HTML" '>Blocking<'
+assert_contains "review should_fix counter" "$HTML" '>Should fix<'
+assert_contains "review nitpicks counter" "$HTML" '>Nitpicks<'
+assert_contains "review positive counter" "$HTML" '>Positive<'
+assert_contains "review scope_drift status" "$HTML" "drift_detected"
+assert_contains "review out-of-scope file" "$HTML" "c.ts"
+assert_contains "review finding REV-001" "$HTML" "REV-001"
+assert_contains "review finding description" "$HTML" "Unbounded loop"
+assert_contains "review file:line" "$HTML" "src/loop.ts:42"
+assert_contains "review sev-bad class" "$HTML" 'sev-bad'
+assert_contains "review data-severity attr" "$HTML" 'data-severity="blocking"'
+
+# ─── Cell 12: /security renderer ────────────────────────────
+printf "\n  ${DIM}Cell 12: /security renderer${NC}\n"
+PROJ="$TMP_ROOT/cell12"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_security "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" security --latest)
+assert_true "security html exists" test -f "$HTML"
+assert_contains "security critical counter" "$HTML" '>Critical<'
+assert_contains "security finding SEC-001" "$HTML" "SEC-001"
+assert_contains "security category A03 chip" "$HTML" 'A03'
+assert_contains "security STRIDE category" "$HTML" 'STRIDE'
+assert_contains "security proof_of_concept details" "$HTML" "<details><summary>Proof of concept</summary>"
+assert_contains "security fix recommendation" "$HTML" "Use parameterized queries"
+assert_contains "security confidence" "$HTML" "confidence 9"
+# No "certification" or "compliant" language allowed (architect rule).
+assert_not_contains "no 'certified' language" "$HTML" 'certified'
+assert_not_contains "no 'compliant' language" "$HTML" 'compliant'
+
+# ─── Cell 13: /qa renderer ──────────────────────────────────
+printf "\n  ${DIM}Cell 13: /qa renderer${NC}\n"
+PROJ="$TMP_ROOT/cell13"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_qa "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" qa --latest)
+assert_true "qa html exists" test -f "$HTML"
+assert_contains "qa mode chip" "$HTML" 'browser'
+assert_contains "qa status partial" "$HTML" 'partial'
+assert_contains "qa wtf_likelihood" "$HTML" 'WTF likelihood'
+assert_contains "qa tests_run counter" "$HTML" '>Tests run<'
+assert_contains "qa tests_failed counter" "$HTML" '>Failed<'
+assert_contains "qa finding QA-001" "$HTML" "QA-001"
+assert_contains "qa reproduce details" "$HTML" "<details><summary>Reproduce</summary>"
+assert_contains "qa root_cause" "$HTML" "Root cause"
+
+# ─── Cell 14: /ship renderer normal mode ────────────────────
+printf "\n  ${DIM}Cell 14: /ship renderer normal mode${NC}\n"
+PROJ="$TMP_ROOT/cell14"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_ship "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" ship --latest)
+assert_true "ship html exists" test -f "$HTML"
+assert_contains "ship title" "$HTML" "Visual artifacts PR 1"
+assert_contains "ship pr_number" "$HTML" "217"
+assert_contains "ship status merged" "$HTML" 'merged'
+# Safe github.com URL must render as an <a>.
+assert_contains "ship safe PR URL as link" "$HTML" '<a class="pr-link" href="https://github.com/'
+
+# ─── Cell 15: /ship renderer report_only mode ───────────────
+printf "\n  ${DIM}Cell 15: /ship report_only${NC}\n"
+PROJ="$TMP_ROOT/cell15"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_ship_report_only "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" ship --latest)
+assert_true "ship report_only html exists" test -f "$HTML"
+assert_contains "ship report_only banner" "$HTML" "run_mode = report_only"
+assert_contains "ship report_only body" "$HTML" "Would have shipped"
+# No release-packet styling in report_only.
+assert_not_contains "no Release packet header in report_only" "$HTML" "Release packet"
+
+# ─── Cell 16: /ship malicious PR URL refused as link ────────
+printf "\n  ${DIM}Cell 16: /ship malicious PR URL${NC}\n"
+PROJ="$TMP_ROOT/cell16"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_ship_malicious_url "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" ship --latest)
+assert_contains "ship unsafe URL marker" "$HTML" 'data-testid="unsafe-pr-url"'
+assert_not_contains "ship NO javascript: href" "$HTML" 'href="javascript:'
+assert_not_contains "ship NO active <a> for javascript scheme" "$HTML" 'href="javascript'
+assert_contains "ship escapes title XSS" "$HTML" '&lt;script&gt;evil&lt;/script&gt;'
+assert_not_contains "ship NO raw <script>evil" "$HTML" '<script>evil'
+
+# ─── Cell 17: XSS across all 5 new phases ──────────────────
+printf "\n  ${DIM}Cell 17: XSS escape across core phases${NC}\n"
+PROJ="$TMP_ROOT/cell17"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# Malicious think
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" think '{
+  "phase":"think",
+  "summary":{"value_proposition":"<script>alert(1)</script>","scope_mode":"<img src=x onerror=alert(1)>","target_user":"a","narrowest_wedge":"b","key_risk":"c","premise_validated":true},
+  "context_checkpoint":{"summary":"\"><iframe>x</iframe>","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" think --latest)
+assert_not_contains "think no raw <script>alert" "$HTML" '<script>alert'
+assert_not_contains "think no raw <iframe>x" "$HTML" '<iframe>x</iframe>'
+assert_contains "think escapes script tag" "$HTML" '&lt;script&gt;'
+
+# Malicious review (finding description contains JS)
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" review '{
+  "phase":"review","summary":{"blocking":1,"should_fix":0,"nitpicks":0,"positive":0},
+  "scope_drift":{"status":"clean","planned_files":[],"actual_files":[],"out_of_scope_files":[],"missing_files":[]},
+  "findings":[{"id":"REV-X","severity":"blocking","description":"<script>alert(\"rev\")</script>","file":"a","line":1}],
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest)
+assert_not_contains "review no raw <script>alert" "$HTML" '<script>alert'
+assert_contains "review escapes" "$HTML" '&lt;script&gt;'
+
+# Malicious security proof_of_concept (must escape inside <pre>)
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" security '{
+  "phase":"security","summary":{"critical":1,"high":0,"medium":0,"low":0,"total_findings":1},
+  "findings":[{"id":"SEC-X","severity":"critical","category":"A01","description":"d","file":"f","line":1,"proof_of_concept":"<script>alert(\"poc\")</script>","fix":"<img src=x onerror=alert(1)>"}],
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" security --latest)
+assert_not_contains "security PoC no raw <script>alert" "$HTML" '<script>alert'
+assert_not_contains "security fix no raw <img" "$HTML" '<img src=x onerror=alert(1)>'
+assert_contains "security PoC escaped" "$HTML" '&lt;script&gt;'
+assert_contains "security PoC stays in <pre>" "$HTML" '<details><summary>Proof of concept</summary><pre>'
+
+# Malicious qa (reproduce + root_cause)
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" qa '{
+  "phase":"qa","summary":{"mode":"browser","status":"fail","tests_run":1,"tests_passed":0,"tests_failed":1,"bugs_found":1,"bugs_fixed":0},
+  "findings":[{"id":"QA-X","severity":"high","description":"d","reproduce":"<script>alert(\"qa\")</script>","root_cause":"<img onerror=alert(1)>","fixed":false}],
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" qa --latest)
+assert_not_contains "qa reproduce no raw script" "$HTML" '<script>alert("qa")'
+assert_not_contains "qa root_cause no raw img" "$HTML" '<img onerror=alert(1)>'
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"


### PR DESCRIPTION
## Summary

PR 2 of the Visual Artifacts v1 round. Wires renderers for the remaining core phases so `/think`, `/review`, `/security`, `/qa`, and `/ship` artifacts can each be inspected as a static HTML view. Same trust + path-safety contract as PR 1.

### What changed

**Shared helpers** (`bin/lib/visual-render.sh`)
- `nano_visual_normalize_artifact` — jq-based coercion that turns a legacy or malformed artifact into a predictable shape (summary, context_checkpoint, scope_drift, findings, conflicts as objects/arrays). Every renderer reads the normalized form.
- `nano_visual_severity_class` — maps `blocking` / `critical` / `high` / etc to a CSS class so review/security/qa agree on color.
- `nano_visual_safe_pr_url` — allowlist for ship `pr_url`. Only `https://github.com/*` renders as a clickable link; every other URL renders as escaped text with an explicit "host not in allowlist" note.
- `nano_visual_safe_screenshot_path` — stricter allowlist for future QA screenshot rendering.
- New CSS for `.counter`, `.finding.sev-bad/warn/info/ok`, `.chip`, `.pr-link`, `.unsafe-url`.

**Body renderers** (`bin/render-artifact.sh`)
- `render_think_body` — value proposition, scope mode chip, narrowest wedge, key risk, premise validation, archetype card with optional example reference, out-of-scope list.
- `render_review_body` — 4-counter summary (blocking / should fix / nitpicks / positive), scope drift status chip with out-of-scope and missing file lists, severity-styled findings.
- `render_security_body` — 5-counter summary (critical / high / medium / low / total), findings with category chips (OWASP A0n / STRIDE), `proof_of_concept` and `reproduce` blocks wrapped in `<details><pre>`.
- `render_qa_body` — mode / status chips, WTF likelihood, 5-counter test/bug breakdown, findings with reproduce + root cause + fixed flag.
- `render_ship_body` — `report_only` mode renders a short report card (no release-packet styling); normal mode renders PR title / number / URL / status / CI passed. Unsafe PR URLs render as text with `data-testid="unsafe-pr-url"`.
- `render_findings_section` — shared helper for review/security/qa.
- `render_context_checkpoint` — shared helper for the trailing card.

**CI extensions**
- 8 new e2e cells: think, review, security, qa, ship normal, ship report_only, ship malicious URL, XSS across all 5 phases.
- 5 new template safety checks: `nano_visual_safe_pr_url` usage, `rel="noopener noreferrer"`, `nano_visual_severity_class`, CSS classes.
- Template safety lint now allows the `# url-allowlist` marker so the legitimate case pattern does not trip the "no http(s) URLs" check.

### Test counts

| Suite | PR 1 | PR 2 |
|-------|------|------|
| `ci/e2e-visual-artifacts.sh` | 86 | 154 |
| `ci/check-visual-artifact-templates.sh` | 20 | 25 |
| **Total contract surface** | **106** | **179** |

### Codex review trail (2 passes, clean)

| Pass | Finding | Fix |
|------|---------|-----|
| 1 | P2: ship `ci_passed` not escaped (boolean-typed in schema, but artifact may store string) | pipe through `nano_html_escape` like every other scalar |
| 2 | (none — clean) | — |

## Test plan
- [x] `ci/e2e-visual-artifacts.sh` 154/154
- [x] `ci/check-visual-artifact-templates.sh` 25/25
- [x] Sabotage: inject URL in renderer source — lint detects (24/25)
- [x] All 5 phase renderers XSS-checked with `<script>` / `<img onerror>` / `<iframe>` fixtures
- [x] Ship malicious PR URL (`javascript:alert(1)`) renders as escaped text only, never as `<a href>`
- [x] Ship `report_only` mode shows the report card and omits the release-packet header
- [x] Codex review pass 2 returned clean