### PR TITLE
ci: shared harness core library + self-test (harness vNext PR 1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -341,6 +341,23 @@ jobs:
                      ! -path './node_modules/*' 2>/dev/null)
           exit $fail
 
+  harness-selftest:
+    name: Harness library self-test
+    runs-on: ubuntu-latest
+    # Harness Architecture vNext PR 1. ci/lib/harness.sh is the shared
+    # primitive every migrated suite sources, so a bug in it can corrupt
+    # many suites at once. This fast self-test runs on every PR and proves
+    # the counters, errexit-safe capture, assert_exit, --filter skip
+    # accounting, NANOSTACK_KEEP_TMP, and /tmp temp-root policy still hold.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ci/e2e-harness-selftest.sh
+        run: |
+          chmod +x ci/e2e-harness-selftest.sh
+          ci/e2e-harness-selftest.sh
+
   skill-frontmatter:
     name: SKILL.md frontmatter
     runs-on: ubuntu-latest

--- a/ci/e2e-concurrency-parity.sh
+++ b/ci/e2e-concurrency-parity.sh
@@ -16,42 +16,35 @@
 # the regression lock — including sabotage cells proving the block is
 # registry-driven (custom phases) rather than a hardcoded built-in list.
 #
+# Migrated onto ci/lib/harness.sh (Harness Architecture vNext PR 1).
+# Same cells, same check count. Supports --filter <pattern>.
+#
 # Exit 0 = all cells pass, exit 1 = any cell failed.
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+. "$REPO/ci/lib/harness.sh"
+
 CHECK_DANGEROUS="$REPO/guard/bin/check-dangerous.sh"
 CHECK_WRITE="$REPO/guard/bin/check-write.sh"
 SESSION_SH="$REPO/bin/session.sh"
 
-GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; DIM=$'\033[0;90m'; NC=$'\033[0m'
-PASS=0; FAIL=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
 
-ok()   { PASS=$((PASS+1)); printf '    %sOK%s    %s\n' "$GREEN" "$NC" "$1"; }
-bad()  { FAIL=$((FAIL+1)); printf '    %sFAIL%s  %s\n' "$RED" "$NC" "$1"; }
-
-# Run check-write.sh with a hook-shaped JSON payload for a given tool.
-write_hook() {
-  local tool="$1" path="$2"
-  printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool" "$path" \
-    | "$CHECK_WRITE" >/dev/null 2>&1
-}
-bash_hook() { (cd "$WORK" && "$CHECK_DANGEROUS" "$1" >/dev/null 2>&1); }
-
-assert_exit() {
-  local want="$1" got="$2" label="$3"
-  if [ "$got" = "$want" ]; then ok "$label (exit $got)"; else bad "$label (want $want, got $got)"; fi
-}
-
-# ─── Workspace + store fixture ──────────────────────────────────────────
-# Use /tmp/ explicitly, not $TMPDIR. On macOS $TMPDIR resolves to
+# Temp root lives under /tmp, not $TMPDIR: on macOS $TMPDIR is
 # /var/folders/..., and check-write.sh correctly denies any path under
-# /var/ — which would make every "Write allowed" assertion fail with a
-# false positive unrelated to phase concurrency. /tmp resolves to
-# /private/tmp on macOS, outside /var/. (Same workaround as
-# ci/e2e-user-flows.sh.)
-WORK="$(mktemp -d /tmp/nano-parity.XXXXXX)"
-trap 'rm -rf "$WORK"' EXIT
+# /var/, which would make every "Write allowed" assertion a false
+# failure unrelated to phase concurrency. nh_init enforces the /tmp root.
+nh_init concurrency-parity nano-parity
+nh_require_cmd git jq
+
+WORK="$NH_TMP"
 cd "$WORK"
 git init -q
 git config user.email t@t.t; git config user.name t
@@ -63,57 +56,66 @@ mkdir -p "$NANOSTACK_STORE"
 SAFE_PATH="$WORK/src/feature.txt"
 mkdir -p "$WORK/src"
 
+# Run check-write.sh with a hook-shaped JSON payload for a given tool.
+write_hook() {
+  local tool="$1" path="$2"
+  printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool" "$path" \
+    | "$CHECK_WRITE" >/dev/null 2>&1
+}
+bash_hook() { (cd "$WORK" && "$CHECK_DANGEROUS" "$1" >/dev/null 2>&1); }
+
 write_session_review() {
   printf '{"workspace":"%s","current_phase":"review","phase_log":[{"phase":"review","status":"in_progress"}]}' \
     "$WORK" > "$NANOSTACK_STORE/session.json"
 }
 
-echo
-echo "${DIM}Cells 1-4: built-in read-only phase (review) blocks every mutation tool${NC}"
-write_session_review
-assert_exit 1 "$(bash_hook 'touch ./src/feature.txt'; echo $?)" "Bash 'touch' blocked during review"
-assert_exit 1 "$(write_hook Write     "$SAFE_PATH"; echo $?)"   "Write blocked during review"
-assert_exit 1 "$(write_hook Edit      "$SAFE_PATH"; echo $?)"   "Edit blocked during review"
-assert_exit 1 "$(write_hook MultiEdit "$SAFE_PATH"; echo $?)"   "MultiEdit blocked during review"
+# Cells 1-4: built-in read-only phase (review) blocks every mutation tool.
+cell_builtin_read() {
+  write_session_review
+  nh_assert_exit "Bash 'touch' blocked during review" 1 bash_hook 'touch ./src/feature.txt'
+  nh_assert_exit "Write blocked during review"        1 write_hook Write     "$SAFE_PATH"
+  nh_assert_exit "Edit blocked during review"         1 write_hook Edit      "$SAFE_PATH"
+  nh_assert_exit "MultiEdit blocked during review"    1 write_hook MultiEdit "$SAFE_PATH"
+}
 
-echo
-echo "${DIM}Cell 5: after phase-complete, Write is allowed again${NC}"
-write_session_review
-"$SESSION_SH" phase-complete review >/dev/null 2>&1 || true
-CURR=$(jq -r '.current_phase // "null"' "$NANOSTACK_STORE/session.json" 2>/dev/null)
-if [ "$CURR" = "null" ]; then ok "current_phase cleared after phase-complete"; else bad "current_phase still '$CURR' after phase-complete"; fi
-assert_exit 0 "$(write_hook Write "$SAFE_PATH"; echo $?)" "Write allowed once review completes"
+# Cell 5: after phase-complete, Write is allowed again.
+cell_phase_complete() {
+  write_session_review
+  "$SESSION_SH" phase-complete review >/dev/null 2>&1 || true
+  local curr
+  curr=$(jq -r '.current_phase // "null"' "$NANOSTACK_STORE/session.json" 2>/dev/null)
+  nh_assert_eq "current_phase cleared after phase-complete" "null" "$curr"
+  nh_assert_exit "Write allowed once review completes" 0 write_hook Write "$SAFE_PATH"
+}
 
