### PR TITLE
adapters: behavior-lock enforcement claims and align README L-level legend

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3644,14 +3644,17 @@ jobs:
     runs-on: ubuntu-latest
     # PR 6 of the 2026-05-10 architecture audit. Runs bin/check-adapters.sh
     # so a stale or malformed adapter cannot ship to main.
+    # PR 2 of the 2026-05-28 follow-up adds --require-readme-contracts so
+    # the README matrix/legend + schema locks fail closed: a missing table
+    # or schema file is a hard failure here, not a silent skip.
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Run check-adapters.sh
+      - name: Run check-adapters.sh (strict)
         run: |
           chmod +x bin/check-adapters.sh
-          bin/check-adapters.sh
+          bin/check-adapters.sh --require-readme-contracts
 
   custom-routing-contract:
     name: Custom routing contract wired into resolve.sh

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Nanostack is agent-agnostic, but agent hosts do not expose the same control poin
 
 | Level | Meaning |
 |-------|---------|
-| **L0 Unsupported** | Nanostack cannot provide this capability on that host. |
-| **L1 Instructions only** | The skill tells the agent what to do, but cannot block it. |
-| **L2 Reported** | Nanostack can detect and report the issue. |
-| **L3 Enforced** | Nanostack can block the action through host hooks or guard scripts. |
+| **L0 Guided** | The skill tells the agent what to do but cannot block it. Also covers a capability the host cannot provide at all. |
+| **L1 Checked** | Nanostack can detect and report the issue, but cannot block it. |
+| **L2 Guarded** | The host runs a nanostack hook before the action. |
+| **L3 Enforced** | The hook can block the action and the host honors the block. |
+| **L4 Continuously verified** | A CI job exercises the capability on every change. |
 
 A detailed per-host matrix (Bash guard, Write/Edit guard, phase gate) lives further down in [What enforces on which agent](#what-enforces-on-which-agent).
 
@@ -491,7 +492,7 @@ All rules live in [`guard/rules.json`](guard/rules.json). Each rule has an ID, r
 
 ### What enforces on which agent
 
-Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today. The capability that ships for each host lives in [`adapters/`](adapters/) as a small JSON file; setup, doctor, and this table all read from those files. Levels follow the L0-L3 vocabulary documented in [`reference/host-adapter-schema.md`](reference/host-adapter-schema.md).
+Honest scope. Nanostack ships skill files that work the same in every supported agent, but the **enforcement layer** (hooks that block commands before they run) depends on what each agent supports today. The capability that ships for each host lives in [`adapters/`](adapters/) as a small JSON file; setup, doctor, and this table all read from those files. Levels follow the L0-L4 vocabulary documented in [`reference/host-adapter-schema.md`](reference/host-adapter-schema.md).
 
 | Agent | Bash guard | Write/Edit guard | Phase gate | What this means |
 |---|---|---|---|---|

--- a/adapters/claude.json
+++ b/adapters/claude.json
@@ -1,10 +1,11 @@
 {
   "host": "claude",
   "schema_version": "1",
-  "last_verified": "2026-04-25",
+  "last_verified": "2026-05-28",
   "verification": {
     "method": "ci",
-    "evidence": ".github/workflows/lint.yml: guard-regression and write-guard-regression jobs exercise check-dangerous.sh and check-write.sh on every PR"
+    "evidence": ".github/workflows/lint.yml: guard-regression and write-guard-regression jobs exercise check-dangerous.sh and check-write.sh on every pull_request and push. The phase gate is additionally exercised by e2e-user-flows and e2e-concurrency-parity in .github/workflows/e2e.yml, which is workflow_dispatch-only (run before release), so those are not listed as continuous ci_jobs.",
+    "ci_jobs": ["guard-regression", "write-guard-regression"]
   },
   "skill_discovery": "native",
   "bash_guard": "enforced",

--- a/bin/check-adapters.sh
+++ b/bin/check-adapters.sh
@@ -8,9 +8,17 @@
 # freshness and surfaces drift before it reaches a release.
 #
 # Usage:
-#   bin/check-adapters.sh                Validate every adapters/*.json.
-#   bin/check-adapters.sh <host>         Validate one adapter.
-#   bin/check-adapters.sh --json         Machine-readable summary.
+#   bin/check-adapters.sh                       Validate every adapters/*.json.
+#   bin/check-adapters.sh <host>                Validate one adapter.
+#   bin/check-adapters.sh --json                Machine-readable summary.
+#   bin/check-adapters.sh --require-readme-contracts
+#                                               Strict mode (for CI): also
+#       require that the schema file, the README per-host matrix, and the
+#       README L-level legend are PRESENT, not just consistent when present.
+#       Without this flag the README/schema-derived locks skip when a file
+#       or table is absent, so an isolated partial checkout still validates
+#       adapter JSON shape. The live lint/e2e jobs pass this flag so the
+#       contracts cannot be silently disabled by deleting a table.
 #
 # Freshness policy:
 #   - warn after 30 days
@@ -35,10 +43,12 @@ WARN_DAYS=30
 FAIL_DAYS=60
 
 JSON_OUT=false
+REQUIRE_CONTRACTS=false
 FILTER=""
 for arg in "$@"; do
   case "$arg" in
     --json) JSON_OUT=true ;;
+    --require-readme-contracts) REQUIRE_CONTRACTS=true ;;
     -h|--help)
       sed -n '/^# /,/^$/p' "$0" | sed 's/^# //'
       exit 0
