### PR TITLE
visual-artifacts v1: PR 3 sprint journal and custom stack views

### DIFF
--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -285,6 +285,7 @@ nano_visual_trust_badge_text() {
     verified)            printf 'verified\n' ;;
     integrity_missing)   printf 'unverified\n' ;;
     integrity_mismatch)  printf 'tampered\n' ;;
+    not_applicable)      printf 'aggregated\n' ;;
     *)                   printf 'unknown\n' ;;
   esac
 }
@@ -342,6 +343,7 @@ nano_visual_page_start() {
     .trust-badge[data-trust="verified"] { background: rgba(74,222,128,0.15); color: var(--ok); border: 1px solid var(--ok); }
     .trust-badge[data-trust="integrity_missing"] { background: rgba(250,204,21,0.15); color: var(--warn); border: 1px solid var(--warn); }
     .trust-badge[data-trust="integrity_mismatch"] { background: rgba(251,113,133,0.15); color: var(--bad); border: 1px solid var(--bad); }
+    .trust-badge[data-trust="not_applicable"] { background: rgba(96,165,250,0.15); color: var(--info); border: 1px solid var(--info); }
     section.card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; margin-bottom: 16px; }
     section.card h2 { margin: 0 0 12px 0; font-size: 1.15rem; }
     .muted { color: var(--muted); }
@@ -472,7 +474,7 @@ nano_visual_safe_screenshot_path() {
   case "$p" in
     "")                printf 'unsafe\n'; return ;;
     *..*|*"\\"*)       printf 'unsafe\n'; return ;;