-echo
-echo "${DIM}Cells 6-7: registry-driven — custom phases get the same treatment (sabotage)${NC}"
-# Register two custom phases with opposite concurrency declarations.
-mkdir -p "$NANOSTACK_STORE/skills/audit-ro" "$NANOSTACK_STORE/skills/audit-rw"
-printf '%s\n' '---' 'name: audit-ro' 'description: read-only custom phase' 'concurrency: read' '---' 'Body.' \
-  > "$NANOSTACK_STORE/skills/audit-ro/SKILL.md"
-printf '%s\n' '---' 'name: audit-rw' 'description: writing custom phase' 'concurrency: write' '---' 'Body.' \
-  > "$NANOSTACK_STORE/skills/audit-rw/SKILL.md"
-printf '{"custom_phases":["audit-ro","audit-rw"]}' > "$NANOSTACK_STORE/config.json"
+# Cells 6-7: registry-driven — custom phases get the same treatment (sabotage).
+cell_custom_phases() {
+  mkdir -p "$NANOSTACK_STORE/skills/audit-ro" "$NANOSTACK_STORE/skills/audit-rw"
+  printf '%s\n' '---' 'name: audit-ro' 'description: read-only custom phase' 'concurrency: read' '---' 'Body.' \
+    > "$NANOSTACK_STORE/skills/audit-ro/SKILL.md"
+  printf '%s\n' '---' 'name: audit-rw' 'description: writing custom phase' 'concurrency: write' '---' 'Body.' \
+    > "$NANOSTACK_STORE/skills/audit-rw/SKILL.md"
+  printf '{"custom_phases":["audit-ro","audit-rw"]}' > "$NANOSTACK_STORE/config.json"
 
-printf '{"workspace":"%s","current_phase":"audit-ro","phase_log":[{"phase":"audit-ro","status":"in_progress"}]}' \
-  "$WORK" > "$NANOSTACK_STORE/session.json"
-assert_exit 1 "$(write_hook Write "$SAFE_PATH"; echo $?)" "custom concurrency=read phase blocks Write"
+  printf '{"workspace":"%s","current_phase":"audit-ro","phase_log":[{"phase":"audit-ro","status":"in_progress"}]}' \
+    "$WORK" > "$NANOSTACK_STORE/session.json"
+  nh_assert_exit "custom concurrency=read phase blocks Write" 1 write_hook Write "$SAFE_PATH"
 
-printf '{"workspace":"%s","current_phase":"audit-rw","phase_log":[{"phase":"audit-rw","status":"in_progress"}]}' \
-  "$WORK" > "$NANOSTACK_STORE/session.json"
-assert_exit 0 "$(write_hook Write "$SAFE_PATH"; echo $?)" "custom concurrency=write phase does NOT block Write"
+  printf '{"workspace":"%s","current_phase":"audit-rw","phase_log":[{"phase":"audit-rw","status":"in_progress"}]}' \
+    "$WORK" > "$NANOSTACK_STORE/session.json"
+  nh_assert_exit "custom concurrency=write phase does NOT block Write" 0 write_hook Write "$SAFE_PATH"
+}
 
-echo
-echo "${DIM}Cell 8: no active session preserves prior allow/deny behavior${NC}"
-rm -f "$NANOSTACK_STORE/session.json"
-assert_exit 0 "$(write_hook Write "$SAFE_PATH"; echo $?)" "no session: in-project Write allowed"
-assert_exit 1 "$(write_hook Write "$WORK/.env"; echo $?)" "no session: secret-path Write still denied"
+# Cell 8: no active session preserves prior allow/deny behavior.
+cell_no_session() {
+  rm -f "$NANOSTACK_STORE/session.json"
+  nh_assert_exit "no session: in-project Write allowed"      0 write_hook Write "$SAFE_PATH"
+  nh_assert_exit "no session: secret-path Write still denied" 1 write_hook Write "$WORK/.env"
+}
 
-echo
-echo "======================="
-if [ "$FAIL" -eq 0 ]; then
-  printf '%sConcurrency Parity E2E: %s checks passed, 0 failed%s\n' "$GREEN" "$PASS" "$NC"
-  exit 0
-else
-  printf '%sConcurrency Parity E2E: %s passed, %s FAILED%s\n' "$RED" "$PASS" "$FAIL" "$NC"
-  exit 1
-fi
+nh_cell builtin-read    cell_builtin_read
+nh_cell phase-complete  cell_phase_complete
+nh_cell custom-phases   cell_custom_phases
+nh_cell no-session      cell_no_session
+
+nh_summary