@@ -81,6 +91,141 @@ SCHEMA_VERSION_ENUM="1"
 # warns).
 README_LISTED=$(grep -oE '`(claude|cursor|codex|opencode|gemini)`' "$NANOSTACK_ROOT/README.md" 2>/dev/null \
   | tr -d '`' | sort -u | tr '\n' ' ')
+
+README_FILE="$NANOSTACK_ROOT/README.md"
+SCHEMA_FILE="$NANOSTACK_ROOT/reference/host-adapter-schema.md"
+WORKFLOW_DIR="$NANOSTACK_ROOT/.github/workflows"
+BT='`'
+
+# ---- L-level vocabulary, parsed from the host adapter schema ----
+# PR 2 of the 2026-05-28 architecture follow-up. reference/host-adapter-schema.md
+# is the single source of truth for the capability -> L-level -> label
+# mapping. Parse it once here so the README legend and per-host matrix can
+# be validated against it instead of a second hardcoded copy that could
+# drift. The bullet lines look like:
+#   - `unsupported` and `instructions_only` are L0 ("Guided")
+#   - `enforced` is L3 ("Enforced")
+#   - L4 ("Continuously verified") is not a capability value ...
+# When the schema is absent (partial checkout, or a test fixture that does
+# not ship it) the README-derived checks that need it are skipped: they
+# cannot run without the source of truth, and the live repo always ships
+# the schema so the real lock still fires.
+SCHEMA_PRESENT=false
+SCHEMA_PARSE_OK=false
+CAP_LEVEL_MAP=""    # newline list of "cap<TAB>level"
+LEVEL_LABEL_MAP=""  # newline list of "level<TAB>label"
+
+# Normalize a cell/label for comparison: lowercase, strip backticks,
+# trim and collapse internal whitespace.
+norm_label() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '`' \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g'
+}
+
+if [ -f "$SCHEMA_FILE" ]; then
+  SCHEMA_PRESENT=true
+  SCHEMA_PARSE_OK=true
+  for _cap in unsupported instructions_only detectable hooked enforced; do
+    _bullet=$(grep -E '^- ' "$SCHEMA_FILE" | grep -F "${BT}${_cap}${BT}" | grep -E 'L[0-9] \("' | head -1)
+    _lvl=$(printf '%s\n' "$_bullet" | sed -nE 's/.* L([0-9]) \(".*/\1/p' | head -1)
+    _lbl=$(printf '%s\n' "$_bullet" | sed -nE 's/.*\("([^"]+)"\).*/\1/p' | head -1)
+    if [ -z "$_lvl" ] || [ -z "$_lbl" ]; then
+      SCHEMA_PARSE_OK=false
+      continue
+    fi
+    CAP_LEVEL_MAP="${CAP_LEVEL_MAP}${_cap}	${_lvl}
+"
+    case "
+$LEVEL_LABEL_MAP" in
+      *"
+${_lvl}	"*) : ;;
+      *) LEVEL_LABEL_MAP="${LEVEL_LABEL_MAP}${_lvl}	${_lbl}
+" ;;
+    esac
+  done
+  _l4=$(grep -E '^- L4 \("' "$SCHEMA_FILE" | head -1)
+  _l4lbl=$(printf '%s\n' "$_l4" | sed -nE 's/.*\("([^"]+)"\).*/\1/p' | head -1)
+  if [ -n "$_l4lbl" ]; then
+    LEVEL_LABEL_MAP="${LEVEL_LABEL_MAP}4	${_l4lbl}
+"
+  else
+    # A schema that ships but loses the L4 bullet is incomplete: the
+    # legend check would skip L4 and strict mode would still pass with a
+    # truncated vocabulary. Treat it as a parse failure so the integrity
+    # guard fires instead of silently dropping the L4 lock.
+    SCHEMA_PARSE_OK=false
+  fi
+fi
+
+cap_level()   { printf '%s' "$CAP_LEVEL_MAP"   | awk -F'\t' -v k="$1" '$1==k{print $2; exit}'; }
+level_label() { printf '%s' "$LEVEL_LABEL_MAP" | awk -F'\t' -v k="$1" '$1==k{print $2; exit}'; }
+
+# ---- Continuously-triggered CI job names ----
+# The evidence gate only counts a ci_jobs entry as proof if it names a
+# real job (a key under `jobs:`) in a workflow that runs on every change
+# (its `on:` block includes pull_request or push). A job that only exists
+# under `on:` (e.g. pull_request), or one that lives in a
+# workflow_dispatch-only workflow, is NOT continuous evidence: a hook that
+# is only exercised when a maintainer manually runs a workflow is not
+# "CI-asserted on every change". The awk tracks which top-level section
+# (on/jobs/other) each line belongs to so an `on:` trigger key is never
+# mistaken for a job key.
+WORKFLOW_JOBS=""
+if [ -d "$WORKFLOW_DIR" ]; then
+  for _wf in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+    [ -f "$_wf" ] || continue
+    _wf_jobs=$(awk '
+      /^[A-Za-z_][A-Za-z0-9_-]*:/ {
+        if ($0 ~ /^jobs:[[:space:]]*$/)      sect="jobs"
+        else if ($0 ~ /^on:/)                sect="on"
+        else                                  sect="other"
+        next
+      }
+      sect=="on" && /^  (pull_request|push):/ { cont=1 }
+      sect=="jobs" && /^  [A-Za-z0-9_-]+:/ { l=$0; sub(/^  /,"",l); sub(/:.*/,"",l); jobs=jobs l "\n" }
+      END { if (cont) printf "%s", jobs }
+    ' "$_wf")
+    WORKFLOW_JOBS="${WORKFLOW_JOBS}${_wf_jobs}"
+  done
+fi
+
+# Exact (non-regex) membership test against the continuous job set.
+job_is_continuous() {
+  printf '%s\n' "$WORKFLOW_JOBS" | grep -Fxq "$1"
+}
+
+# Expected README matrix cell (normalized) for an adapter capability
+# value, e.g. enforced -> "enforced (l3)", instructions_only ->
+# "guided (l0)". host_dependent varies and is skipped.
+expected_cell() {
+  local cap="$1" lvl lbl
+  [ "$cap" = "host_dependent" ] && { printf '__SKIP__'; return; }
+  lvl=$(cap_level "$cap"); [ -z "$lvl" ] && { printf '__UNKNOWN__'; return; }
+  lbl=$(level_label "$lvl"); [ -z "$lbl" ] && { printf '__UNKNOWN__'; return; }
+  norm_label "$lbl (l$lvl)"
+}
+
+# Map an adapter host key to its display name in the README matrix.
+host_display_name() {
+  case "$1" in
+    claude)   printf 'Claude Code' ;;
+    cursor)   printf 'Cursor' ;;
+    codex)    printf 'OpenAI Codex' ;;
+    opencode) printf 'OpenCode' ;;
+    gemini)   printf 'Gemini CLI' ;;
+    *)        printf '' ;;
+  esac
+}
+
+readme_has_matrix() {
+  [ -f "$README_FILE" ] && grep -qE '^\| *Agent *\| *Bash guard *\|' "$README_FILE"
+}
+readme_has_legend() {
+  [ -f "$README_FILE" ] && grep -qE '^\| *Level *\| *Meaning *\|' "$README_FILE"
+}
+matrix_row_for() {
+  grep -E "^\| *$1 *\|" "$README_FILE" 2>/dev/null | grep -E '\(L[0-9]\)' | head -1
+}
 
 NOW_EPOCH=$(date -u +%s)
 
