### PR TITLE
visual-artifacts v1: PR 4 --interactive copy-only mode

### DIFF
--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -382,6 +382,10 @@ nano_visual_page_start() {
     .chip.sev-ok { color: var(--ok); border-color: var(--ok); }
     .pr-link { color: var(--info); }
     .unsafe-url { color: var(--bad); font-family: monospace; }
+    .copy-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 12px; }
+    .copy-btn { background: var(--panel-2); color: var(--fg); border: 1px solid var(--line); border-radius: 6px; padding: 6px 12px; cursor: pointer; font: inherit; font-size: 0.9rem; }
+    .copy-btn:hover, .copy-btn:focus { background: var(--panel); border-color: var(--info); color: var(--info); }
+    .copy-status { color: var(--muted); font-size: 0.85rem; }
   </style>
 </head>
 <body>

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -10,10 +10,12 @@
 #                              [--interactive] [--out <path>]
 #                              [--manifest-only]
 #
-# PR 1 scope: /plan renderer + manifest + safety locks. Other phases
-# exit 1 with a clear "phase not yet supported" message; PR 2 wires
-# think/review/security/qa/ship. journal/stack are reserved for PR 3
-# (exit 2). --interactive is reserved for PR 4 (exit 2).
+# PR 1 scope: /plan renderer + manifest + safety locks.
+# PR 2 wires think/review/security/qa/ship.
+# PR 3 wires journal/stack aggregate views.
+# PR 4 adds --interactive for copy-only buttons on /plan and /review
+# (copy as prompt / Markdown / JSON patch). No filesystem writes,
+# no network calls, no form submission.
 
 set -e
 
@@ -49,7 +51,10 @@ PR 1+2+3 scope:
 
 Flags:
   --strict                   require nano_artifact_trust == verified
-  --interactive              reserved for PR 4 (exit 2)
+  --interactive              enable copy-only interactive controls (PR 4 scope:
+                             /plan and /review get "copy as prompt", "copy as Markdown",
+                             and "copy as JSON patch" buttons; no filesystem writes,
+                             no network calls, no form submission)
   --out <path>               write HTML to explicit path under \$NANOSTACK_STORE/visual
   --manifest-only            write manifest only, skip HTML
   --latest                   resolve via find-artifact.sh (default if no path)
@@ -89,10 +94,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --latest)         USE_LATEST=true ;;
     --strict)         STRICT=true ;;
-    --interactive)
-      echo "render-artifact: --interactive is reserved for PR 4 (copy-only interactive mode)" >&2
-      exit 2
-      ;;
+    --interactive)  INTERACTIVE=true ;;
     --manifest-only)  MANIFEST_ONLY=true ;;
     --out)
       shift
@@ -487,6 +489,36 @@ HTML
     printf '      </ul>\n'
   fi
   printf '    </section>\n'
