### PR TITLE
guard: require trusted artifacts in phase gate

### DIFF
--- a/bin/lib/portable.sh
+++ b/bin/lib/portable.sh
@@ -13,6 +13,11 @@
 #                       both `sha256sum` and `shasum -a 256` output format).
 #   nano_mtime <path>   Print the file's mtime as epoch seconds, or 0 if the
 #                       file is missing or stat fails.
+#   nano_artifact_filename_epoch <path>
+#                       Parse the canonical artifact filename timestamp
+#                       (YYYYMMDD-HHMMSS.json, as written by save-artifact.sh)
+#                       into epoch seconds. Returns 0 when the basename does
+#                       not match the convention.
 
 # Hash a stream from stdin. Prefers sha256sum (Linux default), falls back to
 # shasum -a 256 (macOS / perl-shasum). Without one of the two, scripts that
@@ -41,4 +46,38 @@ nano_mtime() {
   else
     echo 0
   fi
+}
+
+# Epoch seconds for the canonical artifact filename timestamp. save-artifact.sh
+# names every artifact "$(date -u +%Y%m%d-%H%M%S).json", so the timestamp lives
+# in the filename, not just in mtime. Trust-sensitive consumers (the phase gate)
+# order by this rather than mtime: a copied or `touch`-ed stale artifact keeps
+# its original filename timestamp even when its mtime is fresh. Returns 0 when
+# the basename does not match the convention, so an unparseable name reads as
+# "oldest" and fails a freshness check closed rather than passing on a bogus
+# epoch. Bash 3.2 compatible; tries BSD `date` then GNU `date`, both in UTC.
+nano_artifact_filename_epoch() {
+  local path="$1" base stamp
+  base=$(basename "$path")
+  case "$base" in
+    [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].json) ;;
+    *) echo 0; return ;;
+  esac
+  stamp="${base%.json}"   # YYYYMMDD-HHMMSS
+  local epoch roundtrip
+  epoch=$(date -u -j -f "%Y%m%d-%H%M%S" "$stamp" +%s 2>/dev/null) \
+    || epoch=$(date -u -d "${stamp:0:4}-${stamp:4:2}-${stamp:6:2} ${stamp:9:2}:${stamp:11:2}:${stamp:13:2}" +%s 2>/dev/null) \
+    || epoch=0
+  [ -n "$epoch" ] || epoch=0
+  if [ "$epoch" != 0 ]; then
+    # Round-trip guard: BSD `date -j` silently normalizes impossible
+    # calendar dates (20260231 -> 2026-03-03) instead of failing. Reformat
+    # the epoch back and require it to equal the input, so a normalized or
+    # otherwise invalid stamp fails closed (epoch 0 -> treated as oldest).
+    roundtrip=$(date -u -j -f "%s" "$epoch" "+%Y%m%d-%H%M%S" 2>/dev/null) \
+      || roundtrip=$(date -u -d "@$epoch" "+%Y%m%d-%H%M%S" 2>/dev/null) \
+      || roundtrip=""
+    [ "$roundtrip" = "$stamp" ] || epoch=0
+  fi
+  echo "$epoch"
 }

--- a/ci/e2e-artifact-trust.sh
+++ b/ci/e2e-artifact-trust.sh
@@ -290,6 +290,125 @@ assert_eq "custom phase_kind = custom"                 "custom"          "$phase
 assert_eq "custom upstream_status.review = verified"   "verified"        "$status_review"
 assert_eq "custom upstream_status.build = not_applicable" "not_applicable" "$status_build"
 