--- a/ci/e2e-harness-selftest.sh
+++ b/ci/e2e-harness-selftest.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# e2e-harness-selftest.sh — Validates ci/lib/harness.sh itself.
+#
+# Harness Architecture vNext PR 1 (2026-05-28). A shared harness bug can
+# affect every suite, so the library ships with this self-test first. It
+# exercises the library by running small "child" harness scripts as
+# separate processes and asserting on their output and exit codes:
+# pass/fail counters, nh_capture under `set -e`, nh_assert_exit, --filter
+# skip accounting, NANOSTACK_KEEP_TMP=1, and the /tmp temp-root policy.
+#
+# This suite uses the harness to test the harness; the assertions about
+# the library's behavior run against child processes, not this process.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+HARNESS="$REPO/ci/lib/harness.sh"
+. "$HARNESS"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+nh_init harness-selftest nanostack-harness-selftest
+nh_require_cmd bash
+
+# Run a child harness script body in its own process. Captures combined
+# output into CH_OUT and exit code into CH_RC. Extra leading args (e.g.
+# env assignments) are passed through before `bash`.
+CH_OUT=""; CH_RC=""
+run_child() {
+  local body="$1"; shift
+  nh_capture CH_OUT CH_RC "$@" bash -c "set -u; . '$HARNESS'; $body"
+}
+
+# Cell: pass/fail counters and summary exit code.
+cell_counters() {
+  run_child 'nh_init c1; nh_pass a; nh_pass b; nh_fail c; nh_summary'
+  nh_assert_eq       "mixed run exits 1"                "1" "$CH_RC"
+  nh_assert_contains "summary reports 1 failed of 3"    "$CH_OUT" "1 failed of 3 total"
+  run_child 'nh_init c2; nh_pass only; nh_summary'
+  nh_assert_eq       "all-pass run exits 0"             "0" "$CH_RC"
+  nh_assert_contains "summary reports 1 checks passed"  "$CH_OUT" "1 checks passed, 0 failed"
+}
+
+# Cell: nh_assert_eq / nh_assert_contains pass AND fail paths.
+cell_basic_asserts() {
+  run_child 'nh_init c; nh_assert_eq same 1 1; nh_assert_eq diff 1 2; nh_summary'
+  nh_assert_contains "assert_eq fail counted" "$CH_OUT" "1 failed of 2 total"
+  run_child 'nh_init c; nh_assert_contains has abc b; nh_assert_contains hasnot abc z; nh_summary'
+  nh_assert_contains "assert_contains fail counted" "$CH_OUT" "1 failed of 2 total"
+}
+
+# Cell: nh_capture is safe under set -e and records stdout + rc.
+cell_capture_errexit() {
+  # `false` must NOT abort the child despite set -e; the suite continues
+  # and records the pass after the capture.
+  run_child 'set -e; nh_init c; nh_capture o r false; echo "CAP rc=$r"; nh_pass after-capture; nh_summary'
+  nh_assert_eq       "capture under set -e exits 0"   "0" "$CH_RC"
+  nh_assert_contains "capture recorded rc=1 from false" "$CH_OUT" "CAP rc=1"
+  nh_assert_contains "suite continued after capture"  "$CH_OUT" "after-capture"
+  # Captures stdout content and a non-1 rc.
+  run_child 'nh_init c; nh_capture o r bash -c "echo hello; exit 3"; echo "OUT=[$o] RC=$r"; nh_summary'
+  nh_assert_contains "capture grabs stdout"   "$CH_OUT" "OUT=[hello]"
+  nh_assert_contains "capture grabs exit code" "$CH_OUT" "RC=3"
+}
+
+# Cell: nh_assert_exit pass and fail.
+cell_assert_exit() {
+  run_child 'nh_init c; nh_assert_exit "want 2" 2 bash -c "exit 2"; nh_assert_exit "want 0" 0 bash -c "exit 1"; nh_summary'
+  nh_assert_contains "assert_exit pass+fail counted" "$CH_OUT" "1 failed of 2 total"
+  nh_assert_contains "assert_exit prints observed exit" "$CH_OUT" "want 2 (exit 2)"
+}
+
+# Cell: --filter runs only matching cells and counts skips separately.
+cell_filter() {
+  run_child 'nh_init c; nh_set_filter bbb;
+    fa() { nh_pass a; }; fb() { nh_pass b; }; fc() { nh_pass c; };
+    nh_cell aaa fa; nh_cell bbb fb; nh_cell ccc fc; nh_summary'
+  nh_assert_eq       "filtered run exits 0"            "0" "$CH_RC"
+  nh_assert_contains "only matching cell ran"          "$CH_OUT" "1 checks passed, 0 failed (2 skipped)"
+}
+
+# Cell: NANOSTACK_KEEP_TMP=1 preserves the temp root; default removes it.
+cell_keep_tmp() {
+  run_child 'nh_init keepchild; echo "TMP=$NH_TMP"; nh_pass x; nh_summary' env NANOSTACK_KEEP_TMP=1
+  local kept
+  kept=$(printf '%s\n' "$CH_OUT" | sed -n 's/^TMP=//p' | head -1)
+  nh_assert_true "KEEP_TMP=1 preserves tmp root" test -d "$kept"
+  [ -n "$kept" ] && rm -rf "$kept"
+
+  run_child 'nh_init nokeepchild; echo "TMP=$NH_TMP"; nh_pass x; nh_summary'
+  local gone
+  gone=$(printf '%s\n' "$CH_OUT" | sed -n 's/^TMP=//p' | head -1)
+  nh_assert_false "default removes tmp root" test -d "$gone"
+}
+
+# Cell: a pre-init EXIT trap is chained (not clobbered), and nh_atexit
+# cleanups run at exit.
+cell_trap_chaining() {
+  run_child 'trap "echo PREV_TRAP_RAN" EXIT; nh_init c; echo "TMP=$NH_TMP"; nh_summary'
+  nh_assert_contains "pre-init EXIT trap still runs" "$CH_OUT" "PREV_TRAP_RAN"
+  # Distinguish a real run from a broken `eval` of the quoted trap literal,
+  # which would emit a "command not found" error that still contains the
+  # marker text.
+  nh_assert_not_contains "chained trap is executed, not eval'd as a literal" "$CH_OUT" "not found"
+  local t
+  t=$(printf '%s\n' "$CH_OUT" | sed -n 's/^TMP=//p' | head -1)
+  nh_assert_false "harness temp cleanup still ran despite chained trap" test -d "$t"
+  run_child 'nh_init c; nh_atexit "echo ATEXIT_RAN"; nh_summary'
+  nh_assert_contains "nh_atexit cleanup runs on exit" "$CH_OUT" "ATEXIT_RAN"
+  # A failing nh_atexit command under set -e must not flip the exit code
+  # or skip mandatory temp cleanup.
+  run_child 'set -e; nh_init c; nh_atexit false; echo "TMP=$NH_TMP"; nh_pass x; nh_summary'
+  nh_assert_eq "failing nh_atexit keeps passing exit code" "0" "$CH_RC"
+  local t2
+  t2=$(printf '%s\n' "$CH_OUT" | sed -n 's/^TMP=//p' | head -1)
+  nh_assert_false "failing nh_atexit still removed temp root" test -d "$t2"
+}
+
+# Cell: temp root is under /tmp, never $TMPDIR (/var/folders on macOS).
+cell_tmp_policy() {
+  run_child 'nh_init tmpchild; echo "TMP=$NH_TMP"; nh_summary'
+  local t
+  t=$(printf '%s\n' "$CH_OUT" | sed -n 's/^TMP=//p' | head -1)
+  case "$t" in
+    /tmp/*) nh_pass "temp root is under /tmp ($t)" ;;
+    *)      nh_fail "temp root is under /tmp" "got: $t" ;;
+  esac
+}
+
+nh_cell counters       cell_counters
+nh_cell basic-asserts  cell_basic_asserts
+nh_cell capture-errexit cell_capture_errexit
+nh_cell assert-exit    cell_assert_exit
+nh_cell filter         cell_filter
+nh_cell keep-tmp       cell_keep_tmp
+nh_cell trap-chaining  cell_trap_chaining
+nh_cell tmp-policy     cell_tmp_policy
+
+nh_summary

--- a/ci/e2e-structured-artifacts.sh
+++ b/ci/e2e-structured-artifacts.sh
@@ -12,59 +12,33 @@
 #   - bin/find-artifact.sh and bin/resolve.sh still load legacy
 #     artifacts so existing stores are not broken.
 #   - core SKILL.md guidance no longer documents --from-session.
+#
+# Migrated onto ci/lib/harness.sh (Harness Architecture vNext PR 1).
+# Same cells, same check count. Supports --filter <pattern>.
 set -e
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-TMP_ROOT=$(mktemp -d /tmp/nanostack-structured.XXXXXX)
-trap 'rm -rf "$TMP_ROOT"' EXIT
+. "$REPO/ci/lib/harness.sh"
 
-PASS=0
-FAIL=0
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-DIM='\033[0;90m'
-NC='\033[0m'
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
 
-assert_true() {
-  local name="$1"; shift
-  if "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd: %s${NC}\n" "$*"
-  fi
-}
+nh_init structured-artifacts nanostack-structured
+nh_require_cmd git jq
 
-assert_false() {
-  local name="$1"; shift
-  if ! "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
-  fi
-}
+SAVE="$REPO/bin/save-artifact.sh"
+FIND="$REPO/bin/find-artifact.sh"
+RESOLVE="$REPO/bin/resolve.sh"
 
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}expected: %s${NC}\n" "$expected"
-    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
-  fi
-}
-
-# Set up a fresh project + store. Every cell shares this base.
-PROJ="$TMP_ROOT/project"
+# Shared project + store. Every cell uses this base; fixtures are built
+# once here so a --filter run of any single cell still has them.
+PROJ="$NH_TMP/project"
 STORE="$PROJ/.nanostack"
 mkdir -p "$PROJ" "$STORE"
 cd "$PROJ"
@@ -73,17 +47,7 @@ git config user.email "e2e@test.local"
 git config user.name  "e2e"
 export NANOSTACK_STORE="$STORE"
 
-SAVE="$REPO/bin/save-artifact.sh"
-FIND="$REPO/bin/find-artifact.sh"
-RESOLVE="$REPO/bin/resolve.sh"
-
-echo "Structured Artifact Enforcement E2E"
-echo "==================================="
-echo "Tmp root: $TMP_ROOT"
-echo
-
-# Cell 1: per-phase validator accepts the canonical structured shapes.
-echo "[1] nano_validate_artifact accepts canonical shapes"
+# Canonical valid shapes.
 plan_ok=$(jq -n '{phase:"plan",summary:{planned_files:["a.ts"],plan_approval:"manual"},context_checkpoint:{summary:"x"}}')
 review_ok=$(jq -n '{phase:"review",summary:{blocking:0},scope_drift:{status:"clean"},findings:[],context_checkpoint:{summary:"x"}}')
 qa_ok=$(jq -n '{phase:"qa",summary:{tests_run:5},findings:[],context_checkpoint:{summary:"x"}}')
@@ -91,143 +55,133 @@ sec_ok=$(jq -n '{phase:"security",summary:{total_findings:0},findings:[],context
 ship_ok=$(jq -n '{phase:"ship",summary:{pr_number:42,status:"merged"},context_checkpoint:{summary:"x"}}')
 ship_ro=$(jq -n '{phase:"ship",summary:"would have shipped",run_mode:"report_only"}')
 think_ok=$(jq -n '{phase:"think",summary:{value_proposition:"x"}}')
-for kind in plan review qa sec ship ship_ro think; do
-  case "$kind" in
-    plan)    json="$plan_ok";   phase=plan ;;
-    review)  json="$review_ok"; phase=review ;;
-    qa)      json="$qa_ok";     phase=qa ;;
-    sec)     json="$sec_ok";    phase=security ;;
-    ship)    json="$ship_ok";   phase=ship ;;
-    ship_ro) json="$ship_ro";   phase=ship ;;
-    think)   json="$think_ok";  phase=think ;;
-  esac
-  assert_true "validator accepts canonical $kind" \
-    bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
-done
 
-# Cell 2: validator rejects invalid shapes with a stable error format.
-echo "[2] nano_validate_artifact rejects missing required fields"
+# Invalid shapes (missing required fields).
 plan_bad=$(jq -n '{phase:"plan",summary:{plan_approval:"manual"},context_checkpoint:{summary:"x"}}')
 review_bad=$(jq -n '{phase:"review",summary:{},context_checkpoint:{summary:"x"}}')
 qa_bad=$(jq -n '{phase:"qa",summary:{tests_run:5}}')
 sec_bad=$(jq -n '{phase:"security",summary:"a string"}')
 ship_bad=$(jq -n '{phase:"ship",summary:"loose without report_only"}')
 think_bad=$(jq -n '{phase:"think",summary:"plain string"}')
-for kind in plan review qa sec ship think; do
-  case "$kind" in
-    plan)   json="$plan_bad";   phase=plan ;;
-    review) json="$review_bad"; phase=review ;;
-    qa)     json="$qa_bad";     phase=qa ;;
-    sec)    json="$sec_bad";    phase=security ;;
-    ship)   json="$ship_bad";   phase=ship ;;
-    think)  json="$think_bad";  phase=think ;;
-  esac
-  assert_false "validator rejects invalid $kind" \
-    bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
-done
+
+# Cell 1: per-phase validator accepts the canonical structured shapes.
+cell_validator_accepts() {
+  local kind json phase
+  for kind in plan review qa sec ship ship_ro think; do
+    case "$kind" in
+      plan)    json="$plan_ok";   phase=plan ;;
+      review)  json="$review_ok"; phase=review ;;
+      qa)      json="$qa_ok";     phase=qa ;;
+      sec)     json="$sec_ok";    phase=security ;;
+      ship)    json="$ship_ok";   phase=ship ;;
+      ship_ro) json="$ship_ro";   phase=ship ;;
+      think)   json="$think_ok";  phase=think ;;
+    esac
+    nh_assert_true "validator accepts canonical $kind" \
+      bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
+  done
+}
+
+# Cell 2: validator rejects invalid shapes.
+cell_validator_rejects() {
+  local kind json phase
+  for kind in plan review qa sec ship think; do
+    case "$kind" in
+      plan)   json="$plan_bad";   phase=plan ;;
+      review) json="$review_bad"; phase=review ;;
+      qa)     json="$qa_bad";     phase=qa ;;
+      sec)    json="$sec_bad";    phase=security ;;
+      ship)   json="$ship_bad";   phase=ship ;;
+      think)  json="$think_bad";  phase=think ;;
+    esac
+    nh_assert_false "validator rejects invalid $kind" \
+      bash -c "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact '$phase' '$json'"
+  done
+}
 
 # Cell 3: save-artifact.sh refuses to write invalid shapes.
-echo "[3] save-artifact.sh exits 1 on invalid shape (no file written)"
-before=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
-set +e
-out=$( "$SAVE" plan "$plan_bad" 2>&1 )
-rc=$?
-set -e
-after=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
-assert_eq "exit code is 1"           "1"        "$rc"
-assert_eq "no artifact written"      "$before"  "$after"
-echo "$out" | grep -qE 'missing required fields' && \
-  assert_eq "stderr mentions missing required fields" "yes" "yes" || \
-  assert_eq "stderr mentions missing required fields" "yes" "no"
+cell_save_rejects_invalid() {
+  local before after out rc
+  before=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+  nh_capture out rc "$SAVE" plan "$plan_bad"
+  after=$(find "$STORE" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+  nh_assert_eq "exit code is 1"      "1"       "$rc"
+  nh_assert_eq "no artifact written" "$before" "$after"
+  nh_assert_contains "stderr mentions missing required fields" "$out" "missing required fields"
+}
 
-# Cell 4: save-artifact.sh writes valid structured artifacts and the
-# saved file passes nano_artifact_trust (integrity field present).
-echo "[4] save-artifact.sh writes valid structured artifacts"
-saved_plan=$( "$SAVE" plan "$plan_ok" )
-assert_true "plan artifact file exists" test -f "$saved_plan"
-assert_true "plan artifact has context_checkpoint" \
-  bash -c "jq -e '.context_checkpoint != null' '$saved_plan' >/dev/null"
-assert_true "plan artifact has integrity field" \
-  bash -c "jq -e '.integrity != null' '$saved_plan' >/dev/null"
-assert_true "plan artifact has summary.planned_files array" \
-  bash -c "jq -e '(.summary.planned_files | type) == \"array\"' '$saved_plan' >/dev/null"
-
-saved_ship_ro=$( "$SAVE" ship "$ship_ro" )
-assert_true "ship report_only artifact file exists" test -f "$saved_ship_ro"
+# Cell 4: save-artifact.sh writes valid structured artifacts with integrity.
+cell_save_writes_valid() {
+  local saved_plan saved_ship_ro
+  saved_plan=$( "$SAVE" plan "$plan_ok" )
+  nh_assert_true "plan artifact file exists" test -f "$saved_plan"
+  nh_assert_jq_file "plan artifact has context_checkpoint"          "$saved_plan" '.context_checkpoint != null'
+  nh_assert_jq_file "plan artifact has integrity field"             "$saved_plan" '.integrity != null'
+  nh_assert_jq_file "plan artifact has summary.planned_files array" "$saved_plan" '(.summary.planned_files | type) == "array"'
+  saved_ship_ro=$( "$SAVE" ship "$ship_ro" )
+  nh_assert_true "ship report_only artifact file exists" test -f "$saved_ship_ro"
+}
 
 # Cell 5: --from-session still works, emits deprecation, marks legacy.
-echo "[5] --from-session writes a legacy artifact with deprecation warning"
-set +e
-out=$( "$SAVE" --from-session qa 'N tests passed' 2>&1 )
-rc=$?
-set -e
-saved_legacy=$(echo "$out" | tail -1)
-assert_eq "legacy save exit code is 0" "0" "$rc"
-assert_true "legacy artifact file exists" test -f "$saved_legacy"
-assert_true "legacy artifact has schema_legacy: true" \
-  bash -c "jq -e '.schema_legacy == true' '$saved_legacy' >/dev/null"
-echo "$out" | grep -qE '^save-artifact.sh: --from-session is a legacy mode' && \
-  assert_eq "deprecation warning printed" "yes" "yes" || \
-  assert_eq "deprecation warning printed" "yes" "no"
+cell_from_session_legacy() {
+  local out rc saved_legacy
+  nh_capture out rc "$SAVE" --from-session qa 'N tests passed'
+  saved_legacy=$(printf '%s\n' "$out" | tail -1)
+  nh_assert_eq "legacy save exit code is 0" "0" "$rc"
+  nh_assert_true "legacy artifact file exists" test -f "$saved_legacy"
+  nh_assert_jq_file "legacy artifact has schema_legacy: true" "$saved_legacy" '.schema_legacy == true'
+  nh_assert_contains "deprecation warning printed" "$out" "--from-session is a legacy mode"
+}
 
 # Cell 6: legacy artifacts remain readable by find-artifact + resolve.
-echo "[6] legacy artifacts are still readable by downstream tools"
-found=$( "$FIND" qa 30 2>/dev/null )
-assert_true "find-artifact returns the legacy qa artifact" test -f "$found"
-# resolve.sh /ship reads qa upstream; the legacy qa load should not break it
-# but the legacy artifact has summary as string, so upstream_status will
-# be verified (because save-artifact still writes integrity).
-resolved=$( "$RESOLVE" ship 2>/dev/null )
-status_qa=$( echo "$resolved" | jq -r '.upstream_status.qa // ""' )
-assert_eq "resolve.sh upstream_status.qa is verified" "verified" "$status_qa"
+cell_legacy_readable() {
+  local found resolved status_qa
+  # Self-contained under --filter: ensure a legacy qa artifact exists even
+  # when from-session-legacy was filtered out. The full run also seeds one
+  # there; re-seeding is harmless (find/resolve take the newest).
+  "$SAVE" --from-session qa 'N tests passed' >/dev/null 2>&1 || true
+  found=$( "$FIND" qa 30 2>/dev/null )
+  nh_assert_true "find-artifact returns the legacy qa artifact" test -f "$found"
+  resolved=$( "$RESOLVE" ship 2>/dev/null )
+  status_qa=$( printf '%s' "$resolved" | jq -r '.upstream_status.qa // ""' )
+  nh_assert_eq "resolve.sh upstream_status.qa is verified" "verified" "$status_qa"
+}
 
-# Cell 7: SKILL.md acceptance regex (mirrors the lint job).
-echo "[7] core SKILL.md no longer references --from-session normal save"
-set +e
-out=$( grep -nE -- '--from-session (plan|review|qa|security|ship)' \
-  "$REPO/plan/SKILL.md" "$REPO/review/SKILL.md" "$REPO/qa/SKILL.md" \
-  "$REPO/security/SKILL.md" "$REPO/ship/SKILL.md" 2>&1 )
-rc=$?
-set -e
-assert_eq "spec acceptance regex matches nothing (rc 1)" "1" "$rc"
+# Cell 7: core SKILL.md no longer references --from-session normal save.
+cell_skill_md_clean() {
+  local out rc
+  nh_capture out rc grep -nE -- '--from-session (plan|review|qa|security|ship)' \
+    "$REPO/plan/SKILL.md" "$REPO/review/SKILL.md" "$REPO/qa/SKILL.md" \
+    "$REPO/security/SKILL.md" "$REPO/ship/SKILL.md"
+  nh_assert_eq "spec acceptance regex matches nothing (rc 1)" "1" "$rc"
+}
 
-# Cell 8: save-artifact.sh sources artifact-schemas.sh and calls the
-# validator (the lint guards this too; cell exists so the harness is
-# self-contained for local development).
-echo "[8] save-artifact.sh wires the per-phase validator"
-script="$REPO/bin/save-artifact.sh"
-grep -qF 'artifact-schemas.sh' "$script" && \
-  assert_eq "save-artifact.sh sources artifact-schemas.sh" "yes" "yes" || \
-  assert_eq "save-artifact.sh sources artifact-schemas.sh" "yes" "no"
-grep -qF 'nano_validate_artifact' "$script" && \
-  assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "yes" || \
-  assert_eq "save-artifact.sh calls nano_validate_artifact" "yes" "no"
+# Cell 8: save-artifact.sh wires the per-phase validator.
+cell_save_wires_validator() {
+  nh_assert_file_contains "save-artifact.sh sources artifact-schemas.sh"  "$SAVE" 'artifact-schemas.sh'
+  nh_assert_file_contains "save-artifact.sh calls nano_validate_artifact" "$SAVE" 'nano_validate_artifact'
+}
 
-# Cell 9: nano_validate_artifact stays callable from set -e callers
-# even on malformed ship artifacts. A ship payload with a string
-# summary and no top-level run_mode used to crash the jq probe
-# (rc 5), so an errexit caller exited before the validator could
-# return its documented schema error. Codex caught this on the
-# PR 3 sixth review pass.
-echo "[9] nano_validate_artifact survives jq probes on malformed ship"
-ship_loose='{"phase":"ship","summary":"loose string"}'
-set +e
-bash -ec "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact ship '$ship_loose' 2>/dev/null" >/dev/null
-rc=$?
-set -e
-# Schema failure must return 1 (the documented value), not 5 (jq crash)
-# or any other non-1 non-0 value.
-assert_eq "validator returns 1 (schema fail), not 5 (jq crash)" "1" "$rc"
+# Cell 9: nano_validate_artifact stays callable from set -e callers even
+# on malformed ship artifacts. A ship payload with a string summary and
+# no top-level run_mode used to crash the jq probe (rc 5), so an errexit
+# caller exited before the validator could return its documented schema
+# error. Codex caught this on the PR 3 sixth review pass.
+cell_validator_errexit_safe() {
+  local ship_loose out rc
+  ship_loose='{"phase":"ship","summary":"loose string"}'
+  nh_capture out rc bash -ec "source '$REPO/bin/lib/artifact-schemas.sh'; nano_validate_artifact ship '$ship_loose' 2>/dev/null"
+  nh_assert_eq "validator returns 1 (schema fail), not 5 (jq crash)" "1" "$rc"
+}
 
-cd "$TMP_ROOT"
+nh_cell validator-accepts      cell_validator_accepts
+nh_cell validator-rejects      cell_validator_rejects
+nh_cell save-rejects-invalid   cell_save_rejects_invalid
+nh_cell save-writes-valid      cell_save_writes_valid
+nh_cell from-session-legacy    cell_from_session_legacy
+nh_cell legacy-readable        cell_legacy_readable
+nh_cell skill-md-clean         cell_skill_md_clean
+nh_cell save-wires-validator   cell_save_wires_validator
+nh_cell validator-errexit-safe cell_validator_errexit_safe
 
-echo
-echo "==================================="
-TOTAL=$((PASS + FAIL))
-if [ "$FAIL" -eq 0 ]; then
-  printf "${GREEN}Structured Artifact E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
-  exit 0
-else
-  printf "${RED}Structured Artifact E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
-  exit 1
-fi
+nh_summary

--- a/ci/lib/harness.sh
+++ b/ci/lib/harness.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# harness.sh — Shared test-harness core for nanostack CI suites.
+#
+# Harness Architecture vNext PR 1 (2026-05-28). Before this library every
+# large suite owned its own PASS/FAIL counters, ANSI colors, assert_*
+# helpers, set +e/-e capture blocks, and /tmp mktemp rationale. That
+# duplication drifted (some used set -e, some not; some emitted totals
+# differently) and made every set -e capture bug easy to reintroduce.
+# This is the single tested primitive new suites source instead.
+#
+# Properties:
+#   - Bash 3.2 compatible (no associative arrays, no `local -n`).
+#   - Safe under `set -e` AND `set -u`: assertions never abort the suite
+#     on failure (they count and continue), and command-running helpers
+#     save/restore the caller's errexit state around the call.
+#   - No external dependencies beyond what the suite itself needs.
+#   - Temp roots live under /tmp, never $TMPDIR. On macOS $TMPDIR is
+#     /var/folders/..., and the write guard correctly denies paths under
+#     /var/, which would turn "write allowed" assertions into false
+#     failures unrelated to what the suite is testing.
+#   - Functions are namespaced `nh_` to avoid collisions with suite code.
+#
+# Public API:
+#   nh_init <suite_id> [tmp_prefix]      init counters + /tmp root ($NH_TMP)
+#   nh_atexit <command>                  register extra cleanup (runs at EXIT
+#                                        before the temp root is removed)
+#   nh_set_filter <pattern>              only run cells whose id matches
+#   nh_require_cmd <cmd>...              hard-fail if a command is missing
+#   nh_pass <label>                      record a pass
+#   nh_fail <label> [detail]             record a fail
+#   nh_assert_eq <label> <exp> <act>
+#   nh_assert_true <label> <command>...
+#   nh_assert_false <label> <command>...
+#   nh_assert_contains <label> <hay> <needle>
+#   nh_assert_not_contains <label> <hay> <needle>
+#   nh_assert_file_contains <label> <file> <needle>
+#   nh_assert_file_not_contains <label> <file> <needle>
+#   nh_assert_jq_file <label> <file> <jq_expr>
+#   nh_assert_exit <label> <expected_rc> <command>...
+#   nh_capture <out_var> <rc_var> <command>...   stdout+stderr & rc, set -e safe
+#   nh_cell <cell_id> <function_name>            run a cell unless filtered out
+#   nh_should_run <cell_id>                       0 if it would run under filter
+#   nh_summary                                    print totals; rc 1 if any fail
+#
+# Local helpers:
+#   NANOSTACK_KEEP_TMP=1  keep the temp root after exit for inspection.
+#   NO_COLOR / non-tty    suppress ANSI color.
+
+# Idempotent: safe to source more than once in a process.
+if [ "${_NH_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NH_LOADED=1
+
+_NH_SUITE=""
+_NH_CELL=""
+_NH_PASS=0
+_NH_FAIL=0
+_NH_SKIP=0
+_NH_FILTER="${NH_FILTER:-}"
+_NH_PREV_EXIT_TRAP=""
+_NH_ATEXIT=""
+NH_TMP=""
+
+if [ -n "${NO_COLOR:-}" ] || [ ! -t 1 ]; then
+  _NH_GREEN=""; _NH_RED=""; _NH_DIM=""; _NH_NC=""
+else
+  _NH_GREEN=$'\033[0;32m'; _NH_RED=$'\033[0;31m'; _NH_DIM=$'\033[0;90m'; _NH_NC=$'\033[0m'
+fi
+
+# True (0) if errexit is currently on. Used to restore it after a helper
+# deliberately runs a command that may fail.
+_nh_errexit_on() { case "$-" in *e*) return 0 ;; *) return 1 ;; esac }
+
+nh_init() {
+  _NH_SUITE="${1:?nh_init requires a suite id}"
+  local prefix="${2:-nanostack-$_NH_SUITE}"
+  _NH_PASS=0; _NH_FAIL=0; _NH_SKIP=0
+  NH_TMP="$(mktemp -d "/tmp/${prefix}.XXXXXX")"
+  # Chain rather than clobber: capture any EXIT trap that existed before
+  # nh_init so a suite that registered teardown earlier still runs. For
+  # cleanup registered AFTER nh_init, suites must use nh_atexit (a raw
+  # `trap ... EXIT` after this point would replace the harness cleanup).
+  _NH_PREV_EXIT_TRAP="$(trap -p EXIT 2>/dev/null || true)"
+  trap '_nh_cleanup' EXIT
+  echo "${_NH_SUITE} harness"
+  echo "tmp root: $NH_TMP"
+  echo
+}
+
+# Register a command to run at EXIT (before the temp root is removed), so
+# suites needing extra teardown do not have to overwrite the harness trap.
+nh_atexit() {
+  _NH_ATEXIT="${_NH_ATEXIT}${1}
+"
+}
+
+_nh_cleanup() {
+  # Preserve the exiting status: the EXIT trap must not change the script's
+  # final exit code, and no individual cleanup step may abort the rest
+  # (mandatory temp removal + trap chaining must always run). errexit is
+  # disabled for the whole trap; we are on the exit path.
+  local _rc=$?
+  set +e
+  # 1. Suite-registered cleanups run first (they may reference NH_TMP). Run
+  #    them in a contained eval so a failing teardown cannot skip the
+  #    mandatory steps below.
+  [ -n "${_NH_ATEXIT:-}" ] && eval "$_NH_ATEXIT"
+  # 2. Temp root.
+  if [ "${NANOSTACK_KEEP_TMP:-0}" = "1" ]; then
+    printf '%s[harness] NANOSTACK_KEEP_TMP=1 — kept tmp root: %s%s\n' "$_NH_DIM" "$NH_TMP" "$_NH_NC" >&2
+  elif [ -n "$NH_TMP" ]; then
+    rm -rf "$NH_TMP"
+  fi
+  # 3. Chain any EXIT trap that pre-existed nh_init. `trap -p` emits a
+  #    re-installable, shell-quoted statement: trap -- 'ACTION' EXIT. To
+  #    actually RUN the action we strip the `trap -- '` prefix and the
+  #    `' EXIT` suffix (only when that exact shape matches) and eval the
+  #    unquoted action.
+  case "${_NH_PREV_EXIT_TRAP:-}" in
+    "trap -- '"*"' EXIT")
+      local _p="$_NH_PREV_EXIT_TRAP"
+      _p="${_p#trap -- \'}"
+      _p="${_p%\' EXIT}"
+      eval "$_p"
+      ;;
+  esac
+  return "$_rc"
+}
+
+nh_set_filter() { _NH_FILTER="$1"; }
+
+nh_require_cmd() {
+  local missing="" c
+  for c in "$@"; do
+    command -v "$c" >/dev/null 2>&1 || missing="${missing:+$missing }$c"
+  done
+  if [ -n "$missing" ]; then
+    printf '%sMISSING REQUIRED: %s (suite %s cannot run)%s\n' "$_NH_RED" "$missing" "$_NH_SUITE" "$_NH_NC" >&2
+    exit 1
+  fi
+}
+
+nh_pass() {
+  _NH_PASS=$((_NH_PASS + 1))
+  printf '    %sOK%s    %s\n' "$_NH_GREEN" "$_NH_NC" "$1"
+}
+
+nh_fail() {
+  _NH_FAIL=$((_NH_FAIL + 1))
+  printf '    %sFAIL%s  %s\n' "$_NH_RED" "$_NH_NC" "$1"
+  [ -n "${2:-}" ] && printf '          %s%s%s\n' "$_NH_DIM" "$2" "$_NH_NC"
+  printf '          %ssuite=%s cell=%s tmp=%s%s\n' \
+    "$_NH_DIM" "$_NH_SUITE" "${_NH_CELL:-<none>}" "$NH_TMP" "$_NH_NC"
+}
+
+nh_assert_eq() {
+  if [ "$2" = "$3" ]; then
+    nh_pass "$1"
+  else
+    nh_fail "$1" "expected: $2 | actual: $3"
+  fi
+}
+
+# Run a command, expect exit 0. errexit-safe.
+nh_assert_true() {
+  local label="$1"; shift
+  local rc restore=0
+  _nh_errexit_on && restore=1
+  set +e
+  "$@" >/dev/null 2>&1
+  rc=$?
+  [ "$restore" = "1" ] && set -e
+  if [ "$rc" -eq 0 ]; then nh_pass "$label"; else nh_fail "$label" "command failed (rc $rc): $*"; fi
+}
+
+# Run a command, expect non-zero exit. errexit-safe.
+nh_assert_false() {
+  local label="$1"; shift
+  local rc restore=0
+  _nh_errexit_on && restore=1
+  set +e
+  "$@" >/dev/null 2>&1
+  rc=$?
+  [ "$restore" = "1" ] && set -e
+  if [ "$rc" -ne 0 ]; then nh_pass "$label"; else nh_fail "$label" "command unexpectedly succeeded: $*"; fi
+}
+
+nh_assert_contains() {
+  case "$2" in
+    *"$3"*) nh_pass "$1" ;;
+    *)      nh_fail "$1" "missing substring: $3" ;;
+  esac
+}
+
+nh_assert_not_contains() {
+  case "$2" in
+    *"$3"*) nh_fail "$1" "unexpected substring: $3" ;;
+    *)      nh_pass "$1" ;;
+  esac
+}
+
+nh_assert_file_contains() {
+  if [ -f "$2" ] && grep -qF -- "$3" "$2" 2>/dev/null; then
+    nh_pass "$1"
+  else
+    nh_fail "$1" "file does not contain: $3 ($2)"
+  fi
+}
+
+nh_assert_file_not_contains() {
+  if [ -f "$2" ] && grep -qF -- "$3" "$2" 2>/dev/null; then
+    nh_fail "$1" "file unexpectedly contains: $3 ($2)"
+  else
+    nh_pass "$1"
+  fi
+}
+
+nh_assert_jq_file() {
+  if jq -e "$3" "$2" >/dev/null 2>&1; then
+    nh_pass "$1"
+  else
+    nh_fail "$1" "jq expr failed: $3 ($2)"
+  fi
+}
+
+# Run a command, assert its exit code equals an expected value. errexit-safe.
+nh_assert_exit() {
+  local label="$1" expected="$2"; shift 2
+  local rc restore=0
+  _nh_errexit_on && restore=1
+  set +e
+  "$@" >/dev/null 2>&1
+  rc=$?
+  [ "$restore" = "1" ] && set -e
+  if [ "$rc" = "$expected" ]; then
+    nh_pass "$label (exit $rc)"
+  else
+    nh_fail "$label" "exit $rc, expected $expected: $*"
+  fi
+}
+
+# Capture combined stdout+stderr and exit code of a command into two named
+# variables without aborting under errexit. Uses printf -v so arbitrary
+# (multi-line, special-char) output is assigned safely.
+nh_capture() {
+  local _ov="$1" _rv="$2"; shift 2
+  local _out _rc restore=0
+  _nh_errexit_on && restore=1
+  set +e
+  _out=$("$@" 2>&1)
+  _rc=$?
+  [ "$restore" = "1" ] && set -e
+  printf -v "$_ov" '%s' "$_out"
+  printf -v "$_rv" '%s' "$_rc"
+  return 0
+}
+
+nh_should_run() {
+  [ -z "$_NH_FILTER" ] && return 0
+  case "$1" in
+    *"$_NH_FILTER"*) return 0 ;;
+    *)               return 1 ;;
+  esac
+}
+
+# Run a cell (a function) unless a --filter pattern excludes its id.
+# Skips are counted separately from pass/fail.
+nh_cell() {
+  local cell_id="$1" fn="$2"
+  if ! nh_should_run "$cell_id"; then
+    _NH_SKIP=$((_NH_SKIP + 1))
+    return 0
+  fi
+  _NH_CELL="$cell_id"
+  printf '%s[%s]%s\n' "$_NH_DIM" "$cell_id" "$_NH_NC"
+  "$fn"
+  _NH_CELL=""
+}
+
+nh_summary() {
+  local total=$((_NH_PASS + _NH_FAIL))
+  echo
+  echo "====================="
+  if [ "$_NH_FAIL" -eq 0 ]; then
+    printf '%s%s: %d checks passed, 0 failed%s' "$_NH_GREEN" "$_NH_SUITE" "$_NH_PASS" "$_NH_NC"
+    [ "$_NH_SKIP" -gt 0 ] && printf ' (%d skipped)' "$_NH_SKIP"
+    printf '\n'
+    return 0
+  else
+    printf '%s%s: %d failed of %d total%s' "$_NH_RED" "$_NH_SUITE" "$_NH_FAIL" "$total" "$_NH_NC"
+    [ "$_NH_SKIP" -gt 0 ] && printf ' (%d skipped)' "$_NH_SKIP"
+    printf '\n'
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary

PR 1 of the Harness Architecture vNext round. The test harnesses have
become a subsystem, and every large suite reimplemented its own PASS/FAIL
counters, ANSI colors, assert helpers, `set +e/-e` capture blocks, and
/tmp rationale. This adds one tested primitive and migrates two small
suites onto it. No coverage is removed.

## What changed

- **`ci/lib/harness.sh`** (new) — shared core. `nh_init`, `nh_pass/fail`,
  `nh_assert_eq/true/false/contains/not_contains/file_contains/file_not_contains/jq_file/exit`,
  `nh_capture`, `nh_cell`, `nh_should_run`, `nh_set_filter`, `nh_summary`,
  `nh_atexit`, `nh_require_cmd`. Bash 3.2; safe under both `set -e` and
  `set -u` (assertions count and continue instead of aborting; command
  runners save/restore errexit). Temp roots are under `/tmp`, never
  `$TMPDIR` (macOS `/var/folders` would trip the write guard). EXIT trap
  chains any pre-existing trap and runs `nh_atexit` cleanups; cleanup never
  changes the suite exit code or skips temp removal. `NANOSTACK_KEEP_TMP=1`
  preserves the temp root for inspection.

- **`ci/e2e-harness-selftest.sh`** (new) — validates the library via child
  processes: counters + summary exit code, `nh_capture` under `set -e`,
  `nh_assert_exit`, `--filter` skip accounting, EXIT-trap chaining +
  `nh_atexit` (including a failing teardown not breaking cleanup),
  `NANOSTACK_KEEP_TMP=1`, and the /tmp policy. 24 checks.

- **`ci/e2e-concurrency-parity.sh`**, **`ci/e2e-structured-artifacts.sh`** —
  migrated onto the library; cells are now functions run via `nh_cell`, and
  both gained a `--filter <pattern>` flag for local iteration.

- **`.github/workflows/lint.yml`** — new `harness-selftest` job runs the
  self-test on every PR.

## Metrics

- Suites migrated: 2.
- Check counts unchanged: concurrency-parity 10 -> 10, structured-artifacts
  31 -> 31.
- Duplicated boilerplate (counters, colors, assert helpers, summary)
  removed from the two suites: ~76 lines, centralized into the shared
  library (296 lines, reusable by all future suites).
- Workflow/job names touched: added `harness-selftest` (lint.yml). No job
  renamed. `guard-regression` and `write-guard-regression` untouched.
- Adapter evidence job names changed: no.
- Tier behavior: the two migrated suites stay opt-in in `e2e.yml`
  (unchanged). One new continuous PR job (`harness-selftest`) added; no
  existing suite's tier changed.

## Validation

The `--filter` flag selects whole cells (cell groups); `nh_summary` reports
how many cells were skipped, separate from the pass/fail check count.

- `ci/e2e-harness-selftest.sh`: 24/24.
- `ci/e2e-concurrency-parity.sh`: 10/10 (full, 4 cells). `--filter custom`
  runs the 1 matching cell (2 checks); summary reports 3 skipped cells.
- `ci/e2e-structured-artifacts.sh`: 31/31 (full, 9 cells). `--filter save`
  runs 3 matching cells (10 checks), 6 skipped cells; `--filter
  legacy-readable` runs standalone (self-seeds its fixture).
- Negative controls preserved: neutering check-write's read-only block
  fails 4 concurrency cells; neutering `nano_validate_artifact` fails 10
  structured checks. Restored -> green.
- bash 3.2 clean; lint YAML parses; no public docs changed; codex review
  clean.

Harness Architecture vNext PR 1 of 6.