+
+  # PR 4 interactive: copy buttons that export the plan back to the
+  # agent in the requested shape. Built from the normalized JSON so
+  # malformed shapes still produce useful payloads.
+  if [ "${INTERACTIVE:-false}" = true ]; then
+    local plan_prompt plan_markdown plan_json_patch
+    plan_prompt=$(printf '%s' "$norm" | jq -r '
+      "Approve the plan and continue.\n" +
+      "Goal: " + (.summary.goal // "Not recorded") + "\n" +
+      "Scope: " + (.summary.scope // "Not recorded") + "\n" +
+      "Planned files:\n  - " + ((.summary.planned_files // []) | join("\n  - ")) + "\n" +
+      "Risks:\n  - " + ((.summary.risks // []) | join("\n  - "))
+    ')
+    plan_markdown=$(printf '%s' "$norm" | jq -r '
+      "## Plan summary\n\n" +
+      "- **Goal:** " + (.summary.goal // "Not recorded") + "\n" +
+      "- **Scope:** " + (.summary.scope // "Not recorded") + "\n" +
+      "- **Approval:** " + (.summary.plan_approval // "Not recorded") + "\n\n" +
+      "### Planned files\n\n" +
+      ((.summary.planned_files // []) | map("- `" + . + "`") | join("\n"))
+    ')
+    plan_json_patch=$(printf '%s' "$norm" | jq -c '{
+      action: "plan.approve",
+      goal: .summary.goal,
+      scope: .summary.scope,
+      planned_files: .summary.planned_files,
+      out_of_scope: .summary.out_of_scope
+    }')
+    render_copy_actions "$plan_prompt" "$plan_markdown" "$plan_json_patch"
+  fi
 }
 
 # Shared helper: find the latest artifact for <phase>, surfacing
@@ -678,6 +710,40 @@ HTML
   render_findings_section "$norm" "Review findings"
 
   render_context_checkpoint "$norm"
+
+  # PR 4 interactive: review triage payloads. The agent can paste
+  # the prompt back to drive a re-review or accept the findings
+  # as-is.
+  if [ "${INTERACTIVE:-false}" = true ]; then
+    local review_prompt review_markdown review_json_patch
+    review_prompt=$(printf '%s' "$norm" | jq -r '
+      "Address the review findings before /ship.\n" +
+      "Summary: " + (.summary.blocking|tostring) + " blocking / " +
+                   (.summary.should_fix|tostring) + " should-fix / " +
+                   (.summary.nitpicks|tostring) + " nitpicks\n" +
+      "Scope drift: " + (.scope_drift.status // "unknown") + "\n" +
+      "Now-fix:\n  - " +
+      ((.findings // []) | map(select(.severity == "blocking" or .severity == "should_fix")) | map(.description) | join("\n  - "))
+    ')
+    review_markdown=$(printf '%s' "$norm" | jq -r '
+      "## Review findings\n\n" +
+      "| Severity | Count |\n|----|----|\n" +
+      "| Blocking | " + (.summary.blocking|tostring) + " |\n" +
+      "| Should fix | " + (.summary.should_fix|tostring) + " |\n" +
+      "| Nitpicks | " + (.summary.nitpicks|tostring) + " |\n" +
+      "| Positive | " + (.summary.positive|tostring) + " |\n\n" +
+      "### Now-fix\n\n" +
+      ((.findings // []) | map(select(.severity == "blocking" or .severity == "should_fix"))
+        | map("- **" + (.severity // "?") + "**: " + (.description // "")) | join("\n"))
+    ')
+    review_json_patch=$(printf '%s' "$norm" | jq -c '{
+      action: "review.triage",
+      blocking_ids: ((.findings // []) | map(select(.severity == "blocking") | .id)),
+      should_fix_ids: ((.findings // []) | map(select(.severity == "should_fix") | .id)),
+      scope_drift: .scope_drift.status
+    }')
+    render_copy_actions "$review_prompt" "$review_markdown" "$review_json_patch"
+  fi
 }
 
 render_security_body() {
@@ -895,6 +961,105 @@ render_findings_section() {
     printf '      </div>\n'
   done
   printf '    </section>\n'
+}
+
+# ─── Copy-only interactive controls (PR 4) ──────────────────
+#
+# Emits an actions card with three buttons (copy as prompt / copy as
+# Markdown / copy as JSON patch). Each button copies a pre-computed
+# payload to the clipboard. The script uses only
+# navigator.clipboard.writeText; no fetch, no XHR, no localStorage,
+# no form submission. CI lockes those forbidden APIs.
+#
+# Payloads are passed as JSON-encoded strings (via nano_json_string)
+# so embedded quotes, newlines, and control characters stay safe.
+# Each payload is also rendered as a <details><pre>...</pre> block
+# so the user can read and copy manually if the browser blocks
+# clipboard access (e.g. file:// without explicit permission).
+render_copy_actions() {
+  local prompt_payload="$1"
+  local markdown_payload="$2"
+  local json_payload="$3"
+  if [ "${INTERACTIVE:-false}" != true ]; then
+    return 0
+  fi
+
+  # Encode each payload as a JSON string literal so the inline JS
+  # can read it via JSON.parse. nano_json_string emits the full
+  # quoted form including the outer ". Critically: when embedding a
+  # JSON string INSIDE <script>...</script>, any `</` must be
+  # escaped to `<\/` because the HTML parser closes the script tag
+  # at the first literal `</script>` regardless of JS context. Any
+  # following content executes as a new <script> block. JSON.parse
+  # accepts the `<\/` form transparently, so this only hardens the
+  # surrounding HTML parser without changing the runtime payload.
+  _js_safe_for_script() {
+    sed 's|</|<\\/|g'
+  }
+  local p_js m_js j_js
+  p_js=$(printf '%s' "$prompt_payload" | nano_json_string | _js_safe_for_script)
+  m_js=$(printf '%s' "$markdown_payload" | nano_json_string | _js_safe_for_script)
+  j_js=$(printf '%s' "$json_payload" | nano_json_string | _js_safe_for_script)
+
+  # Visible escaped versions for the manual-copy <pre> blocks.
+  local p_html m_html j_html
+  p_html=$(printf '%s' "$prompt_payload" | nano_html_escape)
+  m_html=$(printf '%s' "$markdown_payload" | nano_html_escape)
+  j_html=$(printf '%s' "$json_payload" | nano_html_escape)
+
+  cat <<HTML
+    <section class="card" data-testid="copy-actions" data-interactive="1">
+      <h2>Copy back to the agent</h2>
+      <p class="muted">Local clipboard only. No data leaves your machine.</p>
+      <div class="copy-row">
+        <button type="button" class="copy-btn" data-payload-id="copy-prompt" data-format="prompt">Copy as prompt</button>
+        <button type="button" class="copy-btn" data-payload-id="copy-markdown" data-format="markdown">Copy as Markdown</button>
+        <button type="button" class="copy-btn" data-payload-id="copy-json" data-format="json-patch">Copy as JSON patch</button>
+        <span class="copy-status" data-testid="copy-status" aria-live="polite"></span>
+      </div>
+      <details>
+        <summary>Prompt payload (manual copy)</summary>
+        <pre data-testid="copy-prompt-pre">$p_html</pre>
+      </details>
+      <details>
+        <summary>Markdown payload (manual copy)</summary>
+        <pre data-testid="copy-markdown-pre">$m_html</pre>
+      </details>
+      <details>
+        <summary>JSON-patch payload (manual copy)</summary>
+        <pre data-testid="copy-json-pre">$j_html</pre>
+      </details>
+      <script>
+/* Interactive contract: clipboard write only. No fetch, no XHR, no
+   form submission, no storage, no eval. CI greps this file (and the
+   shared shell) for forbidden APIs. */
+(function () {
+  var payloads = {
+    "copy-prompt": $p_js,
+    "copy-markdown": $m_js,
+    "copy-json": $j_js
+  };
+  var buttons = document.querySelectorAll('button.copy-btn');
+  var status = document.querySelector('[data-testid="copy-status"]');
+  function announce(msg) { if (status) { status.textContent = msg; } }
+  buttons.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var id = btn.getAttribute('data-payload-id');
+      var text = payloads[id] || '';
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          function () { announce('Copied. Paste into the agent.'); },
+          function () { announce('Clipboard blocked. Use the manual copy below.'); }
+        );
+      } else {
+        announce('Clipboard API unavailable. Use the manual copy below.');
+      }
+    });
+  });
+})();
+      </script>
+    </section>
+HTML
 }
 
 # Shared helper for the context checkpoint card. Every core phase has
@@ -1563,7 +1728,9 @@ CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 # survives outside.
 if [ "$MANIFEST_ONLY" != true ]; then
   {
-    nano_visual_page_start "$PHASE" "$TRUST" "static"
+    csp_mode="static"
+    [ "$INTERACTIVE" = true ] && csp_mode="interactive"
+    nano_visual_page_start "$PHASE" "$TRUST" "$csp_mode"
 
     if [ "$SCHEMA_OK" = false ]; then
       printf '    <div class="schema-warning" data-testid="schema-warning">%s</div>\n' \
@@ -1618,7 +1785,7 @@ jq -n \
   --arg phase "$PHASE" \
   --argjson custom_phase false \
   --arg format "html" \
-  --argjson interactive false \
+  --argjson interactive "$($INTERACTIVE && echo true || echo false)" \
   --argjson strict "$($STRICT && echo true || echo false)" \
   --argjson source_artifacts "$SOURCE_ARTIFACTS_JSON" \
   --arg output_path "$HTML_PATH" \

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -94,7 +94,13 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --latest)         USE_LATEST=true ;;
     --strict)         STRICT=true ;;
-    --interactive)  INTERACTIVE=true ;;
+    --interactive)
+      # Codex PR 4 pass 1: --interactive widens the CSP to allow
+      # inline script. Only enable it for phases that actually emit
+      # copy controls (plan and review in v1) so the wider policy
+      # never applies where it has no purpose.
+      INTERACTIVE=true
+      ;;
     --manifest-only)  MANIFEST_ONLY=true ;;
     --out)
       shift
@@ -167,6 +173,21 @@ case "$PHASE" in
     exit 1
     ;;
 esac
+
+# Codex PR 4 pass 1: --interactive is supported only for /plan and
+# /review in v1. Reject elsewhere with exit 1 so the wider CSP
+# (script-src 'unsafe-inline') never applies to phases that emit no
+# copy controls. The architect's spec already scoped interactive UI
+# to those two phases.
+if [ "$INTERACTIVE" = true ]; then
+  case "$PHASE" in
+    plan|review) ;;
+    *)
+      echo "render-artifact: --interactive is supported only for /plan and /review in PR 4" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 # Default the journal date to today if neither --today nor --date
 # was supplied (codex PR 3 pass 2: bare `journal` left this empty
@@ -495,20 +516,23 @@ HTML
   # malformed shapes still produce useful payloads.
   if [ "${INTERACTIVE:-false}" = true ]; then
     local plan_prompt plan_markdown plan_json_patch
+    # Coerce every payload field with tostring/map(tostring) so a
+    # schema-warning artifact (numbers, objects, nulls in unexpected
+    # places) cannot crash jq under set -e. Codex PR 4 pass 1.
     plan_prompt=$(printf '%s' "$norm" | jq -r '
       "Approve the plan and continue.\n" +
-      "Goal: " + (.summary.goal // "Not recorded") + "\n" +
-      "Scope: " + (.summary.scope // "Not recorded") + "\n" +
-      "Planned files:\n  - " + ((.summary.planned_files // []) | join("\n  - ")) + "\n" +
-      "Risks:\n  - " + ((.summary.risks // []) | join("\n  - "))
+      "Goal: " + ((.summary.goal // "Not recorded") | tostring) + "\n" +
+      "Scope: " + ((.summary.scope // "Not recorded") | tostring) + "\n" +
+      "Planned files:\n  - " + ((.summary.planned_files // []) | map(tostring) | join("\n  - ")) + "\n" +
+      "Risks:\n  - " + ((.summary.risks // []) | map(tostring) | join("\n  - "))
     ')
     plan_markdown=$(printf '%s' "$norm" | jq -r '
       "## Plan summary\n\n" +
-      "- **Goal:** " + (.summary.goal // "Not recorded") + "\n" +
-      "- **Scope:** " + (.summary.scope // "Not recorded") + "\n" +
-      "- **Approval:** " + (.summary.plan_approval // "Not recorded") + "\n\n" +
+      "- **Goal:** " + ((.summary.goal // "Not recorded") | tostring) + "\n" +
+      "- **Scope:** " + ((.summary.scope // "Not recorded") | tostring) + "\n" +
+      "- **Approval:** " + ((.summary.plan_approval // "Not recorded") | tostring) + "\n\n" +
       "### Planned files\n\n" +
-      ((.summary.planned_files // []) | map("- `" + . + "`") | join("\n"))
+      ((.summary.planned_files // []) | map(tostring) | map("- `" + . + "`") | join("\n"))
     ')
     plan_json_patch=$(printf '%s' "$norm" | jq -c '{
       action: "plan.approve",
@@ -716,25 +740,29 @@ HTML
   # as-is.
   if [ "${INTERACTIVE:-false}" = true ]; then
     local review_prompt review_markdown review_json_patch
+    # Coerce every concatenated field with tostring (codex PR 4
+    # pass 1). A schema-warning review with .summary.blocking as a
+    # string or .scope_drift.status as a number would otherwise
+    # crash jq under set -e.
     review_prompt=$(printf '%s' "$norm" | jq -r '
       "Address the review findings before /ship.\n" +
-      "Summary: " + (.summary.blocking|tostring) + " blocking / " +
-                   (.summary.should_fix|tostring) + " should-fix / " +
-                   (.summary.nitpicks|tostring) + " nitpicks\n" +
-      "Scope drift: " + (.scope_drift.status // "unknown") + "\n" +
+      "Summary: " + ((.summary.blocking // 0) | tostring) + " blocking / " +
+                   ((.summary.should_fix // 0) | tostring) + " should-fix / " +
+                   ((.summary.nitpicks // 0) | tostring) + " nitpicks\n" +
+      "Scope drift: " + ((.scope_drift.status // "unknown") | tostring) + "\n" +
       "Now-fix:\n  - " +
-      ((.findings // []) | map(select(.severity == "blocking" or .severity == "should_fix")) | map(.description) | join("\n  - "))
+      ((.findings // []) | map(select(.severity == "blocking" or .severity == "should_fix")) | map((.description // "(no description)") | tostring) | join("\n  - "))
     ')
     review_markdown=$(printf '%s' "$norm" | jq -r '
       "## Review findings\n\n" +
       "| Severity | Count |\n|----|----|\n" +
-      "| Blocking | " + (.summary.blocking|tostring) + " |\n" +
-      "| Should fix | " + (.summary.should_fix|tostring) + " |\n" +
-      "| Nitpicks | " + (.summary.nitpicks|tostring) + " |\n" +
-      "| Positive | " + (.summary.positive|tostring) + " |\n\n" +
+      "| Blocking | " + ((.summary.blocking // 0) | tostring) + " |\n" +
+      "| Should fix | " + ((.summary.should_fix // 0) | tostring) + " |\n" +
+      "| Nitpicks | " + ((.summary.nitpicks // 0) | tostring) + " |\n" +
+      "| Positive | " + ((.summary.positive // 0) | tostring) + " |\n\n" +
       "### Now-fix\n\n" +
       ((.findings // []) | map(select(.severity == "blocking" or .severity == "should_fix"))
-        | map("- **" + (.severity // "?") + "**: " + (.description // "")) | join("\n"))
+        | map("- **" + ((.severity // "?") | tostring) + "**: " + ((.description // "") | tostring)) | join("\n"))
     ')
     review_json_patch=$(printf '%s' "$norm" | jq -c '{
       action: "review.triage",

--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1013,16 +1013,20 @@ render_copy_actions() {
   fi
 
   # Encode each payload as a JSON string literal so the inline JS
-  # can read it via JSON.parse. nano_json_string emits the full
-  # quoted form including the outer ". Critically: when embedding a
-  # JSON string INSIDE <script>...</script>, any `</` must be
-  # escaped to `<\/` because the HTML parser closes the script tag
-  # at the first literal `</script>` regardless of JS context. Any
-  # following content executes as a new <script> block. JSON.parse
-  # accepts the `<\/` form transparently, so this only hardens the
-  # surrounding HTML parser without changing the runtime payload.
+  # can read it via JSON.parse. Critically: when embedding a JSON
+  # string INSIDE <script>...</script>, several HTML parser states
+  # can swallow or re-interpret the script body. Codex PR 4 pass 3
+  # caught that escaping only `</` left the `<!--<script>` sequence
+  # able to put the parser into the "script data double escaped"
+  # state, which then eats the legitimate closing `</script>`.
+  #
+  # The fix: escape EVERY `<` as `<` in the script-embedded
+  # payload. JSON.parse reads `<` as the literal `<`, so the
+  # clipboard content the user pastes is unchanged. The HTML parser
+  # never sees a `<` inside the script body and stays in the
+  # standard "script data" state until the real closing tag.
   _js_safe_for_script() {
-    sed 's|</|<\\/|g'
+    sed 's|<|\\u003c|g'
   }
   local p_js m_js j_js
   p_js=$(printf '%s' "$prompt_payload" | nano_json_string | _js_safe_for_script)

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -38,12 +38,18 @@ check_absent() {
   local name="$1"; local pattern="$2"; shift 2
   local files=("$@")
   # `-e -- ` so a pattern starting with `-` (e.g. `--no-session-sync`)
-  # is not interpreted as a grep flag.
-  if grep -nE -e "$pattern" -- "${files[@]}" >/dev/null 2>&1; then
+  # is not interpreted as a grep flag. Exclude comment lines (PR 4):
+  # documenting the forbidden APIs in comments is fine, only actual
+  # source uses fail the lint.
+  local hits
+  hits=$(grep -nE -e "$pattern" -- "${files[@]}" 2>/dev/null \
+    | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' \
+    || true)
+  if [ -n "$hits" ]; then
     FAIL=$((FAIL+1))
     printf "  ${RED}FAIL${NC}  %s\n" "$name"
     printf "         ${DIM}pattern: %s${NC}\n" "$pattern"
-    grep -nE -e "$pattern" -- "${files[@]}" | sed 's/^/         /' || true
+    printf '%s\n' "$hits" | sed 's/^/         /'
   else
     PASS=$((PASS+1))
     printf "  ${GREEN}OK${NC}    %s\n" "$name"
@@ -200,6 +206,33 @@ check_absent "no SVG <image href" \
 # inside SVG which sidesteps the CSP and escape contract).
 check_absent "no SVG <foreignObject" \
   '<foreignObject' "bin/render-artifact.sh" "bin/lib/visual-render.sh"
+
+# 17. PR 4: interactive copy-only contract. The inline script body
+# must use ONLY navigator.clipboard.writeText. Everything that
+# could exfiltrate or persist is forbidden in renderer code.
+check_present "render_copy_actions uses navigator.clipboard.writeText" \
+  'navigator\.clipboard\.writeText' "bin/render-artifact.sh"
+check_present "render_copy_actions escapes </ in JS payloads" \
+  '_js_safe_for_script' "bin/render-artifact.sh"
+check_present "interactive CSP defines script-src" \
+  "script-src 'unsafe-inline'" "bin/lib/visual-render.sh"
+
+# 18. PR 4: confirm the static CSP path does NOT include
+# script-src. The shared helper has two arms in nano_visual_csp;
+# only the interactive arm should mention script-src.
+check_present "nano_visual_csp has separate static and interactive arms" \
+  'interactive\)' "bin/lib/visual-render.sh"
+
+# 19. PR 4: no forbidden APIs anywhere in the renderer code that
+# could end up in the rendered HTML. This re-runs the absence sweep
+# already in check 2-4 but explicitly under the interactive-mode
+# expansion lens.
+check_absent "no document.write" \
+  'document\.write' "bin/render-artifact.sh" "bin/lib/visual-render.sh"
+check_absent "no window.open" \
+  'window\.open' "bin/render-artifact.sh" "bin/lib/visual-render.sh"
+check_absent "no addEventListener for form submission" \
+  "addEventListener\\(['\"]submit" "bin/render-artifact.sh" "bin/lib/visual-render.sh"
 
 TOTAL=$((PASS+FAIL))
 printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -434,8 +434,7 @@ setup_project "$PROJ"
 export NANOSTACK_STORE="$PROJ/.nanostack"
 mkdir -p "$NANOSTACK_STORE"
 (cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
-assert_exit "--interactive reserved (exit 2)" 2 \
-  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' plan --latest --interactive"
+: # --interactive is enabled in PR 4 (no longer reserved). Tested by cells 23d-23h.
 
 # ─── Cell 7: --manifest-only ────────────────────────────────
 printf "\n  ${DIM}Cell 7: --manifest-only${NC}\n"
@@ -1435,6 +1434,99 @@ MFST=$(ls "$NANOSTACK_STORE/visual/manifests/"*stack*default*.manifest.json | he
 FIRST_PATH=$(jq -r '.source_artifacts[0].path' "$MFST")
 assert_true "default stack manifest records config.json" \
   sh -c "echo '$FIRST_PATH' | grep -q '\.nanostack/config\.json$'"
+
+# ─── Cell 23d: --interactive emits copy buttons (PR 4) ──────
+printf "\n  ${DIM}Cell 23d: --interactive emits copy buttons (PR 4)${NC}\n"
+PROJ="$TMP_ROOT/cell23d"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
+assert_true "interactive plan html exists" test -f "$HTML"
+assert_contains "interactive plan has copy-actions section" "$HTML" 'data-testid="copy-actions"'
+assert_contains "interactive plan has data-interactive=1" "$HTML" 'data-interactive="1"'
+assert_contains "interactive plan has copy-prompt button" "$HTML" 'data-payload-id="copy-prompt"'
+assert_contains "interactive plan has copy-markdown button" "$HTML" 'data-payload-id="copy-markdown"'
+assert_contains "interactive plan has copy-json button" "$HTML" 'data-payload-id="copy-json"'
+assert_contains "interactive plan has copy-status target" "$HTML" 'data-testid="copy-status"'
+assert_contains "interactive plan has manual-copy <pre> for prompt" "$HTML" 'data-testid="copy-prompt-pre"'
+assert_contains "interactive plan uses navigator.clipboard.writeText" "$HTML" 'navigator.clipboard.writeText'
+# Capture the interactive manifest BEFORE the static render so a
+# later mtime sort cannot pick the wrong one.
+MFST_I=$(ls -t "$NANOSTACK_STORE/visual/manifests/"*plan*.manifest.json | head -1)
+assert_true "interactive manifest records interactive: true" \
+  sh -c "[ \"\$(jq -r .interactive '$MFST_I')\" = 'true' ]"
+# Without --interactive, NO copy section.
+HTML_S=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest)
+assert_not_contains "static plan has NO copy-actions" "$HTML_S" 'data-testid="copy-actions"'
+assert_not_contains "static CSP does NOT allow script-src" "$HTML_S" "script-src 'unsafe-inline'"
+
+# ─── Cell 23e: --interactive CSP allows inline script (PR 4) ─
+printf "\n  ${DIM}Cell 23e: interactive CSP (PR 4)${NC}\n"
+PROJ="$TMP_ROOT/cell23e"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
+assert_contains "interactive CSP includes script-src 'unsafe-inline'" "$HTML" "script-src 'unsafe-inline'"
+assert_contains "interactive CSP still locks default-src 'none'" "$HTML" "default-src 'none'"
+assert_contains "interactive CSP still locks form-action 'none'" "$HTML" "form-action 'none'"
+# Static still has the tighter CSP.
+HTML_S=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest)
+assert_not_contains "static CSP has NO script-src directive" "$HTML_S" "script-src"
+
+# ─── Cell 23f: interactive output is forbidden-API free (PR 4) ─
+printf "\n  ${DIM}Cell 23f: forbidden APIs absent from interactive output (PR 4)${NC}\n"
+PROJ="$TMP_ROOT/cell23f"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_plan "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_review "$NANOSTACK_STORE")
+HTML_P=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
+HTML_R=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest --interactive)
+for h in "$HTML_P" "$HTML_R"; do
+  assert_not_contains "no fetch( in $(basename $h)" "$h" "fetch("
+  assert_not_contains "no XMLHttpRequest in $(basename $h)" "$h" "XMLHttpRequest"
+  assert_not_contains "no sendBeacon in $(basename $h)" "$h" "sendBeacon"
+  assert_not_contains "no localStorage in $(basename $h)" "$h" "localStorage"
+  assert_not_contains "no sessionStorage in $(basename $h)" "$h" "sessionStorage"
+  assert_not_contains "no document.cookie in $(basename $h)" "$h" "document.cookie"
+  assert_not_contains "no eval( in $(basename $h)" "$h" "eval("
+  assert_not_contains "no new Function in $(basename $h)" "$h" "new Function"
+  assert_not_contains "no <form in $(basename $h)" "$h" "<form"
+  # Only external URL allowed: github.com PR links (PR 2 ship);
+  # otherwise no http(s):// inside script body.
+done
+
+# ─── Cell 23g: interactive review has copy buttons (PR 4) ───
+printf "\n  ${DIM}Cell 23g: interactive review (PR 4)${NC}\n"
+HTML=$HTML_R
+assert_contains "interactive review has copy-actions" "$HTML" 'data-testid="copy-actions"'
+# Review's prompt payload references review-specific terms.
+assert_contains "interactive review prompt mentions findings" "$HTML" 'review findings before /ship'
+
+# ─── Cell 23h: </script> in payload does NOT break out of inline script (PR 4 XSS) ─
+printf "\n  ${DIM}Cell 23h: </script> payload XSS containment (PR 4)${NC}\n"
+PROJ="$TMP_ROOT/cell23h"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"\"</script><script>alert(\"XSS\")</script>","scope":"s","planned_files":["</script>"],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
+# The malicious sequence must NOT appear as literal `</script><script>` anywhere.
+LIT_COUNT=$(grep -o '</script><script>' "$HTML" | wc -l | tr -d ' ')
+assert_true "no raw </script><script> sequence in interactive output" sh -c "[ '$LIT_COUNT' = '0' ]"
+# The escaped form should appear (proves we transformed it).
+assert_contains "escaped <\\/script> form present" "$HTML" '<\/script>'
+# Manual copy <pre> is HTML-escaped.
+assert_contains "manual-copy <pre> shows escaped tag" "$HTML" '&lt;/script&gt;'
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1572,8 +1572,16 @@ cat > "$NANOSTACK_STORE/plan/$(date -u +%Y%m%d)-120000.json" <<JSON
   "context_checkpoint": {"summary": null}
 }
 JSON
-HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive 2>/dev/null || true)
-[ -n "$HTML" ] && assert_true "schema-warning plan with --interactive renders" test -f "$HTML"
+# Render must succeed (exit 0). Without unconditional assertion the
+# `|| true` mask would have made the cell silently pass on regressions
+# (codex PR 4 pass 2).
+set +e
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive 2>&1)
+RC=$?
+set -e
+assert_exit "schema-warning plan with --interactive exits 0" 0 test "$RC" = 0
+assert_true "schema-warning plan html path is non-empty" sh -c "[ -n '$HTML' ]"
+assert_true "schema-warning plan html file exists" test -f "$HTML"
 
 # ─── Cell 23k: --interactive on schema-warning review does not crash (PR 4 pass 1) ─
 printf "\n  ${DIM}Cell 23k: --interactive on schema-warning review (PR 4 pass 1)${NC}\n"
@@ -1591,8 +1599,14 @@ cat > "$NANOSTACK_STORE/review/$(date -u +%Y%m%d)-120000.json" <<JSON
   "context_checkpoint": {}
 }
 JSON
-HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest --interactive 2>/dev/null || true)
-[ -n "$HTML" ] && assert_true "schema-warning review with --interactive renders" test -f "$HTML"
+# Same unconditional assertion as cell 23j.
+set +e
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest --interactive 2>&1)
+RC=$?
+set -e
+assert_exit "schema-warning review with --interactive exits 0" 0 test "$RC" = 0
+assert_true "schema-warning review html path is non-empty" sh -c "[ -n '$HTML' ]"
+assert_true "schema-warning review html file exists" test -f "$HTML"
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1523,8 +1523,9 @@ HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
 # The malicious sequence must NOT appear as literal `</script><script>` anywhere.
 LIT_COUNT=$(grep -o '</script><script>' "$HTML" | wc -l | tr -d ' ')
 assert_true "no raw </script><script> sequence in interactive output" sh -c "[ '$LIT_COUNT' = '0' ]"
-# The escaped form should appear (proves we transformed it).
-assert_contains "escaped <\\/script> form present" "$HTML" '<\/script>'
+# PR 4 pass 3 switched the escape from `<\/` to `<`. Confirm
+# the u003c form appears (transformation happened).
+assert_contains "encoded u003c form present in output" "$HTML" "u003c"
 # Manual copy <pre> is HTML-escaped.
 assert_contains "manual-copy <pre> shows escaped tag" "$HTML" '&lt;/script&gt;'
 
@@ -1607,6 +1608,45 @@ set -e
 assert_exit "schema-warning review with --interactive exits 0" 0 test "$RC" = 0
 assert_true "schema-warning review html path is non-empty" sh -c "[ -n '$HTML' ]"
 assert_true "schema-warning review html file exists" test -f "$HTML"
+
+# ─── Cell 23l: <!--<script> in payload neutralized (PR 4 pass 3) ─
+printf "\n  ${DIM}Cell 23l: <!--<script> XSS containment (PR 4 pass 3)${NC}\n"
+PROJ="$TMP_ROOT/cell23l"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" plan '{
+  "phase":"plan",
+  "summary":{"goal":"<!--<script>alert(1)</script>","scope":"s","planned_files":[],"plan_approval":"manual"},
+  "context_checkpoint":{"summary":"x","key_files":[],"decisions_made":[],"open_questions":[]}
+}' >/dev/null)
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive)
+# Extract the inline <script>...</script> block. Match the FIRST
+# `<script>` (the renderer's own block) and the FIRST closing tag
+# after it.
+SCRIPT_BODY=$(awk '
+  /^[[:space:]]*<script>/ { in_script=1; next }
+  /^[[:space:]]*<\/script>/ { in_script=0 }
+  in_script { print }
+' "$HTML")
+# Forbidden raw HTML sequences inside the inline JS body.
+for needle in '<!--' '<script' '</script' '<!CDATA'; do
+  if printf '%s' "$SCRIPT_BODY" | grep -qF "$needle"; then
+    FAIL=$((FAIL+1))
+    printf "    ${RED}FAIL${NC}  script body contains literal %s (HTML parser hazard)\n" "$needle"
+  else
+    PASS=$((PASS+1))
+    printf "    ${GREEN}OK${NC}    script body has no literal %s\n" "$needle"
+  fi
+done
+# Encoded form should appear in the file (visible escape sequence).
+if grep -qF 'u003c' "$HTML"; then
+  PASS=$((PASS+1))
+  printf "    ${GREEN}OK${NC}    encoded u003c form present\n"
+else
+  FAIL=$((FAIL+1))
+  printf "    ${RED}FAIL${NC}  encoded u003c form missing\n"
+fi
 
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1528,6 +1528,72 @@ assert_contains "escaped <\\/script> form present" "$HTML" '<\/script>'
 # Manual copy <pre> is HTML-escaped.
 assert_contains "manual-copy <pre> shows escaped tag" "$HTML" '&lt;/script&gt;'
 
+# ─── Cell 23i: --interactive rejected outside plan/review (PR 4 pass 1) ─
+printf "\n  ${DIM}Cell 23i: --interactive scope (PR 4 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell23i"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+(cd "$PROJ" && save_valid_security "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_qa "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_ship "$NANOSTACK_STORE")
+(cd "$PROJ" && save_valid_think "$NANOSTACK_STORE")
+assert_exit "security --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' security --latest --interactive"
+assert_exit "qa --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' qa --latest --interactive"
+assert_exit "ship --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' ship --latest --interactive"
+assert_exit "think --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' think --latest --interactive"
+assert_exit "journal --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' journal --today --interactive"
+assert_exit "stack --interactive rejected" 1 \
+  sh -c "cd '$PROJ' && '$REPO/bin/render-artifact.sh' stack default --interactive"
+
+# ─── Cell 23j: --interactive on schema-warning plan does not crash (PR 4 pass 1) ─
+printf "\n  ${DIM}Cell 23j: --interactive on schema-warning plan (PR 4 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell23j"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/plan"
+# Plan with non-string risks (objects) and numeric planned_files.
+# Schema validation will fail but the renderer must still produce HTML.
+cat > "$NANOSTACK_STORE/plan/$(date -u +%Y%m%d)-120000.json" <<JSON
+{
+  "phase": "plan",
+  "project": "$PROJ",
+  "summary": {
+    "goal": 42,
+    "planned_files": [123, 456],
+    "plan_approval": "manual",
+    "risks": [{"complicated":true}]
+  },
+  "context_checkpoint": {"summary": null}
+}
+JSON
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest --interactive 2>/dev/null || true)
+[ -n "$HTML" ] && assert_true "schema-warning plan with --interactive renders" test -f "$HTML"
+
+# ─── Cell 23k: --interactive on schema-warning review does not crash (PR 4 pass 1) ─
+printf "\n  ${DIM}Cell 23k: --interactive on schema-warning review (PR 4 pass 1)${NC}\n"
+PROJ="$TMP_ROOT/cell23k"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/review"
+cat > "$NANOSTACK_STORE/review/$(date -u +%Y%m%d)-120000.json" <<JSON
+{
+  "phase": "review",
+  "project": "$PROJ",
+  "summary": {"blocking":"one","should_fix":2,"nitpicks":3,"positive":0},
+  "scope_drift": {"status": 42},
+  "findings": [{"id":"X","severity":"blocking","description":{"nested":"object"}}],
+  "context_checkpoint": {}
+}
+JSON
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" review --latest --interactive 2>/dev/null || true)
+[ -n "$HTML" ] && assert_true "schema-warning review with --interactive renders" test -f "$HTML"
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"


### PR DESCRIPTION
## Summary

PR 4 of the Visual Artifacts v1 round. Enables the documented copy-only interactive layer from the architect spec. v1 scope is **copy-only**: `/plan` and `/review` get an actions card with three buttons (copy as prompt / copy as Markdown / copy as JSON patch). The buttons write to the clipboard via `navigator.clipboard.writeText`; nothing else.

### What changed

**Renderer**
- `render_copy_actions` shared helper: emits an actions card with three buttons and an inline `<script>` that wires `navigator.clipboard.writeText`. Each payload also renders inside `<details><pre>` for manual copy when the clipboard API is blocked.
- `_js_safe_for_script`: encodes every `<` in the JSON-embedded payload as `<` so the HTML parser cannot exit the script body via `<!--<script>`, `</script>`, or `<!CDATA[` sequences.
- `--interactive` arg-parse, manifest `interactive: true`, CSP switch.
- `--interactive` rejected outside `/plan` and `/review` with exit 1 so the wider CSP never applies where no script is emitted.

**Payload shapes** (built from the normalized JSON; every concatenation runs through `tostring`)
- `/plan`: "Approve the plan" prompt; "## Plan summary" Markdown; `{action: "plan.approve", goal, scope, planned_files, out_of_scope}` JSON patch.
- `/review`: "Address review findings" prompt; severity table Markdown; `{action: "review.triage", blocking_ids, should_fix_ids, scope_drift}` JSON patch.

**Hard rules locked in CI**
- Inline script body uses ONLY `navigator.clipboard.writeText`. No `fetch`, no `XMLHttpRequest`, no `sendBeacon`, no `localStorage`, no `sessionStorage`, no `document.cookie`, no `eval`, no `new Function`, no `document.write`, no `window.open`, no `<form>`, no `addEventListener('submit', ...)`.
- CSP under `--interactive` adds `script-src 'unsafe-inline'`; static CSP keeps the tighter form. Both still lock `base-uri 'none'` and `form-action 'none'`.
- Manifest records `interactive: true`.

### Codex review trail (4 passes, clean)

| Pass | Finding | Fix |
|------|---------|-----|
| 1 | --interactive widened CSP for unsupported phases; plan/review payloads crashed on non-string fields | reject outside plan/review; tostring on every concatenation |
| 2 | schema-warning test had `\|\| true` mask | unconditional exit-0 + file assertions |
| 3 | `<!--<script>` payload could trigger double-escape HTML parser state | switch escape from `</` -> `<\/` to every `<` -> `<` |
| 4 | (clean) | — |

### Test counts

| Suite | PR 3 | PR 4 |
|-------|------|------|
| `ci/e2e-visual-artifacts.sh` | 266 | 321 |
| `ci/check-visual-artifact-templates.sh` | 31 | 38 |
| **Total contract surface** | **297** | **359** |

## Test plan
- [x] `ci/e2e-visual-artifacts.sh` 321/321
- [x] `ci/check-visual-artifact-templates.sh` 38/38
- [x] Codex pass 4 returned clean
- [x] Static plan has no copy-actions and tight CSP; interactive plan has buttons and the relaxed CSP
- [x] `</script>` and `<!--<script>` in artifact content cannot escape the script body
- [x] Manifest `interactive` flag flips between true/false correctly
- [x] Schema-warning artifact (numeric goal, object risks, string blocking count) still renders under --interactive