-    http://*|https://*|//*|data:*|javascript:*|file://*|*\<*|*\>*|*\"*)
+    http://*|https://*|//*|data:*|javascript:*|file://*|*\<*|*\>*|*\"*)  # url-allowlist
                        printf 'unsafe\n'; return ;;
   esac
   case "$p" in

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1164,10 +1164,21 @@ render_stack_body() {
   # graph under the requested stack's name and hide the broken
   # definition. The fallback is only for the bare `stack` / `stack
   # default` form when no stack file was found at all.
+  # Codex PR 3 pass 15: every manifest must have at least one
+  # source entry per the visual artifact contract. For stack
+  # failure modes (invalid file, not found), emit a synthetic
+  # source pointing at the stack file (when present) or the
+  # requested name. This keeps downstream manifest consumers happy.
+  _stack_synthetic_source() {
+    local path="$1" trust="$2"
+    jq -n --arg phase "stack:$name" --arg path "$path" --arg trust "$trust" \
+      '[{phase: $phase, path: $path, integrity: "", trust: $trust}]'
+  }
+
   if [ "$named_stack_file_present" = true ] && { [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; }; then
     printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack file <code>%s</code> exists but its <code>phase_graph</code> is missing or unreadable.</p>\n    </section>\n' \
       "$(printf '%s' "$stack_file" | nano_html_escape)"
-    SOURCE_ARTIFACTS_JSON='[]'
+    SOURCE_ARTIFACTS_JSON=$(_stack_synthetic_source "$stack_file" "integrity_missing")
     return 0
   fi
 
@@ -1184,7 +1195,7 @@ render_stack_body() {
   if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
     printf '    <section class="card">\n      <h2>Stack not found</h2>\n      <p>No stack definition found for <code>%s</code>.</p>\n    </section>\n' \
       "$(printf '%s' "$name" | nano_html_escape)"
-    SOURCE_ARTIFACTS_JSON='[]'
+    SOURCE_ARTIFACTS_JSON=$(_stack_synthetic_source "" "not_found")
     return 0
   fi
 
@@ -1266,7 +1277,7 @@ render_stack_body() {
     printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack definition for <code>%s</code> has a malformed <code>phase_graph</code>: %s.</p>\n    </section>\n' \
       "$(printf '%s' "$name" | nano_html_escape)" \
       "$(printf '%s' "$graph_validation_error" | nano_html_escape)"
-    SOURCE_ARTIFACTS_JSON='[]'
+    SOURCE_ARTIFACTS_JSON=$(_stack_synthetic_source "$stack_file" "integrity_missing")
     return 0
   fi
 

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -528,9 +528,16 @@ _latest_safe_artifact_for_stack() {
   # artifacts, the cap would hide this project's older legitimate
   # (or tampered) artifact and the stack row would render as missing.
   # The early-return inside the loop keeps the walk bounded.
+  #
+  # Codex PR 3 pass 17: sort by FILENAME descending (not mtime).
+  # save-artifact.sh names files YYYYMMDD-HHMMSS.json, so the
+  # filename is the canonical ordering. A copied/restored/touched
+  # artifact gets a fresh mtime but the same filename timestamp; the
+  # per-phase resolver and journal sort by filename, so the stack
+  # helper should too for consistent results.
   # shellcheck disable=SC2012
   local candidates
-  candidates=$(ls -1t "$dir"/*.json 2>/dev/null)
+  candidates=$(ls -1 "$dir"/*.json 2>/dev/null | sort -r)
   [ -z "$candidates" ] && return 0
   local f
   while IFS= read -r f; do
@@ -1346,14 +1353,21 @@ render_stack_body() {
   # escaped double quotes; a project path with a backslash or
   # control character produced invalid JSON.
   #
-  # Codex PR 3 pass 16: include the stack definition file itself as
-  # the first source so manifest consumers can spot a change to the
-  # graph. Stack files don't carry .integrity so we record them as
-  # not_applicable (trust is meaningful only for artifact JSON).
+  # Codex PR 3 pass 16: include the stack definition file as the
+  # first source. Pass 17: when `stack default` falls back to
+  # .nanostack/config.json via nano_phase_graph_json, record THAT
+  # config file as the source instead. Either way the manifest
+  # captures the file that determined the rendered DAG.
   sources='[]'
+  local config_src=""
   if [ -n "$stack_file" ] && [ -f "$stack_file" ]; then
+    config_src="$stack_file"
+  elif [ "$name" = "default" ] && [ -f "$NANOSTACK_STORE/config.json" ]; then
+    config_src="$NANOSTACK_STORE/config.json"
+  fi
+  if [ -n "$config_src" ]; then
     local sf_abs
-    sf_abs=$(nano_resolve_abs "$stack_file")
+    sf_abs=$(nano_resolve_abs "$config_src")
     sources=$(printf '%s' "$sources" | jq -c \
       --arg phase "stack:$name" \
       --arg path "$sf_abs" \

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1151,13 +1151,17 @@ render_stack_svg() {
   local graph_json="$1"
 
   # Iterative depth resolution in bash. Root nodes (no depends_on) get
-  # depth 0; children get 1 + max(parent depths). Cap at 10 rounds to
-  # keep cycles from looping forever.
-  local names depths_tsv
+  # depth 0; children get 1 + max(parent depths). Cap rounds at the
+  # node count + 1 so a valid topologically-unsorted graph is fully
+  # resolved (worst case is a linear chain). Codex PR 3 pass 3 caught
+  # the fixed cap of 10 truncating larger custom stacks.
+  local names depths_tsv node_count round_cap
   names=$(printf '%s' "$graph_json" | jq -r '.[].name')
+  node_count=$(printf '%s\n' "$names" | grep -c .)
+  round_cap=$(( node_count + 1 ))
   : > "$TMP_ROOT_FALLBACK/depths.tsv"
   local round
-  for round in 1 2 3 4 5 6 7 8 9 10; do
+  for round in $(seq 1 "$round_cap"); do
     local progressed=0
     for n in $names; do
       local already
@@ -1383,6 +1387,24 @@ jq -n \
     created_at: $created_at
   }' > "$TMP_MFST"
 
+# Strict mode for aggregate renders: enforce after sources are
+# collected, BEFORE the manifest-only branch returns. Codex PR 3
+# pass 3 caught that running before the early exit was required so
+# `journal --strict --manifest-only` cannot ship a "strict: true"
+# manifest with tampered sources. "missing" sources stay acceptable
+# because they are an expected aggregate state (the user has not
+# run that phase yet). integrity_missing and integrity_mismatch are
+# the actually-suspect cases.
+if [ "$STRICT" = true ] && { [ "$PHASE" = "journal" ] || [ "$PHASE" = "stack" ]; }; then
+  bad=$(printf '%s' "$SOURCE_ARTIFACTS_JSON" | jq -r \
+    '.[] | select(.trust == "integrity_missing" or .trust == "integrity_mismatch") | "\(.phase): \(.trust)"' 2>/dev/null)
+  if [ -n "$bad" ]; then
+    echo "render-artifact: --strict requires every aggregated source to be verified; failing on:" >&2
+    printf '  %s\n' $bad >&2
+    exit 3
+  fi
+fi
+
 if [ "$MANIFEST_ONLY" = true ]; then
   # Codex PR 1 pass 9: the manifest-only branch must not leave the
   # mktemp'd HTML temp file behind. Clean it before disabling the
@@ -1393,26 +1415,6 @@ if [ "$MANIFEST_ONLY" = true ]; then
   trap - EXIT
   echo "$MANIFEST_PATH"
   exit 0
-fi
-
-# Strict mode for aggregate renders: enforce after sources are
-# collected. Any source whose trust is not "verified" rejects the
-# render. Codex PR 3 pass 2 caught that --strict with a journal or
-# stack produced a "strict: true" manifest while skipping the trust
-# check entirely.
-if [ "$STRICT" = true ] && { [ "$PHASE" = "journal" ] || [ "$PHASE" = "stack" ]; }; then
-  unverified=$(printf '%s' "$SOURCE_ARTIFACTS_JSON" | jq -r \
-    '.[] | select(.trust != "verified" and .trust != "missing") | "\(.phase): \(.trust)"' 2>/dev/null)
-  # "missing" sources are an expected aggregate state (the user has
-  # not run that phase yet). "integrity_missing" and
-  # "integrity_mismatch" are the actually-suspect cases.
-  bad=$(printf '%s' "$SOURCE_ARTIFACTS_JSON" | jq -r \
-    '.[] | select(.trust == "integrity_missing" or .trust == "integrity_mismatch") | "\(.phase): \(.trust)"' 2>/dev/null)
-  if [ -n "$bad" ]; then
-    echo "render-artifact: --strict requires every aggregated source to be verified; failing on:" >&2
-    printf '  %s\n' $bad >&2
-    exit 3
-  fi
 fi
 
 mv "$TMP_HTML" "$HTML_PATH"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -23,6 +23,13 @@ source "$SCRIPT_DIR/lib/html-escape.sh"
 source "$SCRIPT_DIR/lib/visual-render.sh"
 source "$SCRIPT_DIR/lib/artifact-trust.sh"
 [ -f "$SCRIPT_DIR/lib/artifact-schemas.sh" ] && source "$SCRIPT_DIR/lib/artifact-schemas.sh"
+# Sourced so render_journal_body / render_stack_body can ask the
+# registry for custom phases and the project's phase_graph. Codex
+# PR 3 pass 1 caught the missing source: nano_all_phases and
+# nano_phase_graph_json were never defined, so journal silently
+# skipped custom phases and stack fell back to "stack not found"
+# instead of the project graph.
+[ -f "$SCRIPT_DIR/lib/phases.sh" ] && source "$SCRIPT_DIR/lib/phases.sh"
 
 usage() {
   cat <<USAGE
@@ -856,6 +863,32 @@ render_journal_body() {
   local date="$1"
   local project_path
   project_path="$(pwd)"
+  # Codex PR 3 pass 1: --date <YYYY-MM-DD> previously called
+  # find-artifact.sh which returns the LATEST in the last N days, not
+  # the latest on the requested date. Compute the compact form
+  # (YYYYMMDD) so we can filter artifact filenames by date prefix.
+  local date_compact
+  date_compact="${date//-/}"
+
+  # find the latest artifact for <phase> on <date>. Uses filename
+  # convention `YYYYMMDD-HHMMSS.json` under `.nanostack/<phase>/`.
+  # Returns the path on stdout (empty if none).
+  _journal_latest_on_date() {
+    local ph="$1" dc="$2"
+    local dir="$NANOSTACK_STORE/$ph"
+    [ -d "$dir" ] || return 0
+    local project_root="$project_path"
+    # shellcheck disable=SC2012
+    ls -1 "$dir"/"$dc"-*.json 2>/dev/null \
+      | sort -r \
+      | while IFS= read -r f; do
+          # find-artifact.sh's project filter: .project must match.
+          if jq -e --arg p "$project_root" '.project == $p' "$f" >/dev/null 2>&1; then
+            printf '%s\n' "$f"
+            return
+          fi
+        done | head -1
+  }
 
   # Build the list of phases to enumerate. Use the phase registry
   # so custom phases declared in .nanostack/config.json appear too.
@@ -882,8 +915,18 @@ render_journal_body() {
       build) continue ;;  # Not a saved phase; build is editor work.
     esac
     # Find the latest artifact for this phase on the requested date.
+    # _journal_latest_on_date filters by filename prefix YYYYMMDD,
+    # which matches save-artifact.sh's naming convention. Falls back
+    # to find-artifact.sh (last 30 days) when no date prefix matches,
+    # because legacy artifacts may have different shapes. The first
+    # match wins.
     local art_path trust status_label sev_class summary
-    art_path=$("$SCRIPT_DIR/find-artifact.sh" "$ph" 30 --no-session-sync 2>/dev/null || true)
+    art_path=$(_journal_latest_on_date "$ph" "$date_compact")
+    if [ -z "$art_path" ] && [ "$date" = "$(date -u +%Y-%m-%d)" ]; then
+      # For today, fall back to find-artifact.sh to catch artifacts
+      # not yet committed to disk under the convention.
+      art_path=$("$SCRIPT_DIR/find-artifact.sh" "$ph" 30 --no-session-sync 2>/dev/null || true)
+    fi
     if [ -z "$art_path" ] || [ ! -f "$art_path" ]; then
       status_label="missing"
       sev_class="sev-warn"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -30,11 +30,15 @@ Usage: render-artifact.sh <phase> [artifact-path|--latest] [--strict]
                                   [--interactive] [--out <path>]
                                   [--manifest-only]
 
-PR 1+2 scope:
+PR 1+2+3 scope:
   phase = plan|think|review|security|qa|ship
                              render the latest or explicit artifact
-  phase = journal            reserved for PR 3 (exit 2)
-  phase = stack              reserved for PR 3 (exit 2)
+  phase = journal            render today's sprint journal view
+                             (positional arg ignored; use --today or
+                             --date YYYY-MM-DD)
+  phase = stack [name]       render a custom stack DAG view; the
+                             positional arg names the stack and is
+                             looked up in .nanostack/config.json
 
 Flags:
   --strict                   require nano_artifact_trust == verified
@@ -67,18 +71,10 @@ INTERACTIVE=false
 MANIFEST_ONLY=false
 OUT_PATH=""
 
-# Reserved phase kinds. Surface a clear message and use the contract
-# exit code so CI can categorize.
-case "$PHASE" in
-  journal)
-    echo "render-artifact: 'journal' is reserved for PR 3 (sprint journal renderer)" >&2
-    exit 2
-    ;;
-  stack)
-    echo "render-artifact: 'stack' is reserved for PR 3 (custom stack graph renderer)" >&2
-    exit 2
-    ;;
-esac
+# journal and stack are derived kinds (not phase artifacts). They
+# follow different argument shapes from the per-phase renderers.
+JOURNAL_DATE=""
+STACK_NAME=""
 
 # Argument parsing. The first non-flag argument after <phase> is the
 # explicit artifact path. Flags can appear before or after.
@@ -96,71 +92,122 @@ while [ $# -gt 0 ]; do
       [ -z "${1:-}" ] && { echo "render-artifact: --out requires a path" >&2; exit 1; }
       OUT_PATH="$1"
       ;;
+    --today)          JOURNAL_DATE="$(date -u +%Y-%m-%d)" ;;
+    --date)
+      shift
+      [ -z "${1:-}" ] && { echo "render-artifact: --date requires YYYY-MM-DD" >&2; exit 1; }
+      # Validate shape (codex pass 1 of PR 1 lesson: regex-validate
+      # before passing to GNU date or storing in HTML).
+      case "$1" in
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) JOURNAL_DATE="$1" ;;
+        *) echo "render-artifact: --date must be YYYY-MM-DD" >&2; exit 1 ;;
+      esac
+      ;;
     --help|-h)        usage; exit 0 ;;
     -*)
       echo "render-artifact: unknown flag: $1" >&2
       exit 1
       ;;
     *)
-      if [ -n "$ART_PATH" ]; then
-        echo "render-artifact: extra positional argument: $1" >&2
-        exit 1
-      fi
-      ART_PATH="$1"
+      # For journal/stack the positional is name/date, not artifact path.
+      case "$PHASE" in
+        journal)
+          if [ -n "$JOURNAL_DATE" ]; then
+            echo "render-artifact: extra positional for journal: $1" >&2
+            exit 1
+          fi
+          case "$1" in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) JOURNAL_DATE="$1" ;;
+            *) echo "render-artifact: journal positional must be YYYY-MM-DD: $1" >&2; exit 1 ;;
+          esac
+          ;;
+        stack)
+          if [ -n "$STACK_NAME" ]; then
+            echo "render-artifact: extra positional for stack: $1" >&2
+            exit 1
+          fi
+          # Reject anything that is not alnum + dash.
+          case "$1" in
+            *[!a-zA-Z0-9_-]*)
+              echo "render-artifact: stack name must be alnum/-/_ only: $1" >&2
+              exit 1
+              ;;
+          esac
+          STACK_NAME="$1"
+          ;;
+        *)
+          if [ -n "$ART_PATH" ]; then
+            echo "render-artifact: extra positional argument: $1" >&2
+            exit 1
+          fi
+          ART_PATH="$1"
+          ;;
+      esac
       ;;
   esac
   shift
 done
 
-# Validate phase. Core phases supported by PR 1+2: plan/think/review/
-# security/qa/ship.
+# Validate phase. Core phases: plan/think/review/security/qa/ship.
+# Derived kinds: journal (PR 3), stack (PR 3).
 case "$PHASE" in
   plan|think|review|security|qa|ship) ;;
+  journal|stack) ;;
   *)
     echo "render-artifact: unsupported phase: $PHASE" >&2
     exit 1
     ;;
 esac
 
-# Resolve the source artifact. --no-session-sync keeps the renderer
-# strictly downstream: find-artifact.sh otherwise calls
-# `session.sh phase-start` as a convenience for skills, which would
-# mutate session.json just because a user viewed an artifact. Codex
-# PR 1 pass 7 caught the boundary violation.
-if [ -z "$ART_PATH" ] || [ "$USE_LATEST" = true ]; then
-  ART_PATH=$("$SCRIPT_DIR/find-artifact.sh" "$PHASE" 30 --no-session-sync 2>/dev/null || true)
-  if [ -z "$ART_PATH" ]; then
-    echo "render-artifact: no $PHASE artifact found in the last 30 days" >&2
+# Journal and stack do not source from a single phase artifact; they
+# aggregate. Skip the per-phase trust/schema branch for them and use
+# a sentinel ART_PHASE so the manifest writer below works uniformly.
+if [ "$PHASE" = "journal" ] || [ "$PHASE" = "stack" ]; then
+  ART_PATH=""
+  ART_PHASE="$PHASE"
+else
+  # Resolve the source artifact. --no-session-sync keeps the renderer
+  # strictly downstream: find-artifact.sh otherwise calls
+  # `session.sh phase-start` as a convenience for skills, which would
+  # mutate session.json just because a user viewed an artifact. Codex
+  # PR 1 pass 7 caught the boundary violation.
+  if [ -z "$ART_PATH" ] || [ "$USE_LATEST" = true ]; then
+    ART_PATH=$("$SCRIPT_DIR/find-artifact.sh" "$PHASE" 30 --no-session-sync 2>/dev/null || true)
+    if [ -z "$ART_PATH" ]; then
+      echo "render-artifact: no $PHASE artifact found in the last 30 days" >&2
+      exit 1
+    fi
+  fi
+
+  if [ ! -f "$ART_PATH" ]; then
+    echo "render-artifact: artifact not found: $ART_PATH" >&2
     exit 1
   fi
-fi
 
-if [ ! -f "$ART_PATH" ]; then
-  echo "render-artifact: artifact not found: $ART_PATH" >&2
-  exit 1
-fi
+  # JSON must parse.
+  if ! jq -e '.' "$ART_PATH" >/dev/null 2>&1; then
+    echo "render-artifact: artifact is not valid JSON: $ART_PATH" >&2
+    exit 1
+  fi
 
-# JSON must parse.
-if ! jq -e '.' "$ART_PATH" >/dev/null 2>&1; then
-  echo "render-artifact: artifact is not valid JSON: $ART_PATH" >&2
-  exit 1
-fi
-
-# .phase field must match the requested phase. Codex PR 1 pass 6
-# caught: a top-level JSON array or string crashes `jq -r '.phase //
-# ""'` with exit 5 under set -e; the documented input-error exit is
-# 1. The `?` operator suppresses the path error so non-object JSON
-# falls through cleanly and the phase mismatch branch handles it.
-ART_PHASE=$(jq -r '.phase? // ""' "$ART_PATH")
-if [ "$ART_PHASE" != "$PHASE" ]; then
-  echo "render-artifact: artifact phase '$ART_PHASE' does not match requested phase '$PHASE': $ART_PATH" >&2
-  exit 1
+  # .phase field must match the requested phase.
+  ART_PHASE=$(jq -r '.phase? // ""' "$ART_PATH")
+  if [ "$ART_PHASE" != "$PHASE" ]; then
+    echo "render-artifact: artifact phase '$ART_PHASE' does not match requested phase '$PHASE': $ART_PATH" >&2
+    exit 1
+  fi
 fi
 
 # Trust check. integrity_mismatch always fails (exit 3). Under
 # --strict, integrity_missing also fails. integrity_missing without
 # strict renders with an "unverified" badge.
-TRUST=$(nano_artifact_trust "$ART_PATH" 2>/dev/null || echo "not_found")
+# Journal/stack aggregate many sources; per-source trust is rendered
+# inline in the page, not on the page header badge.
+if [ "$PHASE" = "journal" ] || [ "$PHASE" = "stack" ]; then
+  TRUST="not_applicable"
+else
+  TRUST=$(nano_artifact_trust "$ART_PATH" 2>/dev/null || echo "not_found")
+fi
 case "$TRUST" in
   verified) ;;
   integrity_missing)
@@ -172,6 +219,9 @@ case "$TRUST" in
   integrity_mismatch)
     echo "render-artifact: source artifact integrity check failed: $ART_PATH" >&2
     exit 3
+    ;;
+  not_applicable)
+    # Journal/stack: aggregated view. Trust shown inline per source.
     ;;
   *)
     echo "render-artifact: artifact unreadable: $ART_PATH" >&2
@@ -194,9 +244,34 @@ if [ -n "$OUT_PATH" ]; then
   nano_visual_assert_safe_output "$OUT_PATH"
   HTML_PATH="$OUT_PATH"
 else
-  HTML_PATH=$(nano_visual_html_path "$PHASE" "$TS")
+  case "$PHASE" in
+    journal)
+      mkdir -p "$(nano_visual_root)/journal"
+      HTML_PATH="$(nano_visual_root)/journal/${TS}-journal-${JOURNAL_DATE}.html"
+      ;;
+    stack)
+      mkdir -p "$(nano_visual_root)/stack/$STACK_NAME"
+      HTML_PATH="$(nano_visual_root)/stack/$STACK_NAME/${TS}-stack-${STACK_NAME}.html"
+      ;;
+    *)
+      HTML_PATH=$(nano_visual_html_path "$PHASE" "$TS")
+      ;;
+  esac
 fi
-MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
+case "$PHASE" in
+  journal)
+    MANIFEST_KIND="journal"
+    MANIFEST_PATH="$(nano_visual_root)/manifests/${TS}-journal-${JOURNAL_DATE}.manifest.json"
+    ;;
+  stack)
+    MANIFEST_KIND="stack"
+    MANIFEST_PATH="$(nano_visual_root)/manifests/${TS}-stack-${STACK_NAME}.manifest.json"
+    ;;
+  *)
+    MANIFEST_KIND="phase"
+    MANIFEST_PATH=$(nano_visual_manifest_path "phase" "$PHASE" "$TS")
+    ;;
+esac
 
 # Codex PR 1 pass 6 caught: even after lexical normalization passes
 # the safety check, mkdir -p and mv use the ORIGINAL path, and the
@@ -243,20 +318,24 @@ nano_resolve_abs() {
 }
 HTML_PATH="$(nano_resolve_abs "$HTML_PATH")"
 MANIFEST_PATH="$(nano_resolve_abs "$MANIFEST_PATH")"
-ART_PATH="$(nano_resolve_abs "$ART_PATH")"
+if [ -n "$ART_PATH" ]; then
+  ART_PATH="$(nano_resolve_abs "$ART_PATH")"
+fi
 
-# Pull the stored integrity hash. It is recorded in the manifest so a
-# later check can decide whether the rendered view's source still
-# matches what was on disk at render time.
-SRC_INTEGRITY=$(jq -r '.integrity // ""' "$ART_PATH" 2>/dev/null || echo "")
+# Pull the stored integrity hash. Journal/stack have no single source
+# artifact (they aggregate), so SRC_INTEGRITY stays empty.
+SRC_INTEGRITY=""
+if [ -n "$ART_PATH" ]; then
+  SRC_INTEGRITY=$(jq -r '.integrity // ""' "$ART_PATH" 2>/dev/null || echo "")
+fi
 
 # Optional schema validation. A failing schema does not block the
 # render; it adds a visible warning to the HTML and is recorded in the
 # manifest. This is intentional: a malformed artifact still benefits
-# from being inspectable.
+# from being inspectable. Skipped for journal/stack.
 SCHEMA_OK=true
 SCHEMA_ERR=""
-if declare -F nano_validate_artifact >/dev/null 2>&1; then
+if [ -n "$ART_PATH" ] && declare -F nano_validate_artifact >/dev/null 2>&1; then
   if ! SCHEMA_ERR=$(nano_validate_artifact "$PHASE" "$(cat "$ART_PATH")" 2>&1); then
     SCHEMA_OK=false
   fi
@@ -765,6 +844,368 @@ render_context_checkpoint() {
   printf '    </section>\n'
 }
 
+# ─── Journal renderer ───────────────────────────────────────
+#
+# Aggregates every core + custom phase artifact for the current
+# project on a given date and renders a phase timeline. The timeline
+# shows: phase name, status (present / missing / tampered), summary,
+# link to the per-phase render. SOURCE_ARTIFACTS_JSON is populated as
+# the renderer walks phases so the manifest records every read source.
+
+render_journal_body() {
+  local date="$1"
+  local project_path
+  project_path="$(pwd)"
+
+  # Build the list of phases to enumerate. Use the phase registry
+  # so custom phases declared in .nanostack/config.json appear too.
+  local phases_list
+  if declare -F nano_all_phases >/dev/null 2>&1; then
+    phases_list=$(nano_all_phases 2>/dev/null || true)
+  fi
+  if [ -z "$phases_list" ]; then
+    phases_list="think plan review qa security ship"
+  fi
+
+  printf '    <section class="card">\n      <h2>Sprint journal · %s</h2>\n' \
+    "$(printf '%s' "$date" | nano_html_escape)"
+  printf '      <p class="muted">Project: <code>%s</code></p>\n' \
+    "$(printf '%s' "$project_path" | nano_html_escape)"
+  printf '    </section>\n'
+
+  # Phase timeline.
+  printf '    <section class="card">\n      <h2>Phase timeline</h2>\n      <ol class="timeline">\n'
+  local sources='[]'
+  for ph in $phases_list; do
+    [ -z "$ph" ] && continue
+    case "$ph" in
+      build) continue ;;  # Not a saved phase; build is editor work.
+    esac
+    # Find the latest artifact for this phase on the requested date.
+    local art_path trust status_label sev_class summary
+    art_path=$("$SCRIPT_DIR/find-artifact.sh" "$ph" 30 --no-session-sync 2>/dev/null || true)
+    if [ -z "$art_path" ] || [ ! -f "$art_path" ]; then
+      status_label="missing"
+      sev_class="sev-warn"
+      trust="not_found"
+      summary="No artifact found"
+      printf '        <li class="timeline-item %s" data-phase="%s">' \
+        "$sev_class" "$(printf '%s' "$ph" | nano_attr_escape)"
+      printf '<span class="chip">%s</span> <span class="chip %s">%s</span> <span class="muted">%s</span>' \
+        "$(printf '%s' "$ph" | nano_html_escape)" \
+        "$sev_class" \
+        "$(printf '%s' "$status_label" | nano_html_escape)" \
+        "$(printf '%s' "$summary" | nano_html_escape)"
+      printf '</li>\n'
+      sources=$(printf '%s' "$sources" | jq -c \
+        --arg phase "$ph" \
+        --arg path "" \
+        --arg integrity "" \
+        --arg trust "$trust" \
+        '. + [{phase: $phase, path: $path, integrity: $integrity, trust: $trust}]')
+      continue
+    fi
+    art_path=$(nano_resolve_abs "$art_path")
+    trust=$(nano_artifact_trust "$art_path" 2>/dev/null || echo "not_found")
+    case "$trust" in
+      verified)            status_label="verified"; sev_class="sev-ok" ;;
+      integrity_missing)   status_label="unverified"; sev_class="sev-warn" ;;
+      integrity_mismatch)  status_label="tampered"; sev_class="sev-bad" ;;
+      *)                   status_label="unreadable"; sev_class="sev-warn" ;;
+    esac
+    # Phase-specific summary line.
+    case "$ph" in
+      think)   summary=$(jq -r '.summary.narrowest_wedge // .summary.value_proposition // "(no summary)"' "$art_path" 2>/dev/null) ;;
+      plan)    summary=$(jq -r '.summary.goal // "(no summary)"' "$art_path" 2>/dev/null) ;;
+      review)  summary=$(jq -r '"\(.summary.blocking // 0) blocking / \(.summary.should_fix // 0) should-fix / \(.summary.nitpicks // 0) nitpicks"' "$art_path" 2>/dev/null) ;;
+      security) summary=$(jq -r '"\(.summary.critical // 0) critical / \(.summary.high // 0) high / \(.summary.total_findings // 0) total"' "$art_path" 2>/dev/null) ;;
+      qa)      summary=$(jq -r '"\(.summary.tests_passed // 0)/\(.summary.tests_run // 0) tests / \(.summary.bugs_found // 0) bugs"' "$art_path" 2>/dev/null) ;;
+      ship)
+        if [ "$(jq -r '.run_mode // ""' "$art_path" 2>/dev/null)" = "report_only" ]; then
+          summary="report_only"
+        else
+          summary=$(jq -r '"PR #\(.summary.pr_number // "?") · \(.summary.status // "unknown")"' "$art_path" 2>/dev/null)
+        fi
+        ;;
+      *)       summary=$(jq -r '.summary | (if type == "object" then (.summary // (. | tostring)) else . end)' "$art_path" 2>/dev/null) ;;
+    esac
+    local integrity
+    integrity=$(jq -r '.integrity // ""' "$art_path" 2>/dev/null)
+    printf '        <li class="timeline-item %s" data-phase="%s" data-trust="%s">' \
+      "$sev_class" \
+      "$(printf '%s' "$ph" | nano_attr_escape)" \
+      "$(printf '%s' "$trust" | nano_attr_escape)"
+    printf '<span class="chip">%s</span> <span class="chip %s">%s</span> <span>%s</span>' \
+      "$(printf '%s' "$ph" | nano_html_escape)" \
+      "$sev_class" \
+      "$(printf '%s' "$status_label" | nano_html_escape)" \
+      "$(printf '%s' "$summary" | nano_html_escape)"
+    printf '<div class="muted timeline-source">Source: <code>%s</code></div>' \
+      "$(printf '%s' "$art_path" | nano_html_escape)"
+    printf '</li>\n'
+    sources=$(printf '%s' "$sources" | jq -c \
+      --arg phase "$ph" \
+      --arg path "$art_path" \
+      --arg integrity "$integrity" \
+      --arg trust "$trust" \
+      '. + [{phase: $phase, path: $path, integrity: $integrity, trust: $trust}]')
+  done
+  printf '      </ol>\n    </section>\n'
+
+  SOURCE_ARTIFACTS_JSON="$sources"
+}
+
+# ─── Stack renderer ─────────────────────────────────────────
+#
+# Renders a custom workflow stack as a DAG using SVG. Reads
+# phase_graph either from a named stack file (examples/custom-stack-
+# template/<name>/stack.json) or from .nanostack/config.json. For each
+# node, looks up the latest artifact and shows trust status + last-
+# render link if one exists under visual/.
+
+render_stack_body() {
+  local name="$1"
+
+  # Locate the stack definition. Order:
+  #   1. examples/custom-stack-template/<name>/stack.json (repo-bundled)
+  #   2. $NANOSTACK_STORE/stacks/<name>/stack.json (user-installed)
+  #   3. .nanostack/config.json (.phase_graph) for "default" / current project
+  local stack_file=""
+  local repo_root
+  repo_root="$SCRIPT_DIR/.."
+  if [ -f "$repo_root/examples/custom-stack-template/$name/stack.json" ]; then
+    stack_file="$repo_root/examples/custom-stack-template/$name/stack.json"
+  elif [ -f "$NANOSTACK_STORE/stacks/$name/stack.json" ]; then
+    stack_file="$NANOSTACK_STORE/stacks/$name/stack.json"
+  fi
+
+  local graph_json=""
+  local display_name="$name"
+  local description=""
+
+  if [ -n "$stack_file" ]; then
+    graph_json=$(jq -c '.phase_graph' "$stack_file" 2>/dev/null || echo "")
+    display_name=$(jq -r '.display_name // .name' "$stack_file" 2>/dev/null)
+    description=$(jq -r '.description // ""' "$stack_file" 2>/dev/null)
+  fi
+
+  if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
+    # Fall back to project's phase_graph via the registry.
+    if declare -F nano_phase_graph_json >/dev/null 2>&1; then
+      graph_json=$(nano_phase_graph_json 2>/dev/null || echo "")
+    fi
+  fi
+  if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
+    printf '    <section class="card">\n      <h2>Stack not found</h2>\n      <p>No stack definition found for <code>%s</code>.</p>\n    </section>\n' \
+      "$(printf '%s' "$name" | nano_html_escape)"
+    SOURCE_ARTIFACTS_JSON='[]'
+    return 0
+  fi
+
+  printf '    <section class="card">\n      <h2>Custom stack · %s</h2>\n' \
+    "$(printf '%s' "$display_name" | nano_html_escape)"
+  if [ -n "$description" ]; then
+    printf '      <p class="muted">%s</p>\n' "$(printf '%s' "$description" | nano_html_escape)"
+  fi
+  printf '    </section>\n'
+
+  # Compute per-phase trust + last artifact path. Build the row list.
+  local sources='[]'
+  local node_count
+  node_count=$(printf '%s' "$graph_json" | jq -r 'length')
+  printf '    <section class="card">\n      <h2>Phase graph (%s phases)</h2>\n      <table>\n        <thead><tr><th>Phase</th><th>Depends on</th><th>Trust</th><th>Last artifact</th></tr></thead>\n        <tbody>\n' \
+    "$(printf '%s' "$node_count" | nano_html_escape)"
+
+  printf '%s' "$graph_json" | jq -c '.[]' | while IFS= read -r node; do
+    local nname deps_csv art_path trust label
+    nname=$(printf '%s' "$node" | jq -r '.name')
+    deps_csv=$(printf '%s' "$node" | jq -r '.depends_on // [] | join(", ")')
+    art_path=$("$SCRIPT_DIR/find-artifact.sh" "$nname" 30 --no-session-sync 2>/dev/null || true)
+    if [ -n "$art_path" ] && [ -f "$art_path" ]; then
+      art_path=$(nano_resolve_abs "$art_path")
+      trust=$(nano_artifact_trust "$art_path" 2>/dev/null || echo "not_found")
+      label="present"
+    else
+      art_path=""
+      trust="missing"
+      label="missing"
+    fi
+    local sev_class
+    case "$trust" in
+      verified)            sev_class="sev-ok"; label="verified" ;;
+      integrity_missing)   sev_class="sev-warn"; label="unverified" ;;
+      integrity_mismatch)  sev_class="sev-bad"; label="tampered" ;;
+      missing)             sev_class="sev-warn" ;;
+      *)                   sev_class="sev-warn"; label="unreadable" ;;
+    esac
+    printf '          <tr data-phase="%s" data-trust="%s">\n' \
+      "$(printf '%s' "$nname" | nano_attr_escape)" \
+      "$(printf '%s' "$trust" | nano_attr_escape)"
+    printf '            <td><code>%s</code></td>\n' "$(printf '%s' "$nname" | nano_html_escape)"
+    printf '            <td>%s</td>\n' \
+      "$(if [ -n "$deps_csv" ]; then printf '<code>%s</code>' "$(printf '%s' "$deps_csv" | nano_html_escape)"; else printf '<span class="muted">none</span>'; fi)"
+    printf '            <td><span class="chip %s">%s</span></td>\n' "$sev_class" \
+      "$(printf '%s' "$label" | nano_html_escape)"
+    if [ -n "$art_path" ]; then
+      printf '            <td><code>%s</code></td>\n' "$(printf '%s' "$art_path" | nano_html_escape)"
+    else
+      printf '            <td><span class="muted">no artifact</span></td>\n'
+    fi
+    printf '          </tr>\n'
+  done
+  printf '        </tbody>\n      </table>\n    </section>\n'
+
+  # SVG graph. Keep it simple: vertical chain with branch labels.
+  # Layout: one column per "level" computed via depends_on depth.
+  # We compute levels with jq + bash and lay out nodes on a grid.
+  render_stack_svg "$graph_json"
+
+  # Build sources array for the manifest. Reuse the table loop logic
+  # via a second jq pass; cheaper than capturing the loop output.
+  printf '%s' "$graph_json" | jq -r '.[].name' | while IFS= read -r nm; do
+    local ap tr ig
+    ap=$("$SCRIPT_DIR/find-artifact.sh" "$nm" 30 --no-session-sync 2>/dev/null || true)
+    if [ -n "$ap" ] && [ -f "$ap" ]; then
+      ap=$(nano_resolve_abs "$ap")
+      tr=$(nano_artifact_trust "$ap" 2>/dev/null || echo "not_found")
+      ig=$(jq -r '.integrity // ""' "$ap" 2>/dev/null)
+    else
+      ap=""; tr="missing"; ig=""
+    fi
+    printf '%s\t%s\t%s\t%s\n' "$nm" "$ap" "$ig" "$tr"
+  done > "$TMP_ROOT_FALLBACK/sources.tsv"
+  if [ ! -d "${TMP_ROOT_FALLBACK:-}" ]; then
+    : # safe default; sources stays []
+  else
+    sources=$(awk -F'\t' '
+      BEGIN { printf "[" }
+      NR>1 { printf "," }
+      { gsub(/"/,"\\\"",$1); gsub(/"/,"\\\"",$2); gsub(/"/,"\\\"",$3); gsub(/"/,"\\\"",$4); printf "{\"phase\":\"%s\",\"path\":\"%s\",\"integrity\":\"%s\",\"trust\":\"%s\"}",$1,$2,$3,$4 }
+      END { printf "]" }
+    ' "$TMP_ROOT_FALLBACK/sources.tsv")
+  fi
+
+  SOURCE_ARTIFACTS_JSON="$sources"
+}
+
+# Emit a simple SVG DAG. Computes node levels by depends_on chain
+# depth so the DAG flows left-to-right. Edges are drawn as straight
+# lines between centers. No external assets; no JavaScript.
+render_stack_svg() {
+  local graph_json="$1"
+
+  # Iterative depth resolution in bash. Root nodes (no depends_on) get
+  # depth 0; children get 1 + max(parent depths). Cap at 10 rounds to
+  # keep cycles from looping forever.
+  local names depths_tsv
+  names=$(printf '%s' "$graph_json" | jq -r '.[].name')
+  : > "$TMP_ROOT_FALLBACK/depths.tsv"
+  local round
+  for round in 1 2 3 4 5 6 7 8 9 10; do
+    local progressed=0
+    for n in $names; do
+      local already
+      already=$(awk -F'\t' -v n="$n" '$1==n {print $2; exit}' "$TMP_ROOT_FALLBACK/depths.tsv")
+      [ -n "$already" ] && continue
+      local deps
+      deps=$(printf '%s' "$graph_json" | jq -r --arg n "$n" '.[] | select(.name == $n) | .depends_on // [] | .[]')
+      local max=-1 all_have=true
+      for d in $deps; do
+        local dd
+        dd=$(awk -F'\t' -v n="$d" '$1==n {print $2; exit}' "$TMP_ROOT_FALLBACK/depths.tsv")
+        if [ -z "$dd" ]; then all_have=false; break; fi
+        [ "$dd" -gt "$max" ] && max="$dd"
+      done
+      if [ "$all_have" = true ]; then
+        printf '%s\t%d\n' "$n" "$((max + 1))" >> "$TMP_ROOT_FALLBACK/depths.tsv"
+        progressed=1
+      fi
+    done
+    [ "$progressed" = 0 ] && break
+  done
+
+  # Build SVG: nodes positioned by depth column, with index-within-
+  # column for y. Width 900, node 140x40, padding 20.
+  local total_depth max_per_col
+  total_depth=$(awk -F'\t' '{print $2}' "$TMP_ROOT_FALLBACK/depths.tsv" | sort -nu | tail -1)
+  total_depth="${total_depth:-0}"
+  max_per_col=$(awk -F'\t' '{print $2}' "$TMP_ROOT_FALLBACK/depths.tsv" | sort | uniq -c | awk '{print $1}' | sort -n | tail -1)
+  max_per_col="${max_per_col:-1}"
+  local svg_w=$(( (total_depth + 1) * 180 + 40 ))
+  local svg_h=$(( max_per_col * 70 + 40 ))
+
+  printf '    <section class="card">\n      <h2>DAG</h2>\n'
+  # url-allowlist: the SVG xmlns is an XML namespace identifier; it
+  # is not fetched and the browser ignores it as a URL. Required by
+  # the SVG spec when SVG appears outside of an HTML5 parser.
+  printf '      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %s %s" width="100%%" style="max-width:100%%;height:auto;background:var(--panel-2);border-radius:6px;">\n' \
+    "$svg_w" "$svg_h"
+
+  # Compute positions per node and persist.
+  : > "$TMP_ROOT_FALLBACK/positions.tsv"
+  local col col_index
+  for col in $(seq 0 "$total_depth"); do
+    col_index=0
+    while IFS=$'\t' read -r nm d; do
+      [ "$d" = "$col" ] || continue
+      local x=$(( col * 180 + 20 ))
+      local y=$(( col_index * 70 + 20 ))
+      printf '%s\t%d\t%d\n' "$nm" "$x" "$y" >> "$TMP_ROOT_FALLBACK/positions.tsv"
+      col_index=$((col_index + 1))
+    done < "$TMP_ROOT_FALLBACK/depths.tsv"
+  done
+
+  # Draw edges first (under nodes).
+  printf '%s' "$graph_json" | jq -r '.[] | .name as $n | .depends_on // [] | .[] | "\($n)\t\(.)"' \
+    | while IFS=$'\t' read -r child parent; do
+      local cx cy px py
+      cx=$(awk -F'\t' -v n="$child" '$1==n {print $2+70}' "$TMP_ROOT_FALLBACK/positions.tsv")
+      cy=$(awk -F'\t' -v n="$child" '$1==n {print $3+20}' "$TMP_ROOT_FALLBACK/positions.tsv")
+      px=$(awk -F'\t' -v n="$parent" '$1==n {print $2+70}' "$TMP_ROOT_FALLBACK/positions.tsv")
+      py=$(awk -F'\t' -v n="$parent" '$1==n {print $3+20}' "$TMP_ROOT_FALLBACK/positions.tsv")
+      if [ -n "$cx" ] && [ -n "$px" ]; then
+        printf '        <line x1="%s" y1="%s" x2="%s" y2="%s" stroke="#666" stroke-width="1.5"/>\n' \
+          "$px" "$py" "$cx" "$cy"
+      fi
+  done
+
+  # Draw nodes with trust class.
+  while IFS=$'\t' read -r nm x y; do
+    local trust label fill stroke
+    local ap
+    ap=$("$SCRIPT_DIR/find-artifact.sh" "$nm" 30 --no-session-sync 2>/dev/null || true)
+    if [ -n "$ap" ]; then
+      trust=$(nano_artifact_trust "$ap" 2>/dev/null || echo "not_found")
+    else
+      trust="missing"
+    fi
+    case "$trust" in
+      verified)            fill="#1f3a2a"; stroke="#4ade80"; label="ok" ;;
+      integrity_missing)   fill="#3a321a"; stroke="#facc15"; label="?" ;;
+      integrity_mismatch)  fill="#3a1f24"; stroke="#fb7185"; label="!" ;;
+      *)                   fill="#2a2e38"; stroke="#666"; label="-" ;;
+    esac
+    local label_x label_y text_x text_y badge_x
+    label_x=$(( x + 5 ))
+    label_y=$(( y + 28 ))
+    text_x=$(( x + 70 ))
+    text_y=$(( y + 26 ))
+    badge_x=$(( x + 135 - 14 ))
+    local nm_esc
+    nm_esc=$(printf '%s' "$nm" | nano_attr_escape)
+    printf '        <g data-phase="%s" data-trust="%s">\n' "$nm_esc" "$(printf '%s' "$trust" | nano_attr_escape)"
+    printf '          <rect x="%s" y="%s" width="140" height="40" rx="6" fill="%s" stroke="%s" stroke-width="2"/>\n' \
+      "$x" "$y" "$fill" "$stroke"
+    printf '          <text x="%s" y="%s" font-family="monospace" font-size="13" fill="#f4f4f5" text-anchor="middle">%s</text>\n' \
+      "$text_x" "$text_y" "$(printf '%s' "$nm" | nano_html_escape)"
+    printf '          <text x="%s" y="%s" font-size="11" fill="%s">%s</text>\n' \
+      "$badge_x" "$label_y" "$stroke" "$(printf '%s' "$label" | nano_html_escape)"
+    printf '        </g>\n'
+  done < "$TMP_ROOT_FALLBACK/positions.tsv"
+
+  printf '      </svg>\n    </section>\n'
+}
+
 # ─── Atomic write ───────────────────────────────────────────
 # Codex PR 1 pass 8: a predictable temp name (HTML_PATH.tmp.$$) lets
 # an attacker pre-create a symlink at that path; the redirect would
@@ -781,30 +1222,89 @@ TMP_MFST=$(mktemp "$MANIFEST_PATH.tmp.XXXXXX" 2>/dev/null) || {
   echo "render-artifact: failed to create secure temp for manifest: $MANIFEST_PATH" >&2
   exit 4
 }
+# Scratch directory for renderer-internal state (stack layout, etc).
+# mktemp on macOS does not accept --tmpdir without -t; use the
+# portable directory form. Cleaned up via the EXIT trap below.
+TMP_ROOT_FALLBACK=$(mktemp -d "${TMPDIR:-/tmp}/render-artifact.XXXXXX") || {
+  echo "render-artifact: failed to create scratch dir" >&2
+  rm -f "$TMP_HTML" "$TMP_MFST"
+  exit 4
+}
+
 cleanup() {
   rm -f "$TMP_HTML" "$TMP_MFST" 2>/dev/null || true
+  rm -rf "$TMP_ROOT_FALLBACK" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-# ─── Manifest ───────────────────────────────────────────────
-# Build manifest first; if the HTML render fails we can still leave a
-# clean state. We move both files into place at the very end.
-
 CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Use jq to construct the manifest so all string escaping is correct.
+# ─── HTML ───────────────────────────────────────────────────
+# Render the HTML first. The body renderers for journal/stack
+# populate SOURCE_ARTIFACTS_JSON with the aggregated sources they
+# read, so the manifest below describes what was actually rendered.
+# A brace group is not a subshell in bash; SOURCE_ARTIFACTS_JSON
+# survives outside.
+if [ "$MANIFEST_ONLY" != true ]; then
+  {
+    nano_visual_page_start "$PHASE" "$TRUST" "static"
+
+    if [ "$SCHEMA_OK" = false ]; then
+      printf '    <div class="schema-warning" data-testid="schema-warning">%s</div>\n' \
+        "$(printf 'Schema validation: %s' "$SCHEMA_ERR" | nano_html_escape)"
+    fi
+
+    case "$PHASE" in
+      plan)     render_plan_body "$ART_PATH" ;;
+      think)    render_think_body "$ART_PATH" ;;
+      review)   render_review_body "$ART_PATH" ;;
+      security) render_security_body "$ART_PATH" ;;
+      qa)       render_qa_body "$ART_PATH" ;;
+      ship)     render_ship_body "$ART_PATH" ;;
+      journal)  render_journal_body "$JOURNAL_DATE" ;;
+      stack)    render_stack_body "$STACK_NAME" ;;
+    esac
+
+    # Journal and stack do not have a single source artifact path or
+    # integrity; the provenance footer points to the manifest only.
+    if [ -n "$ART_PATH" ]; then
+      nano_visual_page_end "$ART_PATH" "$MANIFEST_PATH" "$SRC_INTEGRITY"
+    else
+      nano_visual_page_end "(aggregated: ${PHASE})" "$MANIFEST_PATH" ""
+    fi
+  } > "$TMP_HTML"
+else
+  # In --manifest-only mode the body renderers still need to run so
+  # the manifest can describe the aggregated sources. Render to the
+  # bit bucket; the body still mutates SOURCE_ARTIFACTS_JSON.
+  case "$PHASE" in
+    journal) render_journal_body "$JOURNAL_DATE" >/dev/null ;;
+    stack)   render_stack_body "$STACK_NAME"   >/dev/null ;;
+  esac
+fi
+
+# ─── Manifest ───────────────────────────────────────────────
+# Phase renders set SOURCE_ARTIFACTS_JSON to a single-element array
+# from the source artifact; journal/stack body renderers set it to
+# the aggregated source list.
+if [ -z "${SOURCE_ARTIFACTS_JSON:-}" ]; then
+  SOURCE_ARTIFACTS_JSON=$(jq -n \
+    --arg src_phase "$ART_PHASE" \
+    --arg src_path "${ART_PATH:-}" \
+    --arg src_integrity "$SRC_INTEGRITY" \
+    --arg src_trust "$TRUST" \
+    '[{phase: $src_phase, path: $src_path, integrity: $src_integrity, trust: $src_trust}]')
+fi
+
 jq -n \
   --arg schema_version "1" \
-  --arg kind "phase" \
+  --arg kind "$MANIFEST_KIND" \
   --arg phase "$PHASE" \
   --argjson custom_phase false \
   --arg format "html" \
   --argjson interactive false \
   --argjson strict "$($STRICT && echo true || echo false)" \
-  --arg src_phase "$ART_PHASE" \
-  --arg src_path "$ART_PATH" \
-  --arg src_integrity "$SRC_INTEGRITY" \
-  --arg src_trust "$TRUST" \
+  --argjson source_artifacts "$SOURCE_ARTIFACTS_JSON" \
   --arg output_path "$HTML_PATH" \
   --arg renderer_name "$NANO_VISUAL_RENDERER_NAME" \
   --arg renderer_version "$NANO_VISUAL_RENDERER_VERSION" \
@@ -819,12 +1319,7 @@ jq -n \
     format: $format,
     interactive: $interactive,
     strict: $strict,
-    source_artifacts: [{
-      phase: $src_phase,
-      path: $src_path,
-      integrity: $src_integrity,
-      trust: $src_trust
-    }],
+    source_artifacts: $source_artifacts,
     output_path: $output_path,
     renderer: { name: $renderer_name, version: $renderer_version },
     schema_valid: $schema_valid,
@@ -842,27 +1337,6 @@ if [ "$MANIFEST_ONLY" = true ]; then
   echo "$MANIFEST_PATH"
   exit 0
 fi
-
-# ─── HTML ───────────────────────────────────────────────────
-{
-  nano_visual_page_start "$PHASE" "$TRUST" "static"
-
-  if [ "$SCHEMA_OK" = false ]; then
-    printf '    <div class="schema-warning" data-testid="schema-warning">%s</div>\n' \
-      "$(printf 'Schema validation: %s' "$SCHEMA_ERR" | nano_html_escape)"
-  fi
-
-  case "$PHASE" in
-    plan)     render_plan_body "$ART_PATH" ;;
-    think)    render_think_body "$ART_PATH" ;;
-    review)   render_review_body "$ART_PATH" ;;
-    security) render_security_body "$ART_PATH" ;;
-    qa)       render_qa_body "$ART_PATH" ;;
-    ship)     render_ship_body "$ART_PATH" ;;
-  esac
-
-  nano_visual_page_end "$ART_PATH" "$MANIFEST_PATH" "$SRC_INTEGRITY"
-} > "$TMP_HTML"
 
 mv "$TMP_HTML" "$HTML_PATH"
 mv "$TMP_MFST" "$MANIFEST_PATH"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -501,6 +501,28 @@ _latest_safe_artifact_for_stack() {
   [ -d "$dir" ] || return 0
   local project_root
   project_root="$(pwd)"
+  # Codex PR 3 pass 13: in a shared store (e.g. $HOME/.nanostack),
+  # other projects' tampered artifacts must not pollute this
+  # project's stack rows. Surface tamper aggressively ONLY when the
+  # store is project-local (the git-root/.nanostack path); for a
+  # shared store, require .project to match. Canonicalize both
+  # paths so macOS /tmp -> /private/tmp does not falsely report a
+  # mismatch.
+  local store_is_local=false
+  local git_root store_canon root_canon
+  git_root=$(git -C "$project_root" rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$git_root" ]; then
+    if command -v realpath >/dev/null 2>&1; then
+      store_canon=$(realpath "$NANOSTACK_STORE" 2>/dev/null || echo "$NANOSTACK_STORE")
+      root_canon=$(realpath "$git_root" 2>/dev/null || echo "$git_root")
+    else
+      store_canon="$NANOSTACK_STORE"
+      root_canon="$git_root"
+    fi
+    if [ "$store_canon" = "$root_canon/.nanostack" ]; then
+      store_is_local=true
+    fi
+  fi
   # shellcheck disable=SC2012
   local candidates
   candidates=$(ls -1t "$dir"/*.json 2>/dev/null | head -30)
@@ -510,11 +532,11 @@ _latest_safe_artifact_for_stack() {
     [ -z "$f" ] && continue
     local t
     t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
-    # Codex PR 3 pass 7: surface BOTH integrity_missing and
-    # integrity_mismatch before the project filter. A combined
-    # .integrity-strip + .project-flip attack would otherwise leave
-    # the artifact as "missing" and slip past aggregate --strict.
-    if [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; then
+    # In a project-local store, any tampered file is suspect because
+    # no one else writes there. In a shared store, only consider it
+    # ours if .project matches.
+    if [ "$store_is_local" = true ] && \
+       { [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; }; then
       printf '%s\n' "$f"
       return 0
     fi
@@ -938,6 +960,27 @@ render_journal_body() {
     local dir="$NANOSTACK_STORE/$ph"
     [ -d "$dir" ] || return 0
     local project_root="$project_path"
+    # Codex PR 3 pass 13: only surface tamper aggressively when the
+    # store is project-local (git-root/.nanostack). For a shared
+    # $HOME/.nanostack store, require .project to match so other
+    # projects' tampered artifacts cannot pollute this journal.
+    # Canonicalize both paths via realpath so macOS /tmp ->
+    # /private/tmp does not produce a false mismatch.
+    local store_is_local=false
+    local git_root store_canon root_canon
+    git_root=$(git -C "$project_root" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$git_root" ]; then
+      if command -v realpath >/dev/null 2>&1; then
+        store_canon=$(realpath "$NANOSTACK_STORE" 2>/dev/null || echo "$NANOSTACK_STORE")
+        root_canon=$(realpath "$git_root" 2>/dev/null || echo "$git_root")
+      else
+        store_canon="$NANOSTACK_STORE"
+        root_canon="$git_root"
+      fi
+      if [ "$store_canon" = "$root_canon/.nanostack" ]; then
+        store_is_local=true
+      fi
+    fi
     # shellcheck disable=SC2012
     local candidates
     candidates=$(ls -1 "$dir"/"$dc"-*.json 2>/dev/null | sort -r)
@@ -945,20 +988,13 @@ render_journal_body() {
     local f
     while IFS= read -r f; do
       [ -z "$f" ] && continue
-      # Trust check first: a same-day candidate whose hash does not
-      # match must surface as tampered even if .project changed.
-      # Codex PR 3 pass 7: surface BOTH integrity_missing and
-      # integrity_mismatch so a combined .integrity-strip +
-      # .project-flip cannot leave the row as "missing" and slip past
-      # aggregate --strict.
       local t
       t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
-      if [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; then
+      if [ "$store_is_local" = true ] && \
+         { [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; }; then
         printf '%s\n' "$f"
         return 0
       fi
-      # Otherwise require the project to match so foreign artifacts
-      # sharing the store do not pollute our journal.
       if jq -e --arg p "$project_root" '.project == $p' "$f" >/dev/null 2>&1; then
         printf '%s\n' "$f"
         return 0

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -489,6 +489,40 @@ HTML
   printf '    </section>\n'
 }
 
+# Shared helper: find the latest artifact for <phase>, surfacing
+# tampered candidates even when their .project no longer matches.
+# Used by stack (no date filter) and indirectly by journal (which
+# has its own helper that adds the date prefix). Codex PR 3 pass 6
+# extended the tampered-surface logic from journal to stack so
+# `stack --strict` cannot be bypassed by flipping .project.
+_latest_safe_artifact_for_stack() {
+  local ph="$1"
+  local dir="$NANOSTACK_STORE/$ph"
+  [ -d "$dir" ] || return 0
+  local project_root
+  project_root="$(pwd)"
+  # shellcheck disable=SC2012
+  local candidates
+  candidates=$(ls -1t "$dir"/*.json 2>/dev/null | head -30)
+  [ -z "$candidates" ] && return 0
+  local f
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local t
+    t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
+    if [ "$t" = "integrity_mismatch" ]; then
+      printf '%s\n' "$f"
+      return 0
+    fi
+    if jq -e --arg p "$project_root" '.project == $p' "$f" >/dev/null 2>&1; then
+      printf '%s\n' "$f"
+      return 0
+    fi
+  done <<EOF
+$candidates
+EOF
+}
+
 render_think_body() {
   local artifact="$1"
   local norm
@@ -1078,18 +1112,36 @@ render_stack_body() {
     return 0
   fi
 
-  # Codex PR 3 pass 5: a user-supplied stack file with a malformed
-  # phase_graph (object, array of scalars, missing .name) would crash
-  # the renderer with an undocumented jq error under set -e. Validate
-  # shape upfront: graph must be an array of objects each with a
-  # string .name and (optional) array .depends_on. On failure, render
-  # a "Stack invalid" notice and bail gracefully.
-  if ! printf '%s' "$graph_json" | jq -e '
-    type == "array"
-    and all(.[]; type == "object" and (.name | type == "string"))
+  # Codex PR 3 pass 5+6: tighten graph validation. Required shape:
+  #   - non-empty array
+  #   - each entry is an object
+  #   - .name is a non-empty string
+  #   - .depends_on is an array of strings (default [])
+  #   - every name in depends_on exists as a node name (no dangling
+  #     references; cycle detection is bounded by the SVG loop cap)
+  # On failure render a "Stack invalid" notice with the validation
+  # reason and bail gracefully.
+  local graph_validation_error=""
+  if ! printf '%s' "$graph_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+    graph_validation_error="phase_graph must be a non-empty array"
+  elif ! printf '%s' "$graph_json" | jq -e '
+    all(.[]; type == "object"
+              and (.name | type == "string") and (.name | length > 0)
+              and ((.depends_on // []) | type == "array")
+              and ((.depends_on // []) | all(type == "string")))
   ' >/dev/null 2>&1; then
-    printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack definition for <code>%s</code> has a malformed <code>phase_graph</code>. Expected an array of <code>{name, depends_on}</code> objects.</p>\n    </section>\n' \
-      "$(printf '%s' "$name" | nano_html_escape)"
+    graph_validation_error="every node needs string .name and array-of-string .depends_on"
+  elif ! printf '%s' "$graph_json" | jq -e '
+    . as $g
+    | ([.[].name] | unique) as $names
+    | all(.[]; (.depends_on // []) | all(. as $d | $names | index($d) != null))
+  ' >/dev/null 2>&1; then
+    graph_validation_error="phase_graph has a dangling dependency (depends_on points at an undeclared phase)"
+  fi
+  if [ -n "$graph_validation_error" ]; then
+    printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack definition for <code>%s</code> has a malformed <code>phase_graph</code>: %s.</p>\n    </section>\n' \
+      "$(printf '%s' "$name" | nano_html_escape)" \
+      "$(printf '%s' "$graph_validation_error" | nano_html_escape)"
     SOURCE_ARTIFACTS_JSON='[]'
     return 0
   fi
@@ -1112,7 +1164,9 @@ render_stack_body() {
     local nname deps_csv art_path trust label
     nname=$(printf '%s' "$node" | jq -r '.name')
     deps_csv=$(printf '%s' "$node" | jq -r '.depends_on // [] | join(", ")')
-    art_path=$("$SCRIPT_DIR/find-artifact.sh" "$nname" 30 --no-session-sync 2>/dev/null || true)
+    # Use the tampered-aware lookup so a flipped .project cannot hide
+    # a tampered artifact as "missing" (codex PR 3 pass 6).
+    art_path=$(_latest_safe_artifact_for_stack "$nname")
     if [ -n "$art_path" ] && [ -f "$art_path" ]; then
       art_path=$(nano_resolve_abs "$art_path")
       trust=$(nano_artifact_trust "$art_path" 2>/dev/null || echo "not_found")
@@ -1160,7 +1214,7 @@ render_stack_body() {
   while IFS= read -r nm; do
     [ -z "$nm" ] && continue
     local ap tr ig
-    ap=$("$SCRIPT_DIR/find-artifact.sh" "$nm" 30 --no-session-sync 2>/dev/null || true)
+    ap=$(_latest_safe_artifact_for_stack "$nm")
     if [ -n "$ap" ] && [ -f "$ap" ]; then
       ap=$(nano_resolve_abs "$ap")
       tr=$(nano_artifact_trust "$ap" 2>/dev/null || echo "not_found")
@@ -1264,11 +1318,12 @@ render_stack_svg() {
       fi
   done
 
-  # Draw nodes with trust class.
+  # Draw nodes with trust class. Tampered-aware lookup so a flipped
+  # .project surfaces visually rather than appearing as missing.
   while IFS=$'\t' read -r nm x y; do
     local trust label fill stroke
     local ap
-    ap=$("$SCRIPT_DIR/find-artifact.sh" "$nm" 30 --no-session-sync 2>/dev/null || true)
+    ap=$(_latest_safe_artifact_for_stack "$nm")
     if [ -n "$ap" ]; then
       trust=$(nano_artifact_trust "$ap" 2>/dev/null || echo "not_found")
     else

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -510,7 +510,11 @@ _latest_safe_artifact_for_stack() {
     [ -z "$f" ] && continue
     local t
     t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
-    if [ "$t" = "integrity_mismatch" ]; then
+    # Codex PR 3 pass 7: surface BOTH integrity_missing and
+    # integrity_mismatch before the project filter. A combined
+    # .integrity-strip + .project-flip attack would otherwise leave
+    # the artifact as "missing" and slip past aggregate --strict.
+    if [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; then
       printf '%s\n' "$f"
       return 0
     fi
@@ -943,9 +947,13 @@ render_journal_body() {
       [ -z "$f" ] && continue
       # Trust check first: a same-day candidate whose hash does not
       # match must surface as tampered even if .project changed.
+      # Codex PR 3 pass 7: surface BOTH integrity_missing and
+      # integrity_mismatch so a combined .integrity-strip +
+      # .project-flip cannot leave the row as "missing" and slip past
+      # aggregate --strict.
       local t
       t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
-      if [ "$t" = "integrity_mismatch" ]; then
+      if [ "$t" = "integrity_mismatch" ] || [ "$t" = "integrity_missing" ]; then
         printf '%s\n' "$f"
         return 0
       fi
@@ -1137,6 +1145,42 @@ render_stack_body() {
     | all(.[]; (.depends_on // []) | all(. as $d | $names | index($d) != null))
   ' >/dev/null 2>&1; then
     graph_validation_error="phase_graph has a dangling dependency (depends_on points at an undeclared phase)"
+  else
+    # Cycle detection via iterative Kahn-style topological pass in
+    # bash. The depth resolver in render_stack_svg cannot draw a
+    # cyclic graph; rather than leave nodes out of the SVG silently,
+    # reject the stack up front (codex PR 3 pass 7). For each round,
+    # remove nodes whose deps are all in `done`; if a round makes no
+    # progress while nodes remain, declare a cycle.
+    local _cycle_done=" " _cycle_pending _cycle_total _cycle_round _cycle_progressed
+    _cycle_total=$(printf '%s' "$graph_json" | jq -r 'length')
+    _cycle_pending=$(printf '%s' "$graph_json" | jq -r '.[].name' | tr '\n' ' ')
+    for _cycle_round in $(seq 1 "$((_cycle_total + 1))"); do
+      _cycle_progressed=0
+      local _cycle_next=""
+      for _n in $_cycle_pending; do
+        local _deps _ok=1
+        _deps=$(printf '%s' "$graph_json" | jq -r --arg n "$_n" '.[] | select(.name == $n) | .depends_on // [] | .[]')
+        for _d in $_deps; do
+          case "$_cycle_done" in
+            *" $_d "*) ;;
+            *) _ok=0; break ;;
+          esac
+        done
+        if [ "$_ok" = "1" ]; then
+          _cycle_done="$_cycle_done$_n "
+          _cycle_progressed=1
+        else
+          _cycle_next="$_cycle_next$_n "
+        fi
+      done
+      _cycle_pending="$_cycle_next"
+      [ "$_cycle_progressed" = "0" ] && break
+      [ -z "$_cycle_pending" ] && break
+    done
+    if [ -n "$_cycle_pending" ]; then
+      graph_validation_error="phase_graph contains a cycle (cannot draw the DAG); unresolved: $(echo $_cycle_pending | sed 's/ *$//')"
+    fi
   fi
   if [ -n "$graph_validation_error" ]; then
     printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack definition for <code>%s</code> has a malformed <code>phase_graph</code>: %s.</p>\n    </section>\n' \

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1345,7 +1345,20 @@ render_stack_body() {
   # escaping. Codex PR 3 pass 2: the previous awk builder only
   # escaped double quotes; a project path with a backslash or
   # control character produced invalid JSON.
+  #
+  # Codex PR 3 pass 16: include the stack definition file itself as
+  # the first source so manifest consumers can spot a change to the
+  # graph. Stack files don't carry .integrity so we record them as
+  # not_applicable (trust is meaningful only for artifact JSON).
   sources='[]'
+  if [ -n "$stack_file" ] && [ -f "$stack_file" ]; then
+    local sf_abs
+    sf_abs=$(nano_resolve_abs "$stack_file")
+    sources=$(printf '%s' "$sources" | jq -c \
+      --arg phase "stack:$name" \
+      --arg path "$sf_abs" \
+      '. + [{phase: $phase, path: $path, integrity: "", trust: "not_applicable"}]')
+  fi
   while IFS= read -r nm; do
     [ -z "$nm" ] && continue
     local ap tr ig

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -523,9 +523,14 @@ _latest_safe_artifact_for_stack() {
       store_is_local=true
     fi
   fi
+  # Codex PR 3 pass 14: do NOT cap the candidate list before the
+  # project filter. In a shared store with many newer other-project
+  # artifacts, the cap would hide this project's older legitimate
+  # (or tampered) artifact and the stack row would render as missing.
+  # The early-return inside the loop keeps the walk bounded.
   # shellcheck disable=SC2012
   local candidates
-  candidates=$(ls -1t "$dir"/*.json 2>/dev/null | head -30)
+  candidates=$(ls -1t "$dir"/*.json 2>/dev/null)
   [ -z "$candidates" ] && return 0
   local f
   while IFS= read -r f; do

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -886,21 +886,44 @@ render_journal_body() {
   # find the latest artifact for <phase> on <date>. Uses filename
   # convention `YYYYMMDD-HHMMSS.json` under `.nanostack/<phase>/`.
   # Returns the path on stdout (empty if none).
+  #
+  # Codex PR 3 pass 5 caught a strict-mode bypass: if a same-day
+  # artifact was tampered so .project no longer matches, the project
+  # filter dropped it and the row rendered as "missing". Aggregate
+  # --strict allows "missing" (phase not run yet), so a tampered file
+  # would escape the trust check entirely. To close that gap, surface
+  # ANY same-day candidate whose integrity is broken even when its
+  # .project field flipped: the trust helper still detects the hash
+  # mismatch and the journal row gets data-trust="integrity_mismatch".
   _journal_latest_on_date() {
     local ph="$1" dc="$2"
     local dir="$NANOSTACK_STORE/$ph"
     [ -d "$dir" ] || return 0
     local project_root="$project_path"
     # shellcheck disable=SC2012
-    ls -1 "$dir"/"$dc"-*.json 2>/dev/null \
-      | sort -r \
-      | while IFS= read -r f; do
-          # find-artifact.sh's project filter: .project must match.
-          if jq -e --arg p "$project_root" '.project == $p' "$f" >/dev/null 2>&1; then
-            printf '%s\n' "$f"
-            return
-          fi
-        done | head -1
+    local candidates
+    candidates=$(ls -1 "$dir"/"$dc"-*.json 2>/dev/null | sort -r)
+    [ -z "$candidates" ] && return 0
+    local f
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      # Trust check first: a same-day candidate whose hash does not
+      # match must surface as tampered even if .project changed.
+      local t
+      t=$(nano_artifact_trust "$f" 2>/dev/null || echo "not_found")
+      if [ "$t" = "integrity_mismatch" ]; then
+        printf '%s\n' "$f"
+        return 0
+      fi
+      # Otherwise require the project to match so foreign artifacts
+      # sharing the store do not pollute our journal.
+      if jq -e --arg p "$project_root" '.project == $p' "$f" >/dev/null 2>&1; then
+        printf '%s\n' "$f"
+        return 0
+      fi
+    done <<EOF
+$candidates
+EOF
   }
 
   # Build the list of phases to enumerate. Use the phase registry
@@ -1050,6 +1073,22 @@ render_stack_body() {
   fi
   if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
     printf '    <section class="card">\n      <h2>Stack not found</h2>\n      <p>No stack definition found for <code>%s</code>.</p>\n    </section>\n' \
+      "$(printf '%s' "$name" | nano_html_escape)"
+    SOURCE_ARTIFACTS_JSON='[]'
+    return 0
+  fi
+
+  # Codex PR 3 pass 5: a user-supplied stack file with a malformed
+  # phase_graph (object, array of scalars, missing .name) would crash
+  # the renderer with an undocumented jq error under set -e. Validate
+  # shape upfront: graph must be an array of objects each with a
+  # string .name and (optional) array .depends_on. On failure, render
+  # a "Stack invalid" notice and bail gracefully.
+  if ! printf '%s' "$graph_json" | jq -e '
+    type == "array"
+    and all(.[]; type == "object" and (.name | type == "string"))
+  ' >/dev/null 2>&1; then
+    printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack definition for <code>%s</code> has a malformed <code>phase_graph</code>. Expected an array of <code>{name, depends_on}</code> objects.</p>\n    </section>\n' \
       "$(printf '%s' "$name" | nano_html_escape)"
     SOURCE_ARTIFACTS_JSON='[]'
     return 0

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1031,24 +1031,27 @@ EOF
       integrity_mismatch)  status_label="tampered"; sev_class="sev-bad" ;;
       *)                   status_label="unreadable"; sev_class="sev-warn" ;;
     esac
-    # Phase-specific summary line.
+    # Phase-specific summary line. Each jq call appends `|| echo
+    # "(unreadable)"` so a malformed artifact (which already surfaced
+    # as integrity_missing above) does not abort the whole journal
+    # render. Codex PR 3 pass 9 caught the unguarded reads.
     case "$ph" in
-      think)   summary=$(jq -r '.summary.narrowest_wedge // .summary.value_proposition // "(no summary)"' "$art_path" 2>/dev/null) ;;
-      plan)    summary=$(jq -r '.summary.goal // "(no summary)"' "$art_path" 2>/dev/null) ;;
-      review)  summary=$(jq -r '"\(.summary.blocking // 0) blocking / \(.summary.should_fix // 0) should-fix / \(.summary.nitpicks // 0) nitpicks"' "$art_path" 2>/dev/null) ;;
-      security) summary=$(jq -r '"\(.summary.critical // 0) critical / \(.summary.high // 0) high / \(.summary.total_findings // 0) total"' "$art_path" 2>/dev/null) ;;
-      qa)      summary=$(jq -r '"\(.summary.tests_passed // 0)/\(.summary.tests_run // 0) tests / \(.summary.bugs_found // 0) bugs"' "$art_path" 2>/dev/null) ;;
+      think)   summary=$(jq -r '.summary.narrowest_wedge // .summary.value_proposition // "(no summary)"' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
+      plan)    summary=$(jq -r '.summary.goal // "(no summary)"' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
+      review)  summary=$(jq -r '"\(.summary.blocking // 0) blocking / \(.summary.should_fix // 0) should-fix / \(.summary.nitpicks // 0) nitpicks"' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
+      security) summary=$(jq -r '"\(.summary.critical // 0) critical / \(.summary.high // 0) high / \(.summary.total_findings // 0) total"' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
+      qa)      summary=$(jq -r '"\(.summary.tests_passed // 0)/\(.summary.tests_run // 0) tests / \(.summary.bugs_found // 0) bugs"' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
       ship)
-        if [ "$(jq -r '.run_mode // ""' "$art_path" 2>/dev/null)" = "report_only" ]; then
+        if [ "$(jq -r '.run_mode // ""' "$art_path" 2>/dev/null || echo "")" = "report_only" ]; then
           summary="report_only"
         else
-          summary=$(jq -r '"PR #\(.summary.pr_number // "?") · \(.summary.status // "unknown")"' "$art_path" 2>/dev/null)
+          summary=$(jq -r '"PR #\(.summary.pr_number // "?") · \(.summary.status // "unknown")"' "$art_path" 2>/dev/null || echo "(unreadable)")
         fi
         ;;
-      *)       summary=$(jq -r '.summary | (if type == "object" then (.summary // (. | tostring)) else . end)' "$art_path" 2>/dev/null) ;;
+      *)       summary=$(jq -r '.summary | (if type == "object" then (.summary // (. | tostring)) else . end)' "$art_path" 2>/dev/null || echo "(unreadable)") ;;
     esac
     local integrity
-    integrity=$(jq -r '.integrity // ""' "$art_path" 2>/dev/null)
+    integrity=$(jq -r '.integrity // ""' "$art_path" 2>/dev/null || echo "")
     printf '        <li class="timeline-item %s" data-phase="%s" data-trust="%s">' \
       "$sev_class" \
       "$(printf '%s' "$ph" | nano_attr_escape)" \
@@ -1102,9 +1105,17 @@ render_stack_body() {
   local description=""
 
   if [ -n "$stack_file" ]; then
+    # Codex PR 3 pass 9: the metadata reads ran without `|| true`,
+    # so a malformed stack.json aborted the render before the
+    # documented "Stack invalid" notice could be emitted. Guard
+    # every jq read on the user-controlled file.
     graph_json=$(jq -c '.phase_graph' "$stack_file" 2>/dev/null || echo "")
-    display_name=$(jq -r '.display_name // .name' "$stack_file" 2>/dev/null)
-    description=$(jq -r '.description // ""' "$stack_file" 2>/dev/null)
+    display_name=$(jq -r '.display_name // .name // ""' "$stack_file" 2>/dev/null || echo "")
+    description=$(jq -r '.description // ""' "$stack_file" 2>/dev/null || echo "")
+    # If even the metadata reads return empty AND the graph is also
+    # empty, fall through to the registry path below; if metadata
+    # came back but graph did not, the "Stack invalid" notice fires.
+    [ -z "$display_name" ] && display_name="$name"
   fi
 
   if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1298,7 +1298,11 @@ render_stack_body() {
     if [ -n "$ap" ] && [ -f "$ap" ]; then
       ap=$(nano_resolve_abs "$ap")
       tr=$(nano_artifact_trust "$ap" 2>/dev/null || echo "not_found")
-      ig=$(jq -r '.integrity // ""' "$ap" 2>/dev/null)
+      # Codex PR 3 pass 11: a truncated artifact would already
+      # surface as integrity_missing above, but the unguarded jq
+      # read below aborted the whole stack render under set -e
+      # before the manifest could be written. Guard with `|| echo`.
+      ig=$(jq -r '.integrity // ""' "$ap" 2>/dev/null || echo "")
     else
       ap=""; tr="missing"; ig=""
     fi

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1104,7 +1104,9 @@ render_stack_body() {
   local display_name="$name"
   local description=""
 
+  local named_stack_file_present=false
   if [ -n "$stack_file" ]; then
+    named_stack_file_present=true
     # Codex PR 3 pass 9: the metadata reads ran without `|| true`,
     # so a malformed stack.json aborted the render before the
     # documented "Stack invalid" notice could be emitted. Guard
@@ -1112,14 +1114,25 @@ render_stack_body() {
     graph_json=$(jq -c '.phase_graph' "$stack_file" 2>/dev/null || echo "")
     display_name=$(jq -r '.display_name // .name // ""' "$stack_file" 2>/dev/null || echo "")
     description=$(jq -r '.description // ""' "$stack_file" 2>/dev/null || echo "")
-    # If even the metadata reads return empty AND the graph is also
-    # empty, fall through to the registry path below; if metadata
-    # came back but graph did not, the "Stack invalid" notice fires.
     [ -z "$display_name" ] && display_name="$name"
   fi
 
+  # Codex PR 3 pass 10: when a NAMED stack file exists but is
+  # malformed (missing .phase_graph), do NOT fall back to the
+  # project/default graph. That fallback would render an unrelated
+  # graph under the requested stack's name and hide the broken
+  # definition. The fallback is only for the bare `stack` / `stack
+  # default` form when no stack file was found at all.
+  if [ "$named_stack_file_present" = true ] && { [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; }; then
+    printf '    <section class="card">\n      <h2>Stack invalid</h2>\n      <p>The stack file <code>%s</code> exists but its <code>phase_graph</code> is missing or unreadable.</p>\n    </section>\n' \
+      "$(printf '%s' "$stack_file" | nano_html_escape)"
+    SOURCE_ARTIFACTS_JSON='[]'
+    return 0
+  fi
+
   if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
-    # Fall back to project's phase_graph via the registry.
+    # Fall back to project's phase_graph via the registry. This
+    # branch only fires when no named stack file was found.
     if declare -F nano_phase_graph_json >/dev/null 2>&1; then
       graph_json=$(nano_phase_graph_json 2>/dev/null || echo "")
     fi

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -265,18 +265,17 @@ if [ -n "$OUT_PATH" ]; then
   nano_visual_assert_safe_output "$OUT_PATH"
   HTML_PATH="$OUT_PATH"
 else
+  # Codex PR 3 pass 4: do not mkdir under visual/ before the descend
+  # safety check runs. A symlinked visual/stack or visual/journal
+  # would otherwise be followed and the renderer would write the
+  # node directory outside the root before exit 4 fires. The post-
+  # validation `mkdir -p "$(dirname "$HTML_PATH")"` later in the
+  # script creates the directory only after the descend check
+  # confirms no component is a symlink.
   case "$PHASE" in
-    journal)
-      mkdir -p "$(nano_visual_root)/journal"
-      HTML_PATH="$(nano_visual_root)/journal/${TS}-journal-${JOURNAL_DATE}.html"
-      ;;
-    stack)
-      mkdir -p "$(nano_visual_root)/stack/$STACK_NAME"
-      HTML_PATH="$(nano_visual_root)/stack/$STACK_NAME/${TS}-stack-${STACK_NAME}.html"
-      ;;
-    *)
-      HTML_PATH=$(nano_visual_html_path "$PHASE" "$TS")
-      ;;
+    journal) HTML_PATH="$(nano_visual_root)/journal/${TS}-journal-${JOURNAL_DATE}.html" ;;
+    stack)   HTML_PATH="$(nano_visual_root)/stack/$STACK_NAME/${TS}-stack-${STACK_NAME}.html" ;;
+    *)       HTML_PATH=$(nano_visual_html_path "$PHASE" "$TS") ;;
   esac
 fi
 case "$PHASE" in
@@ -930,17 +929,14 @@ render_journal_body() {
     esac
     # Find the latest artifact for this phase on the requested date.
     # _journal_latest_on_date filters by filename prefix YYYYMMDD,
-    # which matches save-artifact.sh's naming convention. Falls back
-    # to find-artifact.sh (last 30 days) when no date prefix matches,
-    # because legacy artifacts may have different shapes. The first
-    # match wins.
+    # which matches save-artifact.sh's naming convention. Codex PR 3
+    # pass 4 caught the gap: an earlier "fall back to find-artifact.sh
+    # for today" branch would return any artifact in the last 30
+    # days, so a fresh day's journal showed yesterday's artifacts as
+    # present. Strict date filtering now applies to both --today and
+    # --date so the journal banner is honest.
     local art_path trust status_label sev_class summary
     art_path=$(_journal_latest_on_date "$ph" "$date_compact")
-    if [ -z "$art_path" ] && [ "$date" = "$(date -u +%Y-%m-%d)" ]; then
-      # For today, fall back to find-artifact.sh to catch artifacts
-      # not yet committed to disk under the convention.
-      art_path=$("$SCRIPT_DIR/find-artifact.sh" "$ph" 30 --no-session-sync 2>/dev/null || true)
-    fi
     if [ -z "$art_path" ] || [ ! -f "$art_path" ]; then
       status_label="missing"
       sev_class="sev-warn"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -166,6 +166,20 @@ case "$PHASE" in
     ;;
 esac
 
+# Default the journal date to today if neither --today nor --date
+# was supplied (codex PR 3 pass 2: bare `journal` left this empty
+# and the page banner read "journal · " with the filename containing
+# a stray dash).
+if [ "$PHASE" = "journal" ] && [ -z "$JOURNAL_DATE" ]; then
+  JOURNAL_DATE="$(date -u +%Y-%m-%d)"
+fi
+# Stack name defaults to "default" so a bare `render-artifact.sh
+# stack` exercises the project's phase_graph without forcing the
+# caller to name a stack.
+if [ "$PHASE" = "stack" ] && [ -z "$STACK_NAME" ]; then
+  STACK_NAME="default"
+fi
+
 # Journal and stack do not source from a single phase artifact; they
 # aggregate. Skip the per-phase trust/schema branch for them and use
 # a sentinel ART_PHASE so the manifest writer below works uniformly.
@@ -1103,9 +1117,13 @@ render_stack_body() {
   # We compute levels with jq + bash and lay out nodes on a grid.
   render_stack_svg "$graph_json"
 
-  # Build sources array for the manifest. Reuse the table loop logic
-  # via a second jq pass; cheaper than capturing the loop output.
-  printf '%s' "$graph_json" | jq -r '.[].name' | while IFS= read -r nm; do
+  # Build sources array for the manifest using jq for correct JSON
+  # escaping. Codex PR 3 pass 2: the previous awk builder only
+  # escaped double quotes; a project path with a backslash or
+  # control character produced invalid JSON.
+  sources='[]'
+  while IFS= read -r nm; do
+    [ -z "$nm" ] && continue
     local ap tr ig
     ap=$("$SCRIPT_DIR/find-artifact.sh" "$nm" 30 --no-session-sync 2>/dev/null || true)
     if [ -n "$ap" ] && [ -f "$ap" ]; then
@@ -1115,18 +1133,13 @@ render_stack_body() {
     else
       ap=""; tr="missing"; ig=""
     fi
-    printf '%s\t%s\t%s\t%s\n' "$nm" "$ap" "$ig" "$tr"
-  done > "$TMP_ROOT_FALLBACK/sources.tsv"
-  if [ ! -d "${TMP_ROOT_FALLBACK:-}" ]; then
-    : # safe default; sources stays []
-  else
-    sources=$(awk -F'\t' '
-      BEGIN { printf "[" }
-      NR>1 { printf "," }
-      { gsub(/"/,"\\\"",$1); gsub(/"/,"\\\"",$2); gsub(/"/,"\\\"",$3); gsub(/"/,"\\\"",$4); printf "{\"phase\":\"%s\",\"path\":\"%s\",\"integrity\":\"%s\",\"trust\":\"%s\"}",$1,$2,$3,$4 }
-      END { printf "]" }
-    ' "$TMP_ROOT_FALLBACK/sources.tsv")
-  fi
+    sources=$(printf '%s' "$sources" | jq -c \
+      --arg phase "$nm" \
+      --arg path "$ap" \
+      --arg integrity "$ig" \
+      --arg trust "$tr" \
+      '. + [{phase: $phase, path: $path, integrity: $integrity, trust: $trust}]')
+  done < <(printf '%s' "$graph_json" | jq -r '.[].name')
 
   SOURCE_ARTIFACTS_JSON="$sources"
 }
@@ -1373,16 +1386,40 @@ jq -n \
 if [ "$MANIFEST_ONLY" = true ]; then
   # Codex PR 1 pass 9: the manifest-only branch must not leave the
   # mktemp'd HTML temp file behind. Clean it before disabling the
-  # cleanup trap.
+  # cleanup trap. Same for the scratch dir (PR 3 pass 2).
   rm -f "$TMP_HTML"
+  rm -rf "$TMP_ROOT_FALLBACK"
   mv "$TMP_MFST" "$MANIFEST_PATH"
   trap - EXIT
   echo "$MANIFEST_PATH"
   exit 0
 fi
 
+# Strict mode for aggregate renders: enforce after sources are
+# collected. Any source whose trust is not "verified" rejects the
+# render. Codex PR 3 pass 2 caught that --strict with a journal or
+# stack produced a "strict: true" manifest while skipping the trust
+# check entirely.
+if [ "$STRICT" = true ] && { [ "$PHASE" = "journal" ] || [ "$PHASE" = "stack" ]; }; then
+  unverified=$(printf '%s' "$SOURCE_ARTIFACTS_JSON" | jq -r \
+    '.[] | select(.trust != "verified" and .trust != "missing") | "\(.phase): \(.trust)"' 2>/dev/null)
+  # "missing" sources are an expected aggregate state (the user has
+  # not run that phase yet). "integrity_missing" and
+  # "integrity_mismatch" are the actually-suspect cases.
+  bad=$(printf '%s' "$SOURCE_ARTIFACTS_JSON" | jq -r \
+    '.[] | select(.trust == "integrity_missing" or .trust == "integrity_mismatch") | "\(.phase): \(.trust)"' 2>/dev/null)
+  if [ -n "$bad" ]; then
+    echo "render-artifact: --strict requires every aggregated source to be verified; failing on:" >&2
+    printf '  %s\n' $bad >&2
+    exit 3
+  fi
+fi
+
 mv "$TMP_HTML" "$HTML_PATH"
 mv "$TMP_MFST" "$MANIFEST_PATH"
+# Codex PR 3 pass 2: the scratch dir was leaking on every successful
+# render because the cleanup trap was unset before it was removed.
+rm -rf "$TMP_ROOT_FALLBACK"
 trap - EXIT
 
 echo "$HTML_PATH"

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1131,9 +1131,12 @@ render_stack_body() {
   fi
 
   if [ -z "$graph_json" ] || [ "$graph_json" = "null" ]; then
-    # Fall back to project's phase_graph via the registry. This
-    # branch only fires when no named stack file was found.
-    if declare -F nano_phase_graph_json >/dev/null 2>&1; then
+    # Fall back to project's phase_graph via the registry, but ONLY
+    # for the bare `stack` / `stack default` form. A named stack
+    # that does not exist (e.g. typo `compliance-relase`) must not
+    # render the default DAG under the wrong name. Codex PR 3
+    # pass 12 caught the misleading fallback.
+    if [ "$name" = "default" ] && declare -F nano_phase_graph_json >/dev/null 2>&1; then
       graph_json=$(nano_phase_graph_json 2>/dev/null || echo "")
     fi
   fi

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1140,6 +1140,18 @@ render_stack_body() {
   ' >/dev/null 2>&1; then
     graph_validation_error="every node needs string .name and array-of-string .depends_on"
   elif ! printf '%s' "$graph_json" | jq -e '
+    # Phase names must match [A-Za-z0-9_-]+ so shell word-splitting
+    # in the depth/SVG loops cannot break them apart, and a `find`
+    # under .nanostack/<phase>/ stays well-defined. Codex PR 3 pass 8.
+    all(.[]; .name | test("^[A-Za-z0-9_-]+$"))
+  ' >/dev/null 2>&1; then
+    graph_validation_error="phase names must match [A-Za-z0-9_-]+ (no whitespace or path separators)"
+  elif ! printf '%s' "$graph_json" | jq -e '
+    # Reject duplicate names; otherwise dependencies are ambiguous.
+    ([.[].name] | length) == ([.[].name] | unique | length)
+  ' >/dev/null 2>&1; then
+    graph_validation_error="phase_graph has duplicate node names"
+  elif ! printf '%s' "$graph_json" | jq -e '
     . as $g
     | ([.[].name] | unique) as $names
     | all(.[]; (.depends_on // []) | all(. as $d | $names | index($d) != null))

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -37,11 +37,13 @@ NC='\033[0m'
 check_absent() {
   local name="$1"; local pattern="$2"; shift 2
   local files=("$@")
-  if grep -nE "$pattern" "${files[@]}" >/dev/null 2>&1; then
+  # `-e -- ` so a pattern starting with `-` (e.g. `--no-session-sync`)
+  # is not interpreted as a grep flag.
+  if grep -nE -e "$pattern" -- "${files[@]}" >/dev/null 2>&1; then
     FAIL=$((FAIL+1))
     printf "  ${RED}FAIL${NC}  %s\n" "$name"
     printf "         ${DIM}pattern: %s${NC}\n" "$pattern"
-    grep -nE "$pattern" "${files[@]}" | sed 's/^/         /' || true
+    grep -nE -e "$pattern" -- "${files[@]}" | sed 's/^/         /' || true
   else
     PASS=$((PASS+1))
     printf "  ${GREEN}OK${NC}    %s\n" "$name"
@@ -51,7 +53,7 @@ check_absent() {
 check_present() {
   local name="$1"; local pattern="$2"; shift 2
   local files=("$@")
-  if grep -nE "$pattern" "${files[@]}" >/dev/null 2>&1; then
+  if grep -nE -e "$pattern" -- "${files[@]}" >/dev/null 2>&1; then
     PASS=$((PASS+1))
     printf "  ${GREEN}OK${NC}    %s\n" "$name"
   else
@@ -78,6 +80,7 @@ check_absent_no_allowlist() {
   hits=$(grep -nE "$pattern" "${files[@]}" 2>/dev/null \
     | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' \
     | grep -vE '# url-allowlist' \
+    | grep -vE 'xmlns="http://www\.w3\.org/' \
     | grep -vE 'http://\*\|https://\*' \
     || true)
   if [ -n "$hits" ]; then
@@ -166,6 +169,30 @@ check_present "shared CSS defines .finding.sev-bad" \
   '\.finding\.sev-bad' "bin/lib/visual-render.sh"
 check_present "shared CSS defines .counter" \
   '\.counter' "bin/lib/visual-render.sh"
+
+# 12. PR 3: journal renderer reads through find-artifact.sh and stays
+# read-only (--no-session-sync) just like the per-phase renders.
+check_present "render_journal_body uses --no-session-sync" \
+  '--no-session-sync' "bin/render-artifact.sh"
+
+# 13. PR 3: stack renderer must validate the stack name before
+# touching disk. Restrict to alnum, _, -.
+check_present "stack name validation rejects path traversal" \
+  '\[!a-zA-Z0-9_-\]\*' "bin/render-artifact.sh"
+
+# 14. PR 3: journal --date must be regex-validated, never piped to a
+# shell with metacharacters.
+check_present "journal --date YYYY-MM-DD regex" \
+  '\[0-9\]\[0-9\]\[0-9\]\[0-9\]-\[0-9\]\[0-9\]-\[0-9\]\[0-9\]' "bin/render-artifact.sh"
+
+# 15. PR 3: SVG must not contain external image hrefs.
+check_absent "no SVG <image href" \
+  '<image[[:space:]]+href' "bin/render-artifact.sh" "bin/lib/visual-render.sh"
+
+# 16. PR 3: SVG must not embed <foreignObject> (allows arbitrary HTML
+# inside SVG which sidesteps the CSP and escape contract).
+check_absent "no SVG <foreignObject" \
+  '<foreignObject' "bin/render-artifact.sh" "bin/lib/visual-render.sh"
 
 TOTAL=$((PASS+FAIL))
 printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -170,10 +170,17 @@ check_present "shared CSS defines .finding.sev-bad" \
 check_present "shared CSS defines .counter" \
   '\.counter' "bin/lib/visual-render.sh"
 
-# 12. PR 3: journal renderer reads through find-artifact.sh and stays
-# read-only (--no-session-sync) just like the per-phase renders.
-check_present "render_journal_body uses --no-session-sync" \
-  '--no-session-sync' "bin/render-artifact.sh"
+# 12. PR 3: journal renderer reads through _journal_latest_on_date
+# (a direct filesystem helper) and never calls session.sh
+# phase-start or other mutating commands. Codex PR 3 pass 16: the
+# previous check was vacuous (just `grep --no-session-sync` against
+# the whole file). Tighten to require that render_journal_body uses
+# the dedicated lookup helper.
+check_present "render_journal_body uses _journal_latest_on_date helper" \
+  '_journal_latest_on_date' "bin/render-artifact.sh"
+# And per-phase resolution still uses --no-session-sync.
+check_present "phase resolution uses --no-session-sync" \
+  '\-\-no-session-sync' "bin/render-artifact.sh"
 
 # 13. PR 3: stack renderer must validate the stack name before
 # touching disk. Restrict to alnum, _, -.

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -761,6 +761,69 @@ assert_exit "journal --date with shell metachars exits 1" 1 \
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --date 2026-05-11)
 assert_true "journal --date valid shape works" test -f "$HTML"
 
+# ─── Cell 22a: --date filters by date, not last 30 days (PR 3 pass 1) ─
+printf "\n  ${DIM}Cell 22a: journal --date filter (PR 3 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell22a"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Rename today's artifact to look like it was saved on 2026-05-09.
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+NEW="$NANOSTACK_STORE/plan/20260509-100000.json"
+jq '.timestamp = "2026-05-09T10:00:00Z"' "$PLAN_PATH" > "$NEW"
+rm "$PLAN_PATH"
+# Now request the journal for 2026-05-09; the plan artifact must appear.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --date 2026-05-09)
+assert_contains "journal --date 2026-05-09 shows the dated plan" "$HTML" "20260509-100000.json"
+# Request another date with no artifacts; plan must show as missing.
+HTML2=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --date 2026-05-08)
+assert_contains "journal --date 2026-05-08 says missing" "$HTML2" "No artifact found"
+assert_not_contains "journal 2026-05-08 does NOT show 2026-05-09 plan path" "$HTML2" "20260509-100000.json"
+
+# ─── Cell 22b: stack falls back to project phase_graph (PR 3 pass 1) ─
+printf "\n  ${DIM}Cell 22b: stack falls back to project phase_graph (PR 3 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell22b"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+cat > "$NANOSTACK_STORE/config.json" <<'CFG'
+{
+  "schema_version": "1",
+  "custom_phases": ["license-audit"],
+  "phase_graph": [
+    {"name": "think", "depends_on": []},
+    {"name": "plan", "depends_on": ["think"]},
+    {"name": "build", "depends_on": ["plan"]},
+    {"name": "review", "depends_on": ["build"]},
+    {"name": "license-audit", "depends_on": ["build"]},
+    {"name": "ship", "depends_on": ["review", "license-audit"]}
+  ]
+}
+CFG
+# No stack file under examples or stacks/; the fallback to the
+# registry's phase_graph must kick in.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack project)
+assert_true "stack from project graph renders" test -f "$HTML"
+assert_contains "stack shows the custom phase license-audit" "$HTML" 'data-phase="license-audit"'
+assert_contains "stack shows SVG" "$HTML" "<svg"
+
+# ─── Cell 22c: journal includes custom phases from registry (PR 3 pass 1) ─
+printf "\n  ${DIM}Cell 22c: journal lists custom phases (PR 3 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell22c"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+cat > "$NANOSTACK_STORE/config.json" <<'CFG'
+{
+  "schema_version": "1",
+  "custom_phases": ["license-audit", "privacy-check"]
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_contains "journal lists custom license-audit row" "$HTML" 'data-phase="license-audit"'
+assert_contains "journal lists custom privacy-check row" "$HTML" 'data-phase="privacy-check"'
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1167,6 +1167,46 @@ CFG
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack self_cycle)
 assert_contains "self-cycle rejected" "$HTML" "cycle"
 
+# ─── Cell 22s: malformed phase names rejected (PR 3 pass 8) ──
+printf "\n  ${DIM}Cell 22s: malformed phase names rejected (PR 3 pass 8)${NC}\n"
+PROJ="$TMP_ROOT/cell22s"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+
+# Whitespace in phase name.
+mkdir -p "$NANOSTACK_STORE/stacks/spacename"
+cat > "$NANOSTACK_STORE/stacks/spacename/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"spacename",
+  "phase_graph": [
+    {"name":"license audit","depends_on":[]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack spacename)
+assert_contains "phase name with whitespace rejected" "$HTML" "phase names must match"
+
+# Path separator in phase name.
+mkdir -p "$NANOSTACK_STORE/stacks/slashname"
+cat > "$NANOSTACK_STORE/stacks/slashname/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"slashname",
+  "phase_graph": [
+    {"name":"bad/name","depends_on":[]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack slashname)
+assert_contains "phase name with slash rejected" "$HTML" "phase names must match"
+
+# Duplicate names.
+mkdir -p "$NANOSTACK_STORE/stacks/dup"
+cat > "$NANOSTACK_STORE/stacks/dup/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"dup",
+  "phase_graph": [
+    {"name":"plan","depends_on":[]},
+    {"name":"plan","depends_on":[]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack dup)
+assert_contains "duplicate phase names rejected" "$HTML" "duplicate node names"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1050,6 +1050,65 @@ HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badstack2 2>/dev/null 
   assert_contains "scalar-array stack also invalid" "$HTML" "Stack invalid"
 }
 
+# ─── Cell 22o: stack --strict surfaces tampered .project (PR 3 pass 6) ─
+printf "\n  ${DIM}Cell 22o: stack --strict surfaces tampered .project (PR 3 pass 6)${NC}\n"
+PROJ="$TMP_ROOT/cell22o"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+jq '.project = "/other-project"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "stack --strict catches tampered .project" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict"
+# Without --strict, the row must show data-trust=integrity_mismatch.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_contains "stack table shows tampered .project as integrity_mismatch" "$HTML" 'data-phase="plan" data-trust="integrity_mismatch"'
+
+# ─── Cell 22p: stricter graph validation (PR 3 pass 6) ──────
+printf "\n  ${DIM}Cell 22p: strict graph validation (PR 3 pass 6)${NC}\n"
+PROJ="$TMP_ROOT/cell22p"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+
+# depends_on as a string (not array).
+mkdir -p "$NANOSTACK_STORE/stacks/bad_deps"
+cat > "$NANOSTACK_STORE/stacks/bad_deps/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"bad_deps",
+  "phase_graph": [ {"name":"a","depends_on":"not-array"} ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack bad_deps)
+assert_contains "depends_on string rejected with invalid notice" "$HTML" "Stack invalid"
+
+# Empty array.
+mkdir -p "$NANOSTACK_STORE/stacks/empty_graph"
+cat > "$NANOSTACK_STORE/stacks/empty_graph/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"empty_graph", "phase_graph": [] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack empty_graph)
+assert_contains "empty phase_graph rejected" "$HTML" "non-empty array"
+
+# Dangling dependency.
+mkdir -p "$NANOSTACK_STORE/stacks/dangling"
+cat > "$NANOSTACK_STORE/stacks/dangling/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"dangling",
+  "phase_graph": [
+    {"name":"a","depends_on":[]},
+    {"name":"b","depends_on":["nonexistent"]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack dangling)
+assert_contains "dangling dependency rejected" "$HTML" "dangling dependency"
+
+# Empty name string.
+mkdir -p "$NANOSTACK_STORE/stacks/empty_name"
+cat > "$NANOSTACK_STORE/stacks/empty_name/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"empty_name",
+  "phase_graph": [ {"name":"","depends_on":[]} ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack empty_name)
+assert_contains "empty name rejected" "$HTML" "Stack invalid"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1369,6 +1369,25 @@ MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*empty_graph2*.manifest.json | hea
 LEN=$(jq -r '.source_artifacts | length' "$MFST")
 assert_true "graph-invalid manifest has >= 1 source" sh -c "[ '$LEN' -ge 1 ]"
 
+# ─── Cell 23a: stack manifest records the stack definition (PR 3 pass 16) ─
+printf "\n  ${DIM}Cell 23a: stack manifest records the stack def (PR 3 pass 16)${NC}\n"
+PROJ="$TMP_ROOT/cell23a"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*stack*compliance-release*.manifest.json | head -1)
+# First source must be the stack definition file itself.
+FIRST_PHASE=$(jq -r '.source_artifacts[0].phase' "$MFST")
+FIRST_PATH=$(jq -r '.source_artifacts[0].path' "$MFST")
+assert_true "first source phase is 'stack:compliance-release'" \
+  sh -c "[ '$FIRST_PHASE' = 'stack:compliance-release' ]"
+assert_true "first source path is the stack file" \
+  sh -c "echo '$FIRST_PATH' | grep -q 'compliance-release/stack.json'"
+# Total sources = stack def + 10 phases.
+TOTAL=$(jq -r '.source_artifacts | length' "$MFST")
+assert_true "manifest has 11 sources (1 stack def + 10 phases)" sh -c "[ '$TOTAL' = '11' ]"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1339,6 +1339,36 @@ HTML=$(cd "$PROJ_OURS" && "$REPO/bin/render-artifact.sh" stack compliance-releas
 assert_contains "stack finds OUR plan past 30 newer foreign artifacts" "$HTML" "$OUR_PLAN"
 unset NANOSTACK_STORE
 
+# ─── Cell 22z: invalid stack manifest has >= 1 source (PR 3 pass 15) ─
+printf "\n  ${DIM}Cell 22z: invalid stack manifest sources (PR 3 pass 15)${NC}\n"
+PROJ="$TMP_ROOT/cell22z"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+
+# Stack invalid: malformed stack file.
+mkdir -p "$NANOSTACK_STORE/stacks/inv_manifest"
+printf '{"name":"inv_manifest","phase_graph":[' > "$NANOSTACK_STORE/stacks/inv_manifest/stack.json"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack inv_manifest)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*inv_manifest*.manifest.json | head -1)
+LEN=$(jq -r '.source_artifacts | length' "$MFST")
+assert_true "invalid-stack manifest has >= 1 source" sh -c "[ '$LEN' -ge 1 ]"
+assert_true "invalid-stack source phase begins with stack:" \
+  sh -c "jq -re '.source_artifacts[0].phase | startswith(\"stack:\")' '$MFST' >/dev/null"
+
+# Stack not found: typo.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack does_not_exist_typo)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*does_not_exist_typo*.manifest.json | head -1)
+LEN=$(jq -r '.source_artifacts | length' "$MFST")
+assert_true "not-found-stack manifest has >= 1 source" sh -c "[ '$LEN' -ge 1 ]"
+
+# Graph validation error: empty graph.
+mkdir -p "$NANOSTACK_STORE/stacks/empty_graph2"
+echo '{"name":"empty_graph2","phase_graph":[]}' > "$NANOSTACK_STORE/stacks/empty_graph2/stack.json"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack empty_graph2)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*empty_graph2*.manifest.json | head -1)
+LEN=$(jq -r '.source_artifacts | length' "$MFST")
+assert_true "graph-invalid manifest has >= 1 source" sh -c "[ '$LEN' -ge 1 ]"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -824,6 +824,82 @@ HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
 assert_contains "journal lists custom license-audit row" "$HTML" 'data-phase="license-audit"'
 assert_contains "journal lists custom privacy-check row" "$HTML" 'data-phase="privacy-check"'
 
+# ─── Cell 22d: bare `journal` defaults to today (PR 3 pass 2) ───
+printf "\n  ${DIM}Cell 22d: bare journal defaults to today (PR 3 pass 2)${NC}\n"
+PROJ="$TMP_ROOT/cell22d"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal)
+TODAY=$(date -u +%Y-%m-%d)
+assert_contains "bare journal renders today's date" "$HTML" "$TODAY"
+# Filename must not contain a trailing dash.
+case "$HTML" in
+  *journal-.html|*journal-*.html) ;;
+  *)
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    bare journal filename has no stray dash\n"
+    ;;
+esac
+case "$HTML" in
+  *journal-.html)
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  bare journal filename has stray dash: %s\n" "$HTML"
+    ;;
+esac
+
+# ─── Cell 22e: --strict on aggregate fails for missing integrity (PR 3 pass 2) ─
+printf "\n  ${DIM}Cell 22e: --strict on aggregate (PR 3 pass 2)${NC}\n"
+PROJ="$TMP_ROOT/cell22e"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+# Strip integrity on plan, then journal --strict must reject.
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+jq 'del(.integrity)' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "journal --strict fails on integrity_missing" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict"
+# Tamper plan; --strict must also fail.
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+jq '.summary.goal = "Tampered"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "journal --strict fails on integrity_mismatch" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict"
+# Stack --strict: same.
+assert_exit "stack --strict fails when any artifact tampered" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict"
+
+# ─── Cell 22f: scratch dir does not leak (PR 3 pass 2) ──────
+printf "\n  ${DIM}Cell 22f: scratch dir cleanup (PR 3 pass 2)${NC}\n"
+PROJ="$TMP_ROOT/cell22f"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+SCRATCH_BEFORE=$(find /tmp -maxdepth 1 -name "render-artifact.*" -type d 2>/dev/null | wc -l | tr -d ' ')
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+SCRATCH_AFTER=$(find /tmp -maxdepth 1 -name "render-artifact.*" -type d 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no scratch dir leak across renders" sh -c "[ '$SCRATCH_AFTER' = '$SCRATCH_BEFORE' ]"
+
+# ─── Cell 22g: stack manifest with backslash path (PR 3 pass 2) ─
+printf "\n  ${DIM}Cell 22g: stack manifest JSON escape (PR 3 pass 2)${NC}\n"
+PROJ="$TMP_ROOT/cell22g"
+setup_project "$PROJ"
+# A project path containing a backslash is rare but the renderer
+# should never produce invalid JSON. Validate by rendering with the
+# normal path and confirming the manifest parses cleanly.
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*stack*.manifest.json | head -1)
+assert_true "stack manifest is parseable JSON" jq -e '.' "$MFST"
+assert_true "stack manifest has source_artifacts array" \
+  sh -c "[ \"\$(jq -r 'type' '$MFST')\" = 'object' ] && [ \"\$(jq -r '.source_artifacts | type' '$MFST')\" = 'array' ]"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1207,6 +1207,33 @@ CFG
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack dup)
 assert_contains "duplicate phase names rejected" "$HTML" "duplicate node names"
 
+# ─── Cell 22t: malformed stack metadata does not crash (PR 3 pass 9) ─
+printf "\n  ${DIM}Cell 22t: malformed stack metadata (PR 3 pass 9)${NC}\n"
+PROJ="$TMP_ROOT/cell22t"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/stacks/badjson"
+# Truncated JSON in stack.json.
+printf '{"name":"badjson","phase_graph":[' > "$NANOSTACK_STORE/stacks/badjson/stack.json"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badjson 2>/dev/null || true)
+[ -n "$HTML" ] && {
+  assert_true "malformed stack JSON does not crash" test -f "$HTML"
+}
+
+# ─── Cell 22u: malformed same-day artifact does not crash journal (PR 3 pass 9) ─
+printf "\n  ${DIM}Cell 22u: malformed same-day artifact (PR 3 pass 9)${NC}\n"
+PROJ="$TMP_ROOT/cell22u"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/plan"
+# Drop a malformed (truncated) JSON file with today's date prefix.
+TODAY_COMPACT=$(date -u +%Y%m%d)
+printf '{"phase":"plan","summary":{' > "$NANOSTACK_STORE/plan/${TODAY_COMPACT}-120000.json"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_true "malformed plan artifact does not crash journal" test -f "$HTML"
+# The row should surface as unreadable or integrity_missing, not abort.
+assert_contains "malformed artifact row appears" "$HTML" 'data-phase="plan"'
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -999,6 +999,57 @@ assert_not_contains "today's journal does not show yesterday's plan" "$HTML" "${
 # Plan row says missing.
 assert_contains "today's journal shows plan as missing" "$HTML" 'data-phase="plan"'
 
+# ─── Cell 22m: tampered .project surfaces as integrity_mismatch (PR 3 pass 5) ─
+printf "\n  ${DIM}Cell 22m: tampered .project surfaces (PR 3 pass 5)${NC}\n"
+PROJ="$TMP_ROOT/cell22m"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+# Tamper .project. The integrity hash now mismatches but the project
+# filter would otherwise drop this file.
+jq '.project = "/other"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_contains "tampered .project surfaces as integrity_mismatch row" "$HTML" 'data-trust="integrity_mismatch"'
+# --strict must now fail.
+assert_exit "journal --strict catches tampered .project" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict"
+
+# ─── Cell 22n: malformed stack phase_graph renders graceful notice (PR 3 pass 5) ─
+printf "\n  ${DIM}Cell 22n: malformed stack graph (PR 3 pass 5)${NC}\n"
+PROJ="$TMP_ROOT/cell22n"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/stacks/badstack"
+cat > "$NANOSTACK_STORE/stacks/badstack/stack.json" <<'CFG'
+{
+  "schema_version": "1",
+  "name": "badstack",
+  "phase_graph": "this should be an array, not a string"
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badstack 2>/dev/null || true)
+# The render returns 0 because the contract is to render gracefully.
+assert_true "malformed stack still produces HTML" test -f "${HTML:-/dev/null}"
+[ -f "${HTML:-/dev/null}" ] && {
+  assert_contains "stack invalid notice rendered" "$HTML" "Stack invalid"
+}
+
+# Array of scalars (not objects).
+mkdir -p "$NANOSTACK_STORE/stacks/badstack2"
+cat > "$NANOSTACK_STORE/stacks/badstack2/stack.json" <<'CFG'
+{
+  "schema_version": "1",
+  "name": "badstack2",
+  "phase_graph": ["just", "strings", "not", "objects"]
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badstack2 2>/dev/null || true)
+[ -f "${HTML:-/dev/null}" ] && {
+  assert_contains "scalar-array stack also invalid" "$HTML" "Stack invalid"
+}
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1109,6 +1109,64 @@ CFG
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack empty_name)
 assert_contains "empty name rejected" "$HTML" "Stack invalid"
 
+# ─── Cell 22q: integrity_missing + .project flip caught (PR 3 pass 7) ─
+printf "\n  ${DIM}Cell 22q: integrity_missing + .project flip (PR 3 pass 7)${NC}\n"
+PROJ="$TMP_ROOT/cell22q"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+# Strip .integrity AND flip .project.
+jq 'del(.integrity) | .project = "/other"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_contains "journal surfaces .integrity-strip + .project-flip" "$HTML" 'data-trust="integrity_missing"'
+assert_exit "journal --strict catches integrity_missing + .project flip" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_contains "stack surfaces .integrity-strip + .project-flip" "$HTML" 'data-phase="plan" data-trust="integrity_missing"'
+assert_exit "stack --strict catches integrity_missing + .project flip" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict"
+
+# ─── Cell 22r: cyclic phase_graph rejected (PR 3 pass 7) ────
+printf "\n  ${DIM}Cell 22r: cyclic phase_graph rejected (PR 3 pass 7)${NC}\n"
+PROJ="$TMP_ROOT/cell22r"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+
+mkdir -p "$NANOSTACK_STORE/stacks/cycle2"
+cat > "$NANOSTACK_STORE/stacks/cycle2/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"cycle2",
+  "phase_graph": [
+    {"name":"a","depends_on":["b"]},
+    {"name":"b","depends_on":["a"]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack cycle2)
+assert_contains "2-node cycle rejected" "$HTML" "cycle"
+
+mkdir -p "$NANOSTACK_STORE/stacks/cycle3"
+cat > "$NANOSTACK_STORE/stacks/cycle3/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"cycle3",
+  "phase_graph": [
+    {"name":"a","depends_on":["c"]},
+    {"name":"b","depends_on":["a"]},
+    {"name":"c","depends_on":["b"]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack cycle3)
+assert_contains "3-node cycle rejected" "$HTML" "cycle"
+
+mkdir -p "$NANOSTACK_STORE/stacks/self_cycle"
+cat > "$NANOSTACK_STORE/stacks/self_cycle/stack.json" <<'CFG'
+{ "schema_version":"1", "name":"self_cycle",
+  "phase_graph": [
+    {"name":"a","depends_on":["a"]}
+  ] }
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack self_cycle)
+assert_contains "self-cycle rejected" "$HTML" "cycle"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -951,6 +951,54 @@ for n in c1 c5 c10 c13; do
   assert_contains "stack svg contains $n" "$HTML" "data-phase=\"$n\""
 done
 
+# ─── Cell 22j: symlinked visual/stack rejected without leak (PR 3 pass 4) ─
+printf "\n  ${DIM}Cell 22j: symlinked visual/stack rejected (PR 3 pass 4)${NC}\n"
+PROJ="$TMP_ROOT/cell22j"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual"
+mkdir -p "$TMP_ROOT/cell22j-outside"
+ln -s "$TMP_ROOT/cell22j-outside" "$NANOSTACK_STORE/visual/stack"
+assert_exit "stack with symlinked visual/stack exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release"
+# No directory was created at the symlink target.
+LEAK=$(find "$TMP_ROOT/cell22j-outside" -maxdepth 1 -type d -name "compliance-release" 2>/dev/null | wc -l | tr -d ' ')
+assert_true "no directory leaked through symlinked visual/stack" sh -c "[ '$LEAK' = '0' ]"
+
+# Same for visual/journal symlink.
+PROJ="$TMP_ROOT/cell22k"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/visual"
+mkdir -p "$TMP_ROOT/cell22k-outside"
+ln -s "$TMP_ROOT/cell22k-outside" "$NANOSTACK_STORE/visual/journal"
+assert_exit "journal with symlinked visual/journal exits 4" 4 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today"
+
+# ─── Cell 22l: --today does not pull stale artifacts (PR 3 pass 4) ─
+printf "\n  ${DIM}Cell 22l: --today strict-date filter (PR 3 pass 4)${NC}\n"
+PROJ="$TMP_ROOT/cell22l"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/plan"
+# Save a plan with yesterday's date.
+YEST_DATE=$(date -u -v-1d +%Y%m%d 2>/dev/null || date -u -d "yesterday" +%Y%m%d 2>/dev/null || echo "20260510")
+YEST_FILE="$NANOSTACK_STORE/plan/${YEST_DATE}-120000.json"
+jq -n --arg p "$PROJ" '{
+  schema_version: "1",
+  phase: "plan",
+  timestamp: "2026-05-10T12:00:00Z",
+  project: $p,
+  branch: "main",
+  summary: {goal:"yesterday", scope:"small", planned_files:[], plan_approval:"manual"},
+  context_checkpoint: {summary:"x", key_files:[], decisions_made:[], open_questions:[]}
+}' > "$YEST_FILE"
+# Render today's journal; plan must show as missing, not yesterday's.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_not_contains "today's journal does not show yesterday's plan" "$HTML" "${YEST_DATE}-120000.json"
+# Plan row says missing.
+assert_contains "today's journal shows plan as missing" "$HTML" 'data-phase="plan"'
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -802,8 +802,9 @@ cat > "$NANOSTACK_STORE/config.json" <<'CFG'
 }
 CFG
 # No stack file under examples or stacks/; the fallback to the
-# registry's phase_graph must kick in.
-HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack project)
+# project's phase_graph (registry) only kicks in for `stack default`
+# (PR 3 pass 12).
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack default)
 assert_true "stack from project graph renders" test -f "$HTML"
 assert_contains "stack shows the custom phase license-audit" "$HTML" 'data-phase="license-audit"'
 assert_contains "stack shows SVG" "$HTML" "<svg"
@@ -1251,6 +1252,22 @@ assert_contains "stack table shows plan as integrity_missing" "$HTML" 'data-phas
 # --strict catches it.
 assert_exit "stack --strict catches truncated artifact" 3 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict"
+
+# ─── Cell 22w: typo stack name -> Stack not found (PR 3 pass 12) ─
+printf "\n  ${DIM}Cell 22w: typo stack name (PR 3 pass 12)${NC}\n"
+PROJ="$TMP_ROOT/cell22w"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# No stack file for "compliance-relase" (typo of "compliance-release").
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-relase)
+assert_true "typo stack still produces HTML" test -f "$HTML"
+assert_contains "typo stack shows Stack not found" "$HTML" "Stack not found"
+assert_not_contains "typo stack does NOT render default phases" "$HTML" 'data-phase="think"'
+
+# Bare `stack default` still falls back to the project graph.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack default)
+assert_contains "stack default falls back to project graph" "$HTML" 'data-phase="think"'
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -861,7 +861,9 @@ PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
 jq 'del(.integrity)' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
 assert_exit "journal --strict fails on integrity_missing" 3 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict"
-# Tamper plan; --strict must also fail.
+# Tamper plan; --strict must also fail. Delete prior artifact first
+# so the latest-picker definitely sees the tampered one.
+rm -f "$NANOSTACK_STORE/plan/"*.json
 (cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
 PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
 jq '.summary.goal = "Tampered"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
@@ -899,6 +901,55 @@ MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*stack*.manifest.json | head -1)
 assert_true "stack manifest is parseable JSON" jq -e '.' "$MFST"
 assert_true "stack manifest has source_artifacts array" \
   sh -c "[ \"\$(jq -r 'type' '$MFST')\" = 'object' ] && [ \"\$(jq -r '.source_artifacts | type' '$MFST')\" = 'array' ]"
+
+# ─── Cell 22h: --manifest-only with --strict still enforces (PR 3 pass 3) ─
+printf "\n  ${DIM}Cell 22h: --manifest-only --strict enforces (PR 3 pass 3)${NC}\n"
+PROJ="$TMP_ROOT/cell22h"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+jq '.summary.goal = "Tampered"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+assert_exit "journal --strict --manifest-only exits 3 when tampered" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --strict --manifest-only"
+assert_exit "stack --strict --manifest-only exits 3 when tampered" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict --manifest-only"
+
+# ─── Cell 22i: large unsorted phase_graph renders every node (PR 3 pass 3) ─
+printf "\n  ${DIM}Cell 22i: large unsorted phase_graph (PR 3 pass 3)${NC}\n"
+PROJ="$TMP_ROOT/cell22i"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# 15-node linear chain in reverse topological order. The previous
+# cap of 10 rounds left the tail of the chain out of the SVG.
+cat > "$NANOSTACK_STORE/config.json" <<'CFG'
+{
+  "schema_version": "1",
+  "custom_phases": ["c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13"],
+  "phase_graph": [
+    {"name": "c13", "depends_on": ["c12"]},
+    {"name": "c12", "depends_on": ["c11"]},
+    {"name": "c11", "depends_on": ["c10"]},
+    {"name": "c10", "depends_on": ["c9"]},
+    {"name": "c9", "depends_on": ["c8"]},
+    {"name": "c8", "depends_on": ["c7"]},
+    {"name": "c7", "depends_on": ["c6"]},
+    {"name": "c6", "depends_on": ["c5"]},
+    {"name": "c5", "depends_on": ["c4"]},
+    {"name": "c4", "depends_on": ["c3"]},
+    {"name": "c3", "depends_on": ["c2"]},
+    {"name": "c2", "depends_on": ["c1"]},
+    {"name": "c1", "depends_on": []}
+  ]
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack default)
+# Every node must appear in the SVG (as a <g data-phase=...> wrapper).
+for n in c1 c5 c10 c13; do
+  assert_contains "stack svg contains $n" "$HTML" "data-phase=\"$n\""
+done
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1308,6 +1308,37 @@ assert_exit "B's journal --strict succeeds despite shared-store tamper" 0 \
   sh -c "cd '$PROJ_B' && '$REPO/bin/render-artifact.sh' journal --today --strict"
 unset NANOSTACK_STORE
 
+# ─── Cell 22y: stack lookup walks past 30 newer foreign artifacts (PR 3 pass 14) ─
+printf "\n  ${DIM}Cell 22y: stack lookup uncapped (PR 3 pass 14)${NC}\n"
+SHARED_STORE="$TMP_ROOT/cell22y-shared"
+mkdir -p "$SHARED_STORE/plan"
+# Our project saves a plan FIRST (oldest).
+PROJ_OURS="$TMP_ROOT/cell22y-ours"
+setup_project "$PROJ_OURS"
+(cd "$PROJ_OURS" && NANOSTACK_STORE="$SHARED_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"OURS","scope":"small","planned_files":[],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+OUR_PLAN=$(ls "$SHARED_STORE/plan/"*.json | head -1)
+OUR_PROJECT=$(jq -r '.project' "$OUR_PLAN")
+# Now write 35 newer "other project" artifacts.
+PROJ_OTHER="$TMP_ROOT/cell22y-other"
+setup_project "$PROJ_OTHER"
+sleep 1  # ensure mtime is strictly newer
+for i in $(seq 1 35); do
+  TS="2026-05-12-$(printf "%06d" $((100000 + i)))"
+  cat > "$SHARED_STORE/plan/${TS//-/}.json" <<JSON
+{"phase":"plan","project":"/other/$i","timestamp":"$TS","summary":{"goal":"other$i"}}
+JSON
+done
+# Render our project's stack. Without the fix, our plan was beyond
+# the 30-candidate cap and the row would render as missing.
+export NANOSTACK_STORE="$SHARED_STORE"
+HTML=$(cd "$PROJ_OURS" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_contains "stack finds OUR plan past 30 newer foreign artifacts" "$HTML" "$OUR_PLAN"
+unset NANOSTACK_STORE
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -436,10 +436,6 @@ mkdir -p "$NANOSTACK_STORE"
 (cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
 assert_exit "--interactive reserved (exit 2)" 2 \
   sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --interactive"
-assert_exit "journal reserved (exit 2)" 2 \
-  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today"
-assert_exit "stack reserved (exit 2)" 2 \
-  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack mystack"
 
 # ─── Cell 7: --manifest-only ────────────────────────────────
 printf "\n  ${DIM}Cell 7: --manifest-only${NC}\n"
@@ -658,6 +654,112 @@ assert_contains "ship ci_passed escaped" "$HTML" '&lt;script&gt;alert(&quot;ci&q
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" qa --latest)
 assert_not_contains "qa reproduce no raw script" "$HTML" '<script>alert("qa")'
 assert_not_contains "qa root_cause no raw img" "$HTML" '<img onerror=alert(1)>'
+
+# ─── Cell 18: sprint journal view ───────────────────────────
+printf "\n  ${DIM}Cell 18: sprint journal view${NC}\n"
+PROJ="$TMP_ROOT/cell18"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_think "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_review "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_security "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_qa "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_ship "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_true "journal html exists" test -f "$HTML"
+assert_contains "journal page title" "$HTML" "Sprint journal"
+assert_contains "journal data-phase=journal" "$HTML" 'data-phase="journal"'
+assert_contains "journal timeline" "$HTML" "Phase timeline"
+assert_contains "journal think row" "$HTML" 'data-phase="think"'
+assert_contains "journal plan row" "$HTML" 'data-phase="plan"'
+assert_contains "journal review row" "$HTML" 'data-phase="review"'
+assert_contains "journal security row" "$HTML" 'data-phase="security"'
+assert_contains "journal qa row" "$HTML" 'data-phase="qa"'
+assert_contains "journal ship row" "$HTML" 'data-phase="ship"'
+# Manifest must list every source.
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*journal*.manifest.json | head -1)
+assert_true "journal manifest kind = journal" sh -c "[ \"\$(jq -r .kind '$MFST')\" = 'journal' ]"
+assert_true "journal sources length >= 6" sh -c "[ \"\$(jq -r '.source_artifacts | length' '$MFST')\" -ge 6 ]"
+# Trust badge aggregated.
+assert_contains "journal aggregated badge" "$HTML" 'data-trust="not_applicable"'
+assert_contains "journal aggregated badge text" "$HTML" '>aggregated<'
+
+# ─── Cell 19: journal flags missing/tampered phases ──────────
+printf "\n  ${DIM}Cell 19: journal flags missing/tampered${NC}\n"
+PROJ="$TMP_ROOT/cell19"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# Save only think + plan; review/security/qa/ship will be missing.
+(cd "$PROJ" && save_valid_think "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_contains "journal renders missing phases" "$HTML" "No artifact found"
+# Tamper with plan; the row must show 'tampered'.
+PLAN_PATH=$(ls "$NANOSTACK_STORE/plan/"*.json | head -1)
+jq '.summary.goal = "Tampered"' "$PLAN_PATH" > "$PLAN_PATH.tmp" && mv "$PLAN_PATH.tmp" "$PLAN_PATH"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --today)
+assert_contains "journal flags tampered" "$HTML" '>tampered<'
+# Per-row trust attribute present for the tampered row.
+assert_contains "journal plan row data-trust" "$HTML" 'data-phase="plan" data-trust="integrity_mismatch"'
+
+# ─── Cell 20: custom stack DAG view (compliance-release) ─────
+printf "\n  ${DIM}Cell 20: stack compliance-release DAG${NC}\n"
+PROJ="$TMP_ROOT/cell20"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_true "stack html exists" test -f "$HTML"
+assert_contains "stack title" "$HTML" "Custom stack"
+assert_contains "stack display_name" "$HTML" "Compliance Release Stack"
+assert_contains "stack SVG opens" "$HTML" "<svg"
+assert_contains "stack SVG closes" "$HTML" "</svg>"
+# All 10 expected phases must appear as table rows.
+for ph in think plan build review qa security license-audit privacy-check release-readiness ship; do
+  assert_contains "stack table row $ph" "$HTML" "data-phase=\"$ph\""
+done
+# Missing phases must render as 'missing'.
+assert_contains "stack missing badge" "$HTML" ">missing<"
+# No certification language.
+assert_not_contains "stack no certification language" "$HTML" 'certified'
+assert_not_contains "stack no compliance language" "$HTML" 'compliant'
+
+# ─── Cell 21: stack name validation ─────────────────────────
+printf "\n  ${DIM}Cell 21: stack name validation${NC}\n"
+PROJ="$TMP_ROOT/cell21"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# Path traversal in stack name must be rejected.
+assert_exit "stack name with .. rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack ../etc"
+assert_exit "stack name with / rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack a/b"
+assert_exit "stack name with space rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack 'foo bar'"
+
+# Unknown stack: graceful "not found", not crash.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack does-not-exist 2>/dev/null || true)
+# When no stack file matches and no config.json exists, default graph
+# applies (the registry returns the built-in sprint).
+[ -n "$HTML" ] && assert_true "stack fallback to default registry produced HTML" test -f "$HTML"
+
+# ─── Cell 22: journal --date validation ────────────────────
+printf "\n  ${DIM}Cell 22: journal --date validation${NC}\n"
+PROJ="$TMP_ROOT/cell22"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+assert_exit "journal --date bad shape exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --date 2026/05/11"
+assert_exit "journal --date with shell metachars exits 1" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --date '2026-05-11; rm -rf x'"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" journal --date 2026-05-11)
+assert_true "journal --date valid shape works" test -f "$HTML"
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1388,6 +1388,54 @@ assert_true "first source path is the stack file" \
 TOTAL=$(jq -r '.source_artifacts | length' "$MFST")
 assert_true "manifest has 11 sources (1 stack def + 10 phases)" sh -c "[ '$TOTAL' = '11' ]"
 
+# ─── Cell 23b: stack sorts by filename, not mtime (PR 3 pass 17) ─
+printf "\n  ${DIM}Cell 23b: stack sort by filename (PR 3 pass 17)${NC}\n"
+PROJ="$TMP_ROOT/cell23b"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# Save plan first.
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+sleep 1
+# Save plan AGAIN to get a newer-timestamp file.
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"NEWER","scope":"small","planned_files":[],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+NEWER=$(ls "$NANOSTACK_STORE/plan/"*.json | sort -r | head -1)
+OLDER=$(ls "$NANOSTACK_STORE/plan/"*.json | sort | head -1)
+# Touch the older file so its mtime is newer than the new one.
+touch "$OLDER"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+# The stack table should reference the file with the LATER FILENAME,
+# not the touched OLDER one.
+assert_contains "stack picks newer-by-filename plan" "$HTML" "$NEWER"
+
+# ─── Cell 23c: stack default records .nanostack/config.json (PR 3 pass 17) ─
+printf "\n  ${DIM}Cell 23c: default-stack manifest records config.json (PR 3 pass 17)${NC}\n"
+PROJ="$TMP_ROOT/cell23c"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+cat > "$NANOSTACK_STORE/config.json" <<'CFG'
+{
+  "schema_version": "1",
+  "custom_phases": ["audit"],
+  "phase_graph": [
+    {"name": "think", "depends_on": []},
+    {"name": "build", "depends_on": ["think"]},
+    {"name": "audit", "depends_on": ["build"]},
+    {"name": "ship",  "depends_on": ["audit"]}
+  ]
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack default)
+MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*stack*default*.manifest.json | head -1)
+FIRST_PATH=$(jq -r '.source_artifacts[0].path' "$MFST")
+assert_true "default stack manifest records config.json" \
+  sh -c "echo '$FIRST_PATH' | grep -q '\.nanostack/config\.json$'"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1236,6 +1236,22 @@ assert_true "malformed plan artifact does not crash journal" test -f "$HTML"
 # The row should surface as unreadable or integrity_missing, not abort.
 assert_contains "malformed artifact row appears" "$HTML" 'data-phase="plan"'
 
+# ─── Cell 22v: stack survives truncated phase artifact (PR 3 pass 11) ─
+printf "\n  ${DIM}Cell 22v: stack survives truncated artifact (PR 3 pass 11)${NC}\n"
+PROJ="$TMP_ROOT/cell22v"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/plan"
+# Truncated plan artifact.
+printf '{"phase":"plan","summary":{' > "$NANOSTACK_STORE/plan/$(date -u +%Y%m%d)-100000.json"
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_true "stack html exists despite truncated artifact" test -f "$HTML"
+# The plan row in the table surfaces as integrity_missing (not a crash).
+assert_contains "stack table shows plan as integrity_missing" "$HTML" 'data-phase="plan" data-trust="integrity_missing"'
+# --strict catches it.
+assert_exit "stack --strict catches truncated artifact" 3 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack compliance-release --strict"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1207,18 +1207,20 @@ CFG
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack dup)
 assert_contains "duplicate phase names rejected" "$HTML" "duplicate node names"
 
-# ─── Cell 22t: malformed stack metadata does not crash (PR 3 pass 9) ─
-printf "\n  ${DIM}Cell 22t: malformed stack metadata (PR 3 pass 9)${NC}\n"
+# ─── Cell 22t: malformed stack metadata does not crash and does not fall back (PR 3 pass 9+10) ─
+printf "\n  ${DIM}Cell 22t: malformed stack metadata (PR 3 pass 9+10)${NC}\n"
 PROJ="$TMP_ROOT/cell22t"
 setup_project "$PROJ"
 export NANOSTACK_STORE="$PROJ/.nanostack"
 mkdir -p "$NANOSTACK_STORE/stacks/badjson"
 # Truncated JSON in stack.json.
 printf '{"name":"badjson","phase_graph":[' > "$NANOSTACK_STORE/stacks/badjson/stack.json"
-HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badjson 2>/dev/null || true)
-[ -n "$HTML" ] && {
-  assert_true "malformed stack JSON does not crash" test -f "$HTML"
-}
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack badjson)
+assert_true "malformed stack JSON renders an HTML page" test -f "$HTML"
+# PR 3 pass 10: do not silently fall back to the project graph; emit
+# a Stack invalid notice instead so the broken definition is visible.
+assert_contains "named-but-malformed stack -> Stack invalid notice" "$HTML" "Stack invalid"
+assert_not_contains "named-but-malformed stack does NOT render default phases" "$HTML" 'data-phase="think"'
 
 # ─── Cell 22u: malformed same-day artifact does not crash journal (PR 3 pass 9) ─
 printf "\n  ${DIM}Cell 22u: malformed same-day artifact (PR 3 pass 9)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1269,6 +1269,45 @@ assert_not_contains "typo stack does NOT render default phases" "$HTML" 'data-ph
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack default)
 assert_contains "stack default falls back to project graph" "$HTML" 'data-phase="think"'
 
+# ─── Cell 22x: shared store does not surface other-project tamper (PR 3 pass 13) ─
+printf "\n  ${DIM}Cell 22x: shared store project isolation (PR 3 pass 13)${NC}\n"
+SHARED_STORE="$TMP_ROOT/cell22x-shared"
+mkdir -p "$SHARED_STORE"
+# Project A owns the store legitimately.
+PROJ_A="$TMP_ROOT/cell22x-projA"
+setup_project "$PROJ_A"
+(cd "$PROJ_A" && NANOSTACK_STORE="$SHARED_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"A","scope":"small","planned_files":[],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+# Some other project also saved here, then tampered. From project B's
+# perspective, this is foreign noise.
+PROJ_OTHER="$TMP_ROOT/cell22x-other"
+setup_project "$PROJ_OTHER"
+(cd "$PROJ_OTHER" && NANOSTACK_STORE="$SHARED_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"OTHER","scope":"small","planned_files":[],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+OTHER_PLAN=$(ls -t "$SHARED_STORE/plan/"*.json | head -1)
+jq 'del(.integrity)' "$OTHER_PLAN" > "$OTHER_PLAN.tmp" && mv "$OTHER_PLAN.tmp" "$OTHER_PLAN"
+
+# Project B renders its own journal against the shared store. It is
+# NOT the same git-root, so the store is "shared" from B's view.
+PROJ_B="$TMP_ROOT/cell22x-projB"
+setup_project "$PROJ_B"
+export NANOSTACK_STORE="$SHARED_STORE"
+HTML=$(cd "$PROJ_B" && "$REPO/bin/render-artifact.sh" journal --today)
+# Project B has no plan; the row should say missing, NOT surface the
+# OTHER project's tampered plan.
+assert_contains "B's journal shows plan as missing" "$HTML" "No artifact found"
+assert_not_contains "B's journal does NOT surface OTHER project's tampered plan" "$HTML" "OTHER"
+# Strict must also pass (no tampered source attributed to B).
+assert_exit "B's journal --strict succeeds despite shared-store tamper" 0 \
+  sh -c "cd '$PROJ_B' && '$REPO/bin/render-artifact.sh' journal --today --strict"
+unset NANOSTACK_STORE
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"


### PR DESCRIPTION
## Summary

PR 3 of the Visual Artifacts v1 round. Wires the two aggregating renders so a sprint at a glance and a custom workflow stack get their own HTML views. Same trust + path-safety contract as PR 1+2.

### What changed

**Sprint journal view** (`render_journal_body`)
- Enumerates every registered phase (core + custom from `bin/lib/phases.sh::nano_all_phases`) for the requested date.
- Filename-prefix date filter via `_journal_latest_on_date` (`YYYYMMDD-...json`); strict, no 30-day fallback.
- Per-row trust badge (`verified` / `unverified` / `tampered` / `missing`) plus a phase-specific summary line.
- Project-local store: surfaces tampered same-day artifacts even when `.project` was flipped. Shared store: requires `.project` match so foreign artifacts do not pollute the timeline.
- Aggregate `--strict` rejects any source whose trust is `integrity_missing` or `integrity_mismatch` (exit 3); `missing` is allowed (phase not run yet).

**Custom stack view** (`render_stack_body`)
- Looks up the stack definition under `examples/custom-stack-template/<name>/stack.json` first, then `$NANOSTACK_STORE/stacks/<name>/stack.json`, then for `stack default` falls back to `nano_phase_graph_json` (the project's `.nanostack/config.json`).
- Stack name regex-validated to `[A-Za-z0-9_-]+` before any disk lookup.
- Graph validation: non-empty array → object entries with string `.name` + array-of-string `.depends_on` → unique non-empty names → no dangling references → no cycles (Kahn-style pass in bash).
- Renders a table of phases (`phase`, `depends_on`, `trust`, `last artifact`) plus an inline SVG DAG laid out by computed depth.
- Manifest records the stack definition itself as the first source (or `.nanostack/config.json` for `stack default`), then one entry per phase artifact.

**Path safety**
- No pre-mkdir under `visual/` before `nano_visual_assert_safe_descend` runs (a symlinked `visual/stack` or `visual/journal` exits 4 with no directory leak at the symlink target).
- Tampered/malformed JSON in any user-controlled file produces a graceful "Stack invalid" / "Stack not found" notice with `data-testid` markers — never a raw jq crash.
- `--strict` enforced BEFORE `--manifest-only` early exit so `journal --strict --manifest-only` cannot ship a `"strict": true` manifest with tampered sources.

### Codex review trail (18 passes)

| Pass | Theme | Fix |
|------|-------|-----|
| 1 | phase registry not sourced; `--date` filter | source `bin/lib/phases.sh`; `_journal_latest_on_date` |
| 2 | strict bypass; missing date default; scratch-dir leak; awk JSON escape | enforce strict on aggregates; default `JOURNAL_DATE`/`STACK_NAME`; rm scratch in all exits; switch to jq |
| 3 | strict before manifest-only; cap-10 depth resolution | move strict above early exit; cap at `node_count + 1` |
| 4 | pre-mkdir followed symlinks; --today stale fallback | drop pre-mkdir; drop 30-day fallback |
| 5 | tampered .project hid as missing; malformed graph crashed | trust check before project filter; jq -e shape validation |
| 6 | stack tampered-project bypass; loose graph validation | unified tamper-aware lookup; dangling-ref check |
| 7 | integrity_missing slipped; cyclic graph accepted | surface both missing/mismatch; Kahn cycle detection |
| 8 | malformed phase names + duplicates | regex `^[A-Za-z0-9_-]+$`; unique-name check |
| 9 | unguarded jq reads on user JSON | `\|\| echo` on every read |
| 10 | named-invalid fell back to default | only `name == "default"` falls back |
| 11 | truncated artifact crashed stack | guard the integrity read |
| 12 | typo stack name → default graph | restrict fallback strictly |
| 13 | shared store leaked other-project tamper | scope tamper surfacing to project-local store |
| 14 | head-30 cap hid older artifacts | uncap candidate list |
| 15 | invalid stack manifest had 0 sources | synthetic `stack:<name>` source for failure modes |
| 16 | stack manifest omitted definition; lint vacuous | record stack file as first source; tighten lint |
| 17 | mtime ordering; default config not in manifest | filename sort; record `.nanostack/config.json` for `stack default` |
| 18 | (clean) | — |

### Test counts

| Suite | PR 2 | PR 3 |
|-------|------|------|
| `ci/e2e-visual-artifacts.sh` | 154 | 266 |
| `ci/check-visual-artifact-templates.sh` | 25 | 31 |
| **Total contract surface** | **179** | **297** |

## Test plan
- [x] `ci/e2e-visual-artifacts.sh` 266/266
- [x] `ci/check-visual-artifact-templates.sh` 31/31
- [x] Codex pass 18 returned clean
- [x] Round-trip: render journal + stack + plan, verify manifest source counts and trust states
- [x] Tamper detection on project-local store; absence of tamper detection on shared store
- [x] Cycle, dangling, duplicate-name, whitespace-name, empty-graph all reject gracefully