@@ -251,6 +396,84 @@ check_adapter() {
     fi
   done
 
+  # ---- Evidence gate: enforced/hooked is a behavioral claim ----
+  # PR 2 of the 2026-05-28 architecture follow-up. enforced/hooked says a
+  # hook actually runs (and, for enforced, blocks). The enum value alone
+  # does not prove it, so require CI evidence: verification.method == ci
+  # plus a non-empty verification.ci_jobs naming jobs that exist under
+  # .github/workflows/. Rule documented in reference/host-adapter-schema.md
+  # ("Evidence gate"). Job existence is only checked when a workflow dir is
+  # present (the live repo always has one); a fixture without workflows
+  # still has its method+ci_jobs shape validated.
+  local needs_evidence=""
+  for field in bash_guard write_guard phase_gate; do
+    val=$(eval echo "\$$field")
+    case "$val" in
+      enforced|hooked) needs_evidence="${needs_evidence:+$needs_evidence }$field" ;;
+    esac
+  done
+  if [ -n "$needs_evidence" ]; then
+    local ev_method
+    ev_method=$(jq -r '.verification.method? // ""' "$file" 2>/dev/null)
+    if [ "$ev_method" != "ci" ]; then
+      errors="${errors:+$errors; }$needs_evidence claim enforced/hooked but verification.method='$ev_method' (must be ci)"
+    fi
+    if ! jq -e '.verification.ci_jobs | type == "array" and length > 0 and all(type == "string" and length > 0)' "$file" >/dev/null 2>&1; then
+      errors="${errors:+$errors; }$needs_evidence claim enforced/hooked but verification.ci_jobs is missing or empty"
+    elif [ -d "$WORKFLOW_DIR" ]; then
+      local job bad_jobs=""
+      while IFS= read -r job; do
+        [ -z "$job" ] && continue
+        # Reject anything that is not a plain job identifier first, so a
+        # value with ERE metacharacters (e.g. ".*") can never be treated
+        # as a pattern. Then require exact membership in the set of jobs
+        # that exist under `jobs:` in a continuously-triggered workflow.
+        if ! printf '%s' "$job" | grep -qE '^[A-Za-z0-9_-]+$'; then
+          bad_jobs="${bad_jobs:+$bad_jobs,}'$job' (not a valid job id)"
+        elif ! job_is_continuous "$job"; then
+          bad_jobs="${bad_jobs:+$bad_jobs,}$job"
+        fi
+      done <<< "$(jq -r '.verification.ci_jobs[]?' "$file" 2>/dev/null)"
+      if [ -n "$bad_jobs" ]; then
+        errors="${errors:+$errors; }verification.ci_jobs must name jobs in a pull_request/push-triggered workflow; not satisfied: $bad_jobs"
+      fi
+    fi
+  fi
+
+  # ---- README matrix equality ----
+  # The per-host matrix in README.md must show the same capability level
+  # as this adapter. Source of truth: the adapter JSON value mapped to the
+  # schema's L-level vocabulary. Runs only when the README ships the matrix
+  # and the schema parsed (the live repo has both, so the lock fires).
+  if $SCHEMA_PARSE_OK && readme_has_matrix; then
+    local display
+    display=$(host_display_name "$name")
+    if [ -n "$display" ]; then
+      local row
+      row=$(matrix_row_for "$display")
+      if [ -z "$row" ]; then
+        errors="${errors:+$errors; }README matrix has no row for '$display' but adapter $name exists"
+      else
+        local idx exp act
+        idx=3
+        for field in bash_guard write_guard phase_gate; do
+          val=$(eval echo "\$$field")
+          exp=$(expected_cell "$val")
+          if [ "$exp" = "__SKIP__" ]; then idx=$((idx+1)); continue; fi
+          if [ "$exp" = "__UNKNOWN__" ]; then
+            errors="${errors:+$errors; }cannot map $field=$val to an L-level from the schema"
+            idx=$((idx+1)); continue
+          fi
+          act=$(norm_label "$(printf '%s\n' "$row" | awk -F'|' -v n="$idx" '{print $n}')")
+          if [ "$act" != "$exp" ]; then
+            errors="${errors:+$errors; }README matrix $field cell for $display is '$act' but $name says '$val' (expected '$exp')"
+          fi
+          idx=$((idx+1))
+        done
+      fi
+    fi
+  fi
+
   if [ -z "$discovery" ]; then
     # Already reported as missing above when the key was absent. Only
     # flag here if the key exists but the value is empty.
