### PR TITLE
security: bump telemetry worker ws advisory

### DIFF
--- a/telemetry-worker/bun.lock
+++ b/telemetry-worker/bun.lock
@@ -11,6 +11,9 @@
       },
     },
   },
+  "overrides": {
+    "ws": "^8.20.1",
+  },
   "packages": {
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
@@ -188,7 +191,7 @@
 
     "wrangler": ["wrangler@4.85.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260424.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260424.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260424.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/telemetry-worker/package.json
+++ b/telemetry-worker/package.json
@@ -13,5 +13,9 @@
     "@cloudflare/workers-types": "^4.20260101.0",
     "typescript": "^5.4.0",
     "wrangler": "^4.85.0"
+  },
+  "//overrides": "ws < 8.20.1 has a moderate advisory (GHSA-58qx-3vcg-4xpx, uninitialized memory disclosure). It reaches us transitively via wrangler > miniflare. Pin to the patched line here rather than bumping wrangler, because wrangler 4.95 adds a third-party native-binary dependency we do not want in a privacy-strict Worker. Revisit when miniflare ships ws >= 8.20.1 upstream.",
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

`bun audit` in the Telemetry Worker supply-chain CI job started failing on a
moderate advisory: GHSA-58qx-3vcg-4xpx (`ws` uninitialized memory disclosure,
affects `>=8.0.0 <8.20.1`). It reaches the Worker transitively via
`wrangler > miniflare > ws` (miniflare pins `ws@8.18.0`). This already fails on
`main` and blocks unrelated PRs.

## Fix

Pin `ws` to the patched line with a single override in
`telemetry-worker/package.json`:

```json
"overrides": { "ws": "^8.20.1" }
```

Resolves `ws` to 8.21.0 across the tree. No vulnerabilities remain.

## Why an override instead of bumping wrangler

Bumping `wrangler` to the current latest (4.95.0) does fix the advisory, but it
adds a new direct dependency, `rosie-skills` (a third-party "package manager for
AI agent skills" with per-platform native binaries), that 4.85.0 does not pull
in. For a privacy-strict, public-facing Worker, trading a moderate advisory for
a new third-party native-binary dependency is the wrong call. The override is the
minimal change: it patches `ws` only, leaves wrangler/miniflare untouched, and is
documented inline with a note to revisit when miniflare ships `ws >= 8.20.1`.

## Validation

- `bun install --frozen-lockfile`: no changes (package.json and bun.lock agree).
- `bun audit`: No vulnerabilities found.
- `bun x tsc --noEmit`: clean.

Scope: `telemetry-worker/` only.
