### PR TITLE
chore: close architecture follow-up backlog

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -228,6 +228,8 @@ Honestidad por host: nanostack manda los mismos archivos de skills a todos los a
 
 Si querés enforcement duro, usá Claude Code. Si aceptás disciplina a nivel agente, los demás corren el mismo workflow guiado. Corré `/nano-doctor` después de instalar para ver el estado real de tu install.
 
+Esta brecha es la mayor salvedad conocida del framework. El plan es sumar la misma capa de enforcement por agente a medida que cada herramienta exponga los hooks adecuados. Cada adapter lleva una fecha `last_verified` y una fuente de verificación, así podés ver qué garantías están aseguradas por CI hoy y cuáles son manuales.
+
 ## Problemas comunes
 
 ¿Las skills no aparecen? Reiniciá tu agente (Cursor y Codex lo necesitan; Claude Code no).

--- a/bin/find-artifact.sh
+++ b/bin/find-artifact.sh
@@ -66,8 +66,11 @@ PROJECT="$(pwd)"
 [ -d "$STORE" ] || exit 1
 
 RESULT=$(find "$STORE" -name "*.json" -mtime -"$MAX_AGE" 2>/dev/null | while read -r f; do
-  # Pre-filter with grep before full jq parse (80% fewer jq calls on multi-project setups)
-  if grep -q "$PROJECT" "$f" 2>/dev/null; then
+  # Pre-filter with grep before full jq parse (80% fewer jq calls on multi-project setups).
+  # -F (fixed string): the project path can contain regex metacharacters (e.g. a
+  # dot or "+"), so a plain grep could match the wrong project or skip the right
+  # one. The authoritative check is the jq .project equality just below.
+  if grep -qF "$PROJECT" "$f" 2>/dev/null; then
     if jq -e --arg p "$PROJECT" '.project == $p' "$f" >/dev/null 2>&1; then
       echo "$f"
     fi

--- a/bin/lib/visual-render.sh
+++ b/bin/lib/visual-render.sh
@@ -471,8 +471,15 @@ nano_visual_safe_pr_url() {
 # Decide whether a screenshot path is safe to render as an <img>.
 # Allowed: absolute paths under the project or the NANOSTACK_STORE,
 # and relative paths starting with a known prefix (no ".." segments).
-# Returns "safe" or "unsafe". Used by render_qa_body so a malicious
-# screenshot URL never reaches the page as an <img src>.
+# Returns "safe" or "unsafe".
+#
+# Reserved, not yet wired: Visual Artifacts v1 does NOT render screenshots,
+# so this helper has no caller today. It is kept so a future PR adding a
+# /qa screenshot gallery can reuse this allowlist instead of re-deriving
+# it; calling it from a render path is a contract change (see
+# reference/visual-artifact-contract.md). The earlier "Used by
+# render_qa_body" note was inaccurate (no such function exists); corrected
+# during the 2026-05-28 architecture follow-up backlog.
 nano_visual_safe_screenshot_path() {
   local p="${1:-}" project="${2:-$PWD}"
   case "$p" in


### PR DESCRIPTION
## Summary

Three independent hygiene items left over from the architecture follow-up
round (PRs #225/#227/#228). No behavior change to the enforced contracts;
this is cleanup.

## What changed

1. **`bin/lib/visual-render.sh`** — `nano_visual_safe_screenshot_path` had an
   inline comment claiming it was "Used by render_qa_body", but no such
   function exists and the helper has no caller. It is not dead cruft:
   `reference/visual-artifact-contract.md` deliberately reserves it for a
   future `/qa` screenshot gallery (v1 does not render screenshots). The
   comment is corrected to state it has no caller yet and is reserved per the
   contract. The function is kept as-is: removing it would contradict the
   contract, and wiring it would add a feature that is out of scope here.

2. **`bin/find-artifact.sh`** — the project pre-filter now uses `grep -qF`
   (fixed string). A project path can contain regex metacharacters (a dot, a
   `+`), so a plain `grep` could match the wrong project or skip the right
   one. The authoritative check remains the `jq .project` equality just below;
   the grep is only a fast pre-filter.

3. **`README.es.md`** — ported the English "single biggest known caveat"
   paragraph to Spanish (voseo) so the EN and ES enforcement sections carry
   the same honesty note about per-host enforcement and CI-asserted vs manual
   guarantees.

## Validation

- `ci/e2e-artifact-trust.sh`: 41/41 (exercises the `find-artifact` pre-filter,
  including a dotted project path).
- `ci/e2e-visual-artifacts.sh`: all checks pass (comment-only change).
- `find-artifact.sh` smoke with a regex-metacharacter project path resolves
  the artifact correctly under `grep -qF`.
- No em-dashes in changed docs; bash 3.2 clean; codex review clean.

Hygiene follow-up after the architecture round. Not a new round.