@@ -374,6 +597,75 @@ for host in $README_LISTED; do
       '. + [{adapter: $name, status: "fail", age_days: 0, message: "listed in README but no JSON file"}]')
   fi
 done
+
+# ---- Strict mode: the README/schema contracts must be PRESENT ----
+# Without --require-readme-contracts the matrix/legend/evidence locks are
+# skip-if-absent so an isolated partial checkout can still validate adapter
+# JSON shape. The live CI jobs pass the flag, which makes a missing schema,
+# missing README matrix, or missing README legend a hard failure: deleting
+# a table can no longer turn the contract off. Runs in full mode only; a
+# single-host diagnostic (--filter) is not the place to demand the whole
+# README.
+if $REQUIRE_CONTRACTS && [ -z "$FILTER" ]; then
+  contract_fail=""
+  if ! $SCHEMA_PRESENT; then
+    contract_fail="${contract_fail:+$contract_fail; }schema file reference/host-adapter-schema.md is missing"
+  fi
+  if [ ! -f "$README_FILE" ]; then
+    contract_fail="${contract_fail:+$contract_fail; }README.md is missing"
+  else
+    readme_has_matrix || contract_fail="${contract_fail:+$contract_fail; }README per-host capability matrix is missing"
+    readme_has_legend || contract_fail="${contract_fail:+$contract_fail; }README L-level legend is missing"
+  fi
+  if [ -n "$contract_fail" ]; then
+    FAIL=$((FAIL + 1))
+    RESULTS_TEXT="${RESULTS_TEXT}FAIL  readme-contracts: $contract_fail
+"
+    RESULTS_JSON=$(echo "$RESULTS_JSON" | jq --arg m "$contract_fail" \
+      '. + [{adapter: "readme-contracts", status: "fail", age_days: 0, message: $m}]')
+  fi
+fi
+
+# ---- Schema parse integrity ----
+# If the schema ships but its L-level vocabulary could not be parsed, the
+# matrix/legend locks silently disable themselves. Fail loudly instead so
+# a schema restructure cannot turn the lock off without anyone noticing.
+if $SCHEMA_PRESENT && ! $SCHEMA_PARSE_OK; then
+  FAIL=$((FAIL + 1))
+  RESULTS_TEXT="${RESULTS_TEXT}FAIL  host-adapter-schema: could not parse the capability/L-level vocabulary from reference/host-adapter-schema.md
+"
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | jq \
+    '. + [{adapter: "host-adapter-schema", status: "fail", age_days: 0, message: "could not parse L-level vocabulary"}]')
+fi
+
+# ---- README legend vs schema vocabulary ----
+# The README L-level legend must use the same level->label words the
+# schema defines. Runs once in full mode (no filter) when both the legend
+# and the parsed schema are present. Sabotaging either the level numbers
+# or the labels in the README legend fails here.
+if [ -z "$FILTER" ] && $SCHEMA_PARSE_OK && readme_has_legend; then
+  legend_fail=""
+  for lvl in 0 1 2 3 4; do
+    lbl=$(level_label "$lvl")
+    [ -z "$lbl" ] && continue
+    legend_row=$(grep -iE "^\| *\*\*L${lvl} " "$README_FILE" | head -1)
+    if [ -z "$legend_row" ]; then
+      legend_fail="${legend_fail:+$legend_fail; }legend missing row for L$lvl"
+      continue
+    fi
+    got=$(printf '%s\n' "$legend_row" | sed -nE 's/^\| *\*\*L'"$lvl"' ([^*]+)\*\*.*/\1/p' | head -1)
+    if [ "$(norm_label "$got")" != "$(norm_label "$lbl")" ]; then
+      legend_fail="${legend_fail:+$legend_fail; }legend L$lvl label is '$(norm_label "$got")' but schema says '$(norm_label "$lbl")'"
+    fi
+  done
+  if [ -n "$legend_fail" ]; then
+    FAIL=$((FAIL + 1))
+    RESULTS_TEXT="${RESULTS_TEXT}FAIL  README-legend: $legend_fail
+"
+    RESULTS_JSON=$(echo "$RESULTS_JSON" | jq --arg m "$legend_fail" \
+      '. + [{adapter: "README-legend", status: "fail", age_days: 0, message: $m}]')
+  fi
+fi
 
 if $JSON_OUT; then
   jq -n --argjson results "$RESULTS_JSON" --argjson fail "$FAIL" --argjson warn "$WARN" \

