### PR TITLE
visual-artifacts: user-installed stack wins over bundled example (VA-STACK-001)

### DIFF
--- a/bin/render-artifact.sh
+++ b/bin/render-artifact.sh
@@ -1332,17 +1332,21 @@ EOF
 render_stack_body() {
   local name="$1"
 
-  # Locate the stack definition. Order:
-  #   1. examples/custom-stack-template/<name>/stack.json (repo-bundled)
-  #   2. $NANOSTACK_STORE/stacks/<name>/stack.json (user-installed)
-  #   3. .nanostack/config.json (.phase_graph) for "default" / current project
+  # Locate the stack definition. User-installed stacks win over
+  # repo-bundled examples so a customized `compliance-release` in
+  # the project store is not silently shadowed by the example with
+  # the same name (architect audit VA-STACK-001, 2026-05-11).
+  # Order:
+  #   1. $NANOSTACK_STORE/stacks/<name>/stack.json (user-installed)
+  #   2. examples/custom-stack-template/<name>/stack.json (bundled fallback)
+  #   3. .nanostack/config.json (.phase_graph) only for `stack default`.
   local stack_file=""
   local repo_root
   repo_root="$SCRIPT_DIR/.."
-  if [ -f "$repo_root/examples/custom-stack-template/$name/stack.json" ]; then
-    stack_file="$repo_root/examples/custom-stack-template/$name/stack.json"
-  elif [ -f "$NANOSTACK_STORE/stacks/$name/stack.json" ]; then
+  if [ -f "$NANOSTACK_STORE/stacks/$name/stack.json" ]; then
     stack_file="$NANOSTACK_STORE/stacks/$name/stack.json"
+  elif [ -f "$repo_root/examples/custom-stack-template/$name/stack.json" ]; then
+    stack_file="$repo_root/examples/custom-stack-template/$name/stack.json"
   fi
 
   local graph_json=""

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -1648,6 +1648,59 @@ else
   printf "    ${RED}FAIL${NC}  encoded u003c form missing\n"
 fi
 
+# ─── Cell 24a: user-installed stack wins over bundled example (VA-STACK-001) ─
+# Architect audit 2026-05-11 (Visual Artifacts v1 Security Audit). Without
+# the fix, `bin/render-artifact.sh stack compliance-release` rendered the
+# repo-bundled example even when a user-installed stack of the same name
+# existed under $NANOSTACK_STORE/stacks/<name>/stack.json. The visual and
+# manifest would describe the wrong workflow with no observable error,
+# which breaks the trust contract for compliance/release reviews.
+printf "\n  ${DIM}Cell 24a: user stack wins over bundled (VA-STACK-001)${NC}\n"
+PROJ="$TMP_ROOT/cell24a-projA"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE/stacks/compliance-release"
+cat > "$NANOSTACK_STORE/stacks/compliance-release/stack.json" <<'CFG'
+{
+  "schema_version": "1",
+  "name": "compliance-release",
+  "display_name": "User Compliance Override",
+  "description": "User-installed stack must win over the bundled example",
+  "phase_graph": [
+    {"name": "plan", "depends_on": []},
+    {"name": "user-gate", "depends_on": ["plan"]}
+  ]
+}
+CFG
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_true "user-installed stack render produced HTML" test -f "$HTML"
+assert_contains "user-installed stack display_name surfaces" "$HTML" "User Compliance Override"
+assert_contains "user-installed stack has user-gate phase" "$HTML" 'data-phase="user-gate"'
+assert_not_contains "user-installed stack does NOT show bundled license-audit phase" "$HTML" 'data-phase="license-audit"'
+MFST=$(ls -t "$NANOSTACK_STORE/visual/manifests/"*stack*compliance-release*.manifest.json | head -1)
+FIRST_PATH=$(jq -r '.source_artifacts[0].path' "$MFST")
+assert_true "manifest first source is the user-installed stack file" \
+  sh -c "[ '$FIRST_PATH' = '$NANOSTACK_STORE/stacks/compliance-release/stack.json' ]"
+unset NANOSTACK_STORE
+
+# ─── Cell 24b: bundled example still renders when no user stack (VA-STACK-001) ─
+printf "\n  ${DIM}Cell 24b: bundled fallback (VA-STACK-001)${NC}\n"
+PROJ="$TMP_ROOT/cell24b-clean"
+setup_project "$PROJ"
+export NANOSTACK_STORE="$PROJ/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+# No $NANOSTACK_STORE/stacks/compliance-release; the bundled example
+# under examples/custom-stack-template must still render.
+HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" stack compliance-release)
+assert_true "bundled fallback produces HTML" test -f "$HTML"
+assert_contains "bundled stack has license-audit phase" "$HTML" 'data-phase="license-audit"'
+assert_contains "bundled stack display_name surfaces" "$HTML" "Compliance Release Stack"
+MFST=$(ls -t "$NANOSTACK_STORE/visual/manifests/"*stack*compliance-release*.manifest.json | head -1)
+FIRST_PATH=$(jq -r '.source_artifacts[0].path' "$MFST")
+assert_true "bundled-fallback manifest references the example file" \
+  sh -c "echo '$FIRST_PATH' | grep -q 'examples/custom-stack-template/compliance-release/stack.json'"
+unset NANOSTACK_STORE
+
 # ─── Cell 9a: --out works on fresh store (PR 1 pass 1 regression) ─
 printf "\n  ${DIM}Cell 9a: --out on fresh store (PR 1 pass 1 regression)${NC}\n"
 PROJ="$TMP_ROOT/cell9a"

--- a/reference/visual-artifact-contract.md
+++ b/reference/visual-artifact-contract.md
@@ -38,7 +38,7 @@ bin/render-artifact.sh stack [<name>] [--strict] [--manifest-only]
 | `journal --today` | Aggregate every registered phase artifact for today's date into a sprint timeline. |
 | `journal --date YYYY-MM-DD` | Same shape, restricted to the requested date. Filename prefix filter; no 30-day fallback. |
 | `journal` (no flag) | Defaults to today's UTC date. |
-| `stack <name>` | Render a custom workflow DAG. Looks up `examples/custom-stack-template/<name>/stack.json`, then `$NANOSTACK_STORE/stacks/<name>/stack.json`. |
+| `stack <name>` | Render a custom workflow DAG. Looks up `$NANOSTACK_STORE/stacks/<name>/stack.json` first (user-installed), then `examples/custom-stack-template/<name>/stack.json` as a bundled-example fallback. A user-installed stack with the same name as a bundled example always wins. |
 | `stack default` | Falls back to `.nanostack/config.json`'s `phase_graph` when no named stack file is found. Any other unknown name renders a "Stack not found" notice rather than falling back. |
 
 | Flag | Behavior |


### PR DESCRIPTION
## Summary

Closes VA-STACK-001 from the Visual Artifacts v1 Security Audit (architect review, 2026-05-11). Single P2 finding: named stack lookup checked the repo-bundled example before the project's user-installed stack, so a customized `compliance-release` was silently shadowed by the example with the same name. The render and manifest looked authoritative but described the wrong workflow.

### Fix

Swap precedence in `render_stack_body`:

1. `$NANOSTACK_STORE/stacks/<name>/stack.json` (user-installed)
2. `examples/custom-stack-template/<name>/stack.json` (bundled fallback)
3. `.nanostack/config.json` only for `stack default` (unchanged)

A user-installed stack with the same name as a bundled example always wins. Bundled fallback still applies when no user stack exists. Malformed-named-stack and stack-not-found paths are unchanged.

### Files

- `bin/render-artifact.sh`: swap the lookup order in `render_stack_body`.
- `reference/visual-artifact-contract.md`: update the `stack <name>` row to reflect the new order.
- `ci/e2e-visual-artifacts.sh`: 2 new cells (24a, 24b) covering both directions.

### Regression coverage

| Cell | Scenario | Asserts |
|------|----------|---------|
| 24a | User-installed `compliance-release` with phase `user-gate` + display_name "User Compliance Override" | HTML shows user phases; does NOT show bundled `license-audit`; manifest first source is the user-installed stack file |
| 24b | No user stack, bundled example only | HTML shows bundled phases; manifest first source is the examples file |

### Codex review trail (1 pass, clean)

Pass 1: clean.

## Test plan
- [x] `ci/check-visual-artifact-templates.sh` 38/38
- [x] `ci/e2e-visual-artifacts.sh` 330/330 (was 321; +9 from cells 24a + 24b)
- [x] `tests/run.sh` 83/83
- [x] Architect's reproduction (user stack overrides bundled) — manifest first source now points at `$NANOSTACK_STORE/stacks/compliance-release/stack.json`
- [x] Codex pass 1 returned clean