+# =====================================================================
+# PR 3 of the 2026-05-28 architecture follow-up: the commit/push phase
+# gate must consume TRUSTED artifacts. It rejects missing-integrity and
+# tampered artifacts (via find-artifact --require-integrity) and judges
+# freshness by the filename timestamp, not mtime, so a touched stale
+# artifact cannot satisfy it. NANOSTACK_SKIP_GATE=1 still bypasses.
+# =====================================================================
+GATE="$REPO/guard/bin/phase-gate.sh"
+
+# A project with an active session whose review/security/qa phases have
+# started (so the gate enforces) and one initial commit (so the
+# last-code-change reference resolves through git log).
+setup_gate_project() {
+  local name="$1"
+  local proj="$TMP_ROOT/$name"
+  local store="$proj/.nanostack"
+  mkdir -p "$proj" "$store"
+  ( cd "$proj" \
+    && git init -q \
+    && git config user.email t@t.test \
+    && git config user.name tester \
+    && echo code > file.txt \
+    && git add -A \
+    && git commit -qm init ) >/dev/null 2>&1
+  printf '{"workspace":"%s","phase_log":[{"phase":"review","status":"in_progress"},{"phase":"security","status":"in_progress"},{"phase":"qa","status":"in_progress"}]}' \
+    "$proj" > "$store/session.json"
+  printf '%s' "$proj"
+}
+
+# Run the gate on a "git commit" from inside the project. Extra args are
+# env assignments prepended before the call (e.g. NANOSTACK_SKIP_GATE=1).
+run_gate() {
+  local proj="$1"; shift
+  local store="$proj/.nanostack"
+  ( cd "$proj" && env "$@" NANOSTACK_STORE="$store" "$GATE" "git commit -m x" >/dev/null 2>&1; echo "RC=$?" )
+}
+
+# Cell 7: every required phase present with valid integrity and a fresh
+# filename timestamp -> the gate allows the commit.
+echo "[7] valid trusted artifacts satisfy the phase gate"
+proj=$(setup_gate_project gate-valid)
+FRESH=$(date -u +%Y%m%d-%H%M%S)
+mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" security verified "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" qa       verified "$FRESH" "$proj"
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "valid + integrity allows commit (rc 0)" "0" "$rc"
+
+# Cell 8: a tampered (integrity_mismatch) phase artifact does not satisfy
+# the gate -> commit blocked.
+echo "[8] integrity_mismatch artifact does not satisfy the gate"
+proj=$(setup_gate_project gate-mismatch)
+FRESH=$(date -u +%Y%m%d-%H%M%S)
+mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" security verified "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" qa       mismatch "$FRESH" "$proj"
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "tampered qa artifact blocks commit (rc 1)" "1" "$rc"
+
+# Cell 9: a phase artifact with no .integrity does not satisfy the gate.
+echo "[9] missing-integrity artifact does not satisfy the gate"
+proj=$(setup_gate_project gate-missing)
+FRESH=$(date -u +%Y%m%d-%H%M%S)
+mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" security missing  "$FRESH" "$proj"
+mk_artifact "$proj/.nanostack" qa       verified "$FRESH" "$proj"
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "missing-integrity security artifact blocks commit (rc 1)" "1" "$rc"
+
+# Cell 10: an OLD artifact whose mtime is freshened by `touch` does not
+# satisfy freshness, because freshness reads the filename timestamp. Under
+# the previous mtime-based check this would have passed; now it blocks.
+echo "[10] touching an old artifact to freshen mtime does not satisfy freshness"
+proj=$(setup_gate_project gate-touch-old)
+OLD=20200101-000000
+mk_artifact "$proj/.nanostack" review   verified "$OLD" "$proj"
+mk_artifact "$proj/.nanostack" security verified "$OLD" "$proj"
+mk_artifact "$proj/.nanostack" qa       verified "$OLD" "$proj"
+# Freshen mtimes so find-artifact's discovery window still sees them and
+# an mtime-based freshness check would (wrongly) accept them.
+touch "$proj/.nanostack/review/$OLD.json" "$proj/.nanostack/security/$OLD.json" "$proj/.nanostack/qa/$OLD.json"
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "touched old artifacts still block commit (rc 1)" "1" "$rc"
+
+# Cell 11: NANOSTACK_SKIP_GATE=1 bypasses the gate even when artifacts are
+# absent. The control (no skip) confirms the same setup blocks.
+echo "[11] NANOSTACK_SKIP_GATE=1 still bypasses the gate"
+proj=$(setup_gate_project gate-skip)
+# No artifacts at all -> would block without the bypass.
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "control: no artifacts blocks commit (rc 1)" "1" "$rc"
+rc=$(run_gate "$proj" NANOSTACK_SKIP_GATE=1 | sed -n 's/^RC=//p')
+assert_eq "NANOSTACK_SKIP_GATE=1 allows commit (rc 0)" "0" "$rc"
+
+# Cell 12: an impossible calendar date in the filename must fail freshness
+# closed. nano_artifact_filename_epoch's round-trip guard returns 0 for a
+# digit-shaped but invalid stamp that BSD `date -j` would otherwise
+# normalize to a real date. The direct helper assertions are
+# date-independent; the gate integration uses a stamp that normalizes to a
+# FUTURE date (Feb 31 2099 -> Mar 3 2099) so that, without the guard, the
+# normalized time would read as fresh and the gate would wrongly allow the
+# commit. That makes the cell a real regression lock regardless of when CI
+# runs.
+echo "[12] impossible calendar date in the filename fails freshness closed"
+helper_epoch() { bash -c "source '$REPO/bin/lib/portable.sh'; nano_artifact_filename_epoch '$1'"; }
+assert_eq "helper: valid stamp parses to non-zero" "ok" \
+  "$([ "$(helper_epoch /x/20260528-143012.json)" -gt 0 ] 2>/dev/null && echo ok || echo no)"
+assert_eq "helper: Feb 31 returns 0"      "0" "$(helper_epoch /x/20260231-120000.json)"
+assert_eq "helper: month 13 returns 0"    "0" "$(helper_epoch /x/20261301-120000.json)"
+assert_eq "helper: hour 25 returns 0"     "0" "$(helper_epoch /x/20260528-250000.json)"
+assert_eq "helper: non-canonical name 0"  "0" "$(helper_epoch /x/2026-05-10T01-00-00.json)"
+proj=$(setup_gate_project gate-bad-date)
+BAD=20990231-120000   # Feb 31 2099 -> BSD normalizes to a FUTURE date
+mk_artifact "$proj/.nanostack" review   verified "$BAD" "$proj"
+mk_artifact "$proj/.nanostack" security verified "$BAD" "$proj"
+mk_artifact "$proj/.nanostack" qa       verified "$BAD" "$proj"
+rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
+assert_eq "impossible-date artifact blocks commit (rc 1)" "1" "$rc"
+
 cd "$TMP_ROOT"
 
 echo