--- a/ci/e2e-adapter-freshness.sh
+++ b/ci/e2e-adapter-freshness.sh
@@ -61,7 +61,7 @@ write_adapter() {
   local body
   body=$(jq -n --arg host "$name" --arg lv "$last_verified" \
     '{host: $host, schema_version: "1", last_verified: $lv,
-      verification: {method: "ci", evidence: "test"},
+      verification: {method: "ci", evidence: "test", ci_jobs: ["guard-regression"]},
       skill_discovery: "native",
       bash_guard: "enforced",
       write_guard: "enforced",
@@ -471,6 +471,241 @@ else
   parsed="no"
 fi
 assert_eq "--json output parses with summary.fail = 0" "yes" "$parsed"
+
+# =====================================================================
+# PR 2 of the 2026-05-28 architecture follow-up: behavior-lock cells.
+# These exercise the three new contracts in check-adapters.sh against a
+# full repo fixture (real README matrix + legend, real schema, real
+# adapters, and a workflow stub declaring the jobs claude.json names):
+#   - README matrix cells must equal adapters/*.json capability values
+#   - enforced/hooked requires verification.method==ci + named ci_jobs
+#   - README legend vocabulary must match the schema
+# =====================================================================
+
+# Build a tmp root that mirrors the live repo closely enough for the
+# matrix/legend/evidence locks to run: copies the real README, schema,
+# and adapters, and writes a workflow stub declaring the job keys
+# claude.json's ci_jobs points at so the existence sub-check resolves.
+new_repo_full() {
+  local name="$1"
+  local root="$TMP_ROOT/$name"
+  mkdir -p "$root/bin" "$root/adapters" "$root/reference" "$root/.github/workflows"
+  cp "$REPO/bin/check-adapters.sh" "$root/bin/"
+  chmod +x "$root/bin/check-adapters.sh"
+  cp "$REPO/README.md" "$root/README.md"
+  cp "$REPO/reference/host-adapter-schema.md" "$root/reference/"
+  cp "$REPO"/adapters/*.json "$root/adapters/"
+  # Continuous workflow (runs on pull_request) declaring the jobs that the
+  # real claude.json names in ci_jobs, so the evidence gate's
+  # continuous-job membership check resolves against something real.
+  {
+    echo "on:"
+    echo "  pull_request:"
+    echo "jobs:"
+    for j in guard-regression write-guard-regression; do
+      echo "  $j:"
+      echo "    runs-on: ubuntu-latest"
+    done
+  } > "$root/.github/workflows/stub.yml"
+  echo "$root"
+}
+
+# Mutate one adapter file in place via jq.
+mutate_adapter() {
+  local root="$1" host="$2" filter="$3"
+  jq "$filter" "$root/adapters/${host}.json" > "$root/adapters/${host}.json.tmp"
+  mv "$root/adapters/${host}.json.tmp" "$root/adapters/${host}.json"
+}
+
+# Cell 9: the real, unmodified adapter set (matrix + legend + schema +
+# evidence) is internally consistent and passes. Positive control: if
+# this ever fails, the live repo itself drifted.
+echo "[9] full real adapter set (matrix + legend + evidence) passes"
+root=$(new_repo_full "cell9-full")
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "full real set exits 0 (lenient)" "0" "$rc"
+out=$(run_check_in "$root" --require-readme-contracts)
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "full real set exits 0 (strict)" "0" "$rc"
+
+# Cell 10: a README matrix cell that disagrees with the adapter JSON
+# fails (drift direction: README overstates/understates a host).
+echo "[10] README matrix cell drift fails"
+root=$(new_repo_full "cell10-matrix-drift")
+sed -i.bak 's/| Claude Code | enforced (L3) |/| Claude Code | guided (L0) |/' "$root/README.md"
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "matrix cell drift exits 1" "1" "$rc"
+echo "$out" | grep -q "README matrix bash_guard cell" && \
+  assert_eq "matrix drift reported" "yes" "yes" || \
+  assert_eq "matrix drift reported" "yes" "no"
+
+# Cell 11: a non-Claude adapter set to enforced without CI evidence
+# fails (overclaim direction). cursor has verification.method=manual.
+echo "[11] non-Claude write_guard=enforced without CI evidence fails"
+root=$(new_repo_full "cell11-overclaim-enforced")
+mutate_adapter "$root" cursor '.write_guard = "enforced"'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "enforced overclaim exits 1" "1" "$rc"
+echo "$out" | grep -q "must be ci" && \
+  assert_eq "evidence gate reported (method)" "yes" "yes" || \
+  assert_eq "evidence gate reported (method)" "yes" "no"
+
+# Cell 12: same overclaim via hooked.
+echo "[12] non-Claude write_guard=hooked without CI evidence fails"
+root=$(new_repo_full "cell12-overclaim-hooked")
+mutate_adapter "$root" cursor '.write_guard = "hooked"'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "hooked overclaim exits 1" "1" "$rc"
+echo "$out" | grep -q "ci_jobs is missing or empty" && \
+  assert_eq "evidence gate reported (ci_jobs)" "yes" "yes" || \
+  assert_eq "evidence gate reported (ci_jobs)" "yes" "no"
+
+# Cell 13: removing ci_jobs from a legitimately enforced adapter fails.
+echo "[13] removing ci_jobs from an enforced adapter fails"
+root=$(new_repo_full "cell13-remove-cijobs")
+mutate_adapter "$root" claude 'del(.verification.ci_jobs)'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "missing ci_jobs exits 1" "1" "$rc"
+echo "$out" | grep -q "ci_jobs is missing or empty" && \
+  assert_eq "missing ci_jobs reported" "yes" "yes" || \
+  assert_eq "missing ci_jobs reported" "yes" "no"
+
+# Cell 14: ci_jobs naming a job that does not exist in any workflow
+# file fails (you cannot satisfy the gate with a fake job name).
+echo "[14] ci_jobs naming a non-existent job fails"
+root=$(new_repo_full "cell14-fake-job")
+mutate_adapter "$root" claude '.verification.ci_jobs = ["not-a-real-job"]'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "fake ci_job exits 1" "1" "$rc"
+echo "$out" | grep -q "not satisfied: not-a-real-job" && \
+  assert_eq "fake-job reported" "yes" "yes" || \
+  assert_eq "fake-job reported" "yes" "no"
+
+# Cell 15: a README legend label that disagrees with the schema fails.
+echo "[15] README legend drift from the schema fails"
+root=$(new_repo_full "cell15-legend-drift")
+sed -i.bak 's/\*\*L0 Guided\*\*/**L0 Unsupported**/' "$root/README.md"
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "legend drift exits 1" "1" "$rc"
+echo "$out" | grep -q "README-legend" && \
+  assert_eq "legend drift reported" "yes" "yes" || \
+  assert_eq "legend drift reported" "yes" "no"
+
+# Cell 16: strict mode fails when the README matrix is deleted (a lock
+# cannot be turned off by removing the table). Lenient mode skips it.
+echo "[16] strict mode fails on a missing README matrix"
+root=$(new_repo_full "cell16-no-matrix")
+# Drop the matrix header line so readme_has_matrix is false.
+grep -v '| Agent | Bash guard |' "$root/README.md" > "$root/README.md.tmp"
+mv "$root/README.md.tmp" "$root/README.md"
+out=$(run_check_in "$root" --require-readme-contracts)
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "strict + missing matrix exits 1" "1" "$rc"
+echo "$out" | grep -q "per-host capability matrix is missing" && \
+  assert_eq "strict missing-matrix reported" "yes" "yes" || \
+  assert_eq "strict missing-matrix reported" "yes" "no"
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "lenient + missing matrix still exits 0" "0" "$rc"
+
+# Cell 17: strict mode fails when the schema file is deleted.
+echo "[17] strict mode fails on a missing schema file"
+root=$(new_repo_full "cell17-no-schema")
+rm -f "$root/reference/host-adapter-schema.md"
+out=$(run_check_in "$root" --require-readme-contracts)
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "strict + missing schema exits 1" "1" "$rc"
+echo "$out" | grep -q "schema file reference/host-adapter-schema.md is missing" && \
+  assert_eq "strict missing-schema reported" "yes" "yes" || \
+  assert_eq "strict missing-schema reported" "yes" "no"
+
+# Cell 18: strict mode fails when the README legend is deleted.
+echo "[18] strict mode fails on a missing README legend"
+root=$(new_repo_full "cell18-no-legend")
+grep -v '| Level | Meaning |' "$root/README.md" > "$root/README.md.tmp"
+mv "$root/README.md.tmp" "$root/README.md"
+out=$(run_check_in "$root" --require-readme-contracts)
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "strict + missing legend exits 1" "1" "$rc"
+echo "$out" | grep -q "L-level legend is missing" && \
+  assert_eq "strict missing-legend reported" "yes" "yes" || \
+  assert_eq "strict missing-legend reported" "yes" "no"
+
+# Cell 19: a schema present but unparseable fails regardless of strict
+# mode, so a schema restructure cannot silently disable the locks.
+echo "[19] unparseable schema fails (lock cannot self-disable)"
+root=$(new_repo_full "cell19-bad-schema")
+echo "this schema has no L-level vocabulary bullets" > "$root/reference/host-adapter-schema.md"
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "unparseable schema exits 1" "1" "$rc"
+echo "$out" | grep -q "could not parse" && \
+  assert_eq "unparseable-schema reported" "yes" "yes" || \
+  assert_eq "unparseable-schema reported" "yes" "no"
+
+# Cell 20: a ci_jobs entry with regex metacharacters must not satisfy the
+# evidence gate by matching an unrelated job. '.*' is a valid JSON string
+# but not a valid job id, so it is rejected, not treated as a pattern.
+echo "[20] ci_jobs with regex metacharacters does not bypass the gate"
+root=$(new_repo_full "cell20-regex-job")
+mutate_adapter "$root" claude '.verification.ci_jobs = [".*"]'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "regex ci_job exits 1" "1" "$rc"
+echo "$out" | grep -q "not a valid job id" && \
+  assert_eq "regex ci_job reported as invalid" "yes" "yes" || \
+  assert_eq "regex ci_job reported as invalid" "yes" "no"
+
+# Cell 21: a schema that drops only the L4 bullet is incomplete and must
+# fail the parse rather than silently dropping the L4 legend lock.
+echo "[21] schema missing the L4 bullet fails the parse"
+root=$(new_repo_full "cell21-no-l4")
+grep -v '^- L4 ("' "$root/reference/host-adapter-schema.md" > "$root/reference/host-adapter-schema.md.tmp"
+mv "$root/reference/host-adapter-schema.md.tmp" "$root/reference/host-adapter-schema.md"
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "missing L4 bullet exits 1" "1" "$rc"
+echo "$out" | grep -q "could not parse" && \
+  assert_eq "missing-L4 reported as parse failure" "yes" "yes" || \
+  assert_eq "missing-L4 reported as parse failure" "yes" "no"
+
+# Cell 22: a job that exists only in a workflow_dispatch-only workflow is
+# not continuous evidence and must not satisfy the gate.
+echo "[22] ci_jobs in a workflow_dispatch-only workflow does not satisfy the gate"
+root=$(new_repo_full "cell22-manual-job")
+{
+  echo "on:"
+  echo "  workflow_dispatch:"
+  echo "jobs:"
+  echo "  manual-only-job:"
+  echo "    runs-on: ubuntu-latest"
+} > "$root/.github/workflows/manual.yml"
+mutate_adapter "$root" claude '.verification.ci_jobs = ["manual-only-job"]'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "manual-only ci_job exits 1" "1" "$rc"
+echo "$out" | grep -q "not satisfied: manual-only-job" && \
+  assert_eq "manual-only job reported" "yes" "yes" || \
+  assert_eq "manual-only job reported" "yes" "no"
+
+# Cell 23: an `on:` trigger key (pull_request) is not a job, so naming it
+# in ci_jobs must fail rather than matching the trigger block.
+echo "[23] ci_jobs naming an on: trigger key (pull_request) does not satisfy the gate"
+root=$(new_repo_full "cell23-trigger-key")
+mutate_adapter "$root" claude '.verification.ci_jobs = ["pull_request"]'
+out=$(run_check_in "$root")
+rc=$(echo "$out" | sed -n 's/^RC=\(.*\)/\1/p' | tail -1)
+assert_eq "trigger-key ci_job exits 1" "1" "$rc"
+echo "$out" | grep -q "not satisfied: pull_request" && \
+  assert_eq "trigger-key reported" "yes" "yes" || \
+  assert_eq "trigger-key reported" "yes" "no"
 
 cd "$TMP_ROOT"
 

--- a/reference/host-adapter-schema.md
+++ b/reference/host-adapter-schema.md
@@ -52,7 +52,8 @@ One file per host. Filename matches the `host` field. Existing host names: `clau
 ```json
 {
   "method": "ci",
-  "evidence": ".github/workflows/lint.yml:guard-regression"
+  "evidence": ".github/workflows/lint.yml:guard-regression",
+  "ci_jobs": ["guard-regression", "write-guard-regression"]
 }
 ```
 
@@ -61,6 +62,16 @@ One file per host. Filename matches the `host` field. Existing host names: `clau
   - `manual` means a human ran a check and signed off; the evidence string should name the check or the commit.
   - `unknown` means nobody has confirmed; the host's claims must be conservative.
 - `evidence`: short pointer to where the proof lives. A file path with optional anchor, a command, or a URL.
+- `ci_jobs`: array of CI job names (the `jobs:` keys under `.github/workflows/`) that exercise the host's hooks. Required when any capability is `enforced` or `hooked` (see the evidence gate below). Each name must be a real job in a workflow that runs on every change, i.e. whose `on:` block includes `pull_request` or `push`. `bin/check-adapters.sh` rejects a name that is not such a job: a key that only appears under `on:` (e.g. `pull_request`), a job in a `workflow_dispatch`-only workflow, or a value with regex metacharacters. A hook that is only exercised when a maintainer manually runs a workflow is not continuous evidence and must not be listed here (mention it in `evidence` instead).
+
+### Evidence gate for `enforced` and `hooked`
+
+A capability value of `enforced` or `hooked` is a behavioral claim: it says a hook actually runs (and, for `enforced`, blocks). An enum value alone does not prove that. So `bin/check-adapters.sh` requires evidence:
+
+- If `bash_guard`, `write_guard`, or `phase_gate` is `enforced` or `hooked`, the adapter must set `verification.method == "ci"` and a non-empty `verification.ci_jobs` array naming jobs that exist under `.github/workflows/`.
+- An adapter cannot claim `enforced`/`hooked` on `verification.method == "manual"` or `unknown`, and cannot name a CI job that does not exist.
+
+Today only Claude Code has hook CI, so only `adapters/claude.json` may claim `enforced`/`hooked` on those surfaces. Every other host stays at `instructions_only` (or whatever its real evidence supports) until a CI job proves otherwise.
 
 ### Capability values
 
@@ -78,8 +89,10 @@ The capability hierarchy maps directly to the L0..L4 levels in the V1 SPEC:
 - `unsupported` and `instructions_only` are L0 ("Guided")
 - `detectable` is L1 ("Checked")
 - `hooked` is L2 ("Guarded")
-- `enforced` is L3 ("Blocked when unsafe")
+- `enforced` is L3 ("Enforced")
 - L4 ("Continuously verified") is not a capability value but a property of the `verification` block: when `method == "ci"`, the declared capability is L4-asserted.
+
+This level-to-label vocabulary (L0 Guided, L1 Checked, L2 Guarded, L3 Enforced, L4 Continuously verified) is the single source of truth. The README L-level legend and the per-host matrix must use the same words; `bin/check-adapters.sh` parses this list and fails if they drift.
 
 ## Observation overrides declaration
 


### PR DESCRIPTION
## Summary

Adapter capability values were enum-locked and freshness-locked but not
evidence-locked: a future edit could mark a non-Claude adapter `enforced`,
bump `last_verified`, and pass CI with no proof the hook exists. The README
matrix was also not tied to `adapters/*.json`, and the README L-level legend
contradicted the schema (it put instructions-only hosts at L1, the schema and
the per-host matrix put them at L0 Guided).

This makes the public enforcement claims mechanically true.

## What changed

`bin/check-adapters.sh` gains three contracts:

1. **README matrix equality.** Each host's row in the README per-host matrix
   must show the same capability level as `adapters/<host>.json`, mapped
   through the schema's L-level vocabulary (e.g. `enforced` -> `enforced (L3)`,
   `instructions_only` -> `guided (L0)`). Drift in either direction fails.

2. **Evidence gate for `enforced`/`hooked`.** A behavioral claim now requires
   `verification.method == "ci"` and a non-empty `verification.ci_jobs` naming
   real jobs that run on every change (their workflow `on:` includes
   `pull_request` or `push`). Job names are matched as exact identifiers, so a
   regex value like `.*`, an `on:` trigger key like `pull_request`, or a
   `workflow_dispatch`-only job cannot satisfy the gate. Today only Claude Code
   has hook CI, so only `adapters/claude.json` can make these claims.

3. **Legend matches the schema.** The schema (`reference/host-adapter-schema.md`)
   is parsed as the single source of truth for the capability -> L-level ->
   label vocabulary; the README legend is checked against it.

A new `--require-readme-contracts` flag (used by the live `adapter-freshness`
lint job) makes a missing schema, missing README matrix, or missing README
legend a hard failure, so the locks cannot be turned off by deleting a table.
An unparseable or incomplete schema (e.g. a dropped L4 bullet) fails closed.

Supporting changes:
- `reference/host-adapter-schema.md`: documents `verification.ci_jobs` and the
  evidence gate; aligns the L-level vocabulary so the README and schema share
  one source of truth.
- `adapters/claude.json`: adds `ci_jobs` (the two continuous lint jobs that
  exercise the Bash and Write guards); the phase gate's manual e2e coverage is
  noted in `evidence`, not claimed as continuous.
- `README.md`: legend rewritten to L0 Guided / L1 Checked / L2 Guarded /
  L3 Enforced / L4 Continuously verified.

## Validation

- `ci/e2e-adapter-freshness.sh`: 74 checks (43 prior + 31 new). New sabotage
  cells: matrix cell drift, enforced/hooked overclaim without CI evidence,
  removed `ci_jobs`, fake/regex/`on:`-key/`workflow_dispatch`-only job names,
  missing matrix/schema/legend under strict mode, and an unparseable/missing-L4
  schema. Each fails before the fix and passes after.
- Live `bin/check-adapters.sh --require-readme-contracts`: passes (the 4
  non-Claude staleness warnings predate this PR).
- bash 3.2 clean; lint/e2e YAML parses; codex review clean.

Architecture follow-up PR 2 of 3. PR 3 (phase-gate trusted evidence) follows.