--- a/guard/bin/phase-gate.sh
+++ b/guard/bin/phase-gate.sh
@@ -108,7 +108,12 @@ check_phases() {
 
   for phase in $REQUIRED_PHASES; do
     local artifact
-    artifact=$("$FIND_ARTIFACT" "$phase" 1 2>/dev/null) || {
+    # PR 3 of the 2026-05-28 architecture follow-up: the gate consumes
+    # TRUSTED artifacts. --require-integrity makes find-artifact.sh exit
+    # non-zero when the phase artifact is absent, has no .integrity, or
+    # whose recomputed hash does not match, so integrity_missing and
+    # integrity_mismatch are treated exactly like missing evidence here.
+    artifact=$("$FIND_ARTIFACT" "$phase" 1 --require-integrity 2>/dev/null) || {
       missing="${missing:+$missing }$phase"
       continue
     }
@@ -117,9 +122,17 @@ check_phases() {
       missing="${missing:+$missing }$phase"
       continue
     fi
-    # Verify artifact is newer than last code change
-    local artifact_time
-    artifact_time=$(stat -f %m "$artifact" 2>/dev/null || stat -c %Y "$artifact" 2>/dev/null || echo 0)
+    # Freshness by FILENAME timestamp, not mtime. save-artifact.sh names
+    # artifacts $(date -u +%Y%m%d-%H%M%S).json, so the timestamp travels
+    # with the filename. A copied or `touch`-ed stale artifact keeps its
+    # old filename timestamp even when its mtime is fresh, so it cannot
+    # pass the freshness check by touching the file. nano_artifact_filename_epoch
+    # returns 0 for an unparseable name, which reads as "older than the
+    # last code change" and fails the phase closed.
+    local artifact_time=0
+    if declare -F nano_artifact_filename_epoch >/dev/null 2>&1; then
+      artifact_time=$(nano_artifact_filename_epoch "$artifact")
+    fi
     if [ "$artifact_time" -lt "$last_change" ]; then
       missing="${missing:+$missing }$phase"
     fi


### PR DESCRIPTION
## Summary

The commit/push phase gate blocked when required phases were missing, but it
accepted a phase's artifact through `find-artifact.sh "$phase" 1` with no
integrity check, and judged freshness by filesystem mtime. A tampered or
unverifiable artifact satisfied the gate, and `touch`-ing a stale artifact
made it look fresh. The gate now consumes trusted, filename-dated evidence.

## What changed

`guard/bin/phase-gate.sh` (`check_phases`):
- Looks up each required-phase artifact with
  `find-artifact.sh "$phase" 1 --require-integrity`. `integrity_missing` and
  `integrity_mismatch` now count as missing evidence, so a tampered artifact or
  one with no `.integrity` does not satisfy the gate.
- Judges freshness by the artifact's **filename** timestamp, not mtime. A
  copied or `touch`-ed stale artifact keeps its old filename timestamp even
  when its mtime is fresh, so it can no longer pass by touching the file.
- `NANOSTACK_SKIP_GATE=1` and project matching are preserved unchanged.

`bin/lib/portable.sh`:
- New shared helper `nano_artifact_filename_epoch` parses the canonical
  `save-artifact.sh` filename convention (`YYYYMMDD-HHMMSS.json`, UTC) to epoch
  seconds. It prints epoch 0, read as "oldest", for a name that does not match,
  and a round-trip guard rejects digit-shaped but impossible calendar dates
  (e.g. `20260231`) that BSD `date -j` would otherwise normalize.

## Validation

- `ci/e2e-artifact-trust.sh`: 41 checks (28 prior + 13 new). New cells: valid +
  integrity allows the commit; `integrity_mismatch` blocks; missing `.integrity`
  blocks; an old artifact with a freshened mtime still blocks (filename
  freshness); `NANOSTACK_SKIP_GATE=1` bypasses (with a no-bypass control); and
  impossible-date filenames fail closed (date-independent helper assertions plus
  a future-normalizing integration case).
- Negative controls: removing `--require-integrity` fails the mismatch/missing
  cells; reverting to mtime freshness fails the touched-artifact cell; removing
  the round-trip guard fails the impossible-date assertions. So each cell locks a
  real regression.
- bash 3.2 clean (BSD and GNU `date`); codex review clean.

## Known scope boundary

A user who can write the store can still copy an old verified artifact to a
fresh canonical filename and pass, because the integrity hash covers the JSON
content, not the path. This is the spec's stated threat boundary for this round
("a user who can write the store can often generate a valid hash or bypass the
gate"); the goal here is to fail closed on tampered/missing-integrity evidence
and to stop mtime-touch from faking freshness. Binding the hash to the filename
would change the artifact trust primitive and is left out of scope.

Architecture follow-up PR 3 of 3.
