### PR TITLE
ci: add shared fixtures for artifact and store harnesses

### DIFF
--- a/ci/e2e-artifact-trust.sh
+++ b/ci/e2e-artifact-trust.sh
@@ -2,422 +2,262 @@
 # e2e-artifact-trust.sh — Artifact Trust v2 contract.
 #
 # Locks the shared trust model introduced in PR 2 of the 2026-05-10
-# architecture audit. Covers the four canonical artifact states across
-# three consumer surfaces:
+# architecture audit, plus the PR 3 phase-gate trusted-evidence contract
+# (2026-05-28). Covers the four canonical artifact states across
+# bin/lib/artifact-trust.sh, bin/find-artifact.sh (--verify and
+# --require-integrity), bin/resolve.sh (upstream_status), and
+# guard/bin/phase-gate.sh (commit/push gate consumes trusted, filename-
+# dated evidence).
 #
-#   - bin/lib/artifact-trust.sh  (the helper itself)
-#   - bin/find-artifact.sh       (--verify and --require-integrity)
-#   - bin/resolve.sh             (upstream_status field)
-#
-# The harness writes artifacts by hand so each trust state is exercised
-# in isolation, then runs the public CLI surfaces and asserts the
-# observable outputs. Save-artifact.sh always writes .integrity, so
-# integrity_missing only happens for legacy artifacts or after an
-# attacker strips the field; both paths are tested here.
+# Migrated onto ci/lib/harness.sh + ci/lib/fixtures.sh (Harness vNext
+# PR 2). Same cells, same check count (41). Artifacts are built via
+# nf_write_artifact, whose "verified" hash is the production canonical
+# hash, so a fixture verifies exactly as a save-artifact.sh output would.
+# Supports --filter <pattern>.
 set -e
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-TMP_ROOT=$(mktemp -d /tmp/nanostack-artifact-trust.XXXXXX)
-trap 'rm -rf "$TMP_ROOT"' EXIT
+. "$REPO/ci/lib/harness.sh"
+. "$REPO/ci/lib/fixtures.sh"
 
-PASS=0
-FAIL=0
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-DIM='\033[0;90m'
-NC='\033[0m'
-
-assert_true() {
-  local name="$1"; shift
-  if "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd: %s${NC}\n" "$*"
-  fi
-}
-
-assert_false() {
-  local name="$1"; shift
-  if ! "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
-  fi
-}
-
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}expected: %s${NC}\n" "$expected"
-    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
-  fi
-}
-
-# Write a json artifact under <store>/<phase>/<ts>.json in one of three
-# trust states. The body is fixed so the canonical hash is reproducible.
-mk_artifact() {
-  local store="$1" phase="$2" mode="$3" ts="$4" project="$5"
-  mkdir -p "$store/$phase"
-  local body
-  body=$(printf '{"phase":"%s","project":"%s","summary":"x"}' "$phase" "$project")
-  case "$mode" in
-    verified)
-      local h
-      h=$(printf '%s' "$body" | jq -Sc 'del(.integrity)' | shasum -a 256 | cut -d' ' -f1)
-      printf '%s' "$body" | jq --arg h "$h" '. + {integrity:$h}' > "$store/$phase/$ts.json"
-      ;;
-    missing)
-      printf '%s' "$body" > "$store/$phase/$ts.json"
-      ;;
-    mismatch)
-      printf '%s' "$body" | jq '. + {integrity:"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}' > "$store/$phase/$ts.json"
-      ;;
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
   esac
-}
+done
 
-echo "Artifact Trust v2 E2E"
-echo "====================="
-echo "Tmp root: $TMP_ROOT"
-echo
+nh_init artifact-trust nanostack-artifact-trust
+nh_require_cmd git jq
 
-PROJ="$TMP_ROOT/project"
-STORE="$PROJ/.nanostack"
-mkdir -p "$PROJ" "$STORE"
-cd "$PROJ"
-git init -q
+FIND="$REPO/bin/find-artifact.sh"
+RESOLVE="$REPO/bin/resolve.sh"
+GATE="$REPO/guard/bin/phase-gate.sh"
 
 # Cell 1: nano_artifact_trust returns each of the four statuses.
-echo "[1] nano_artifact_trust returns the four canonical statuses"
-mk_artifact "$STORE" trust verified  2026-05-10T01-00-00 "$PROJ"
-mk_artifact "$STORE" trust missing   2026-05-10T01-01-00 "$PROJ"
-mk_artifact "$STORE" trust mismatch  2026-05-10T01-02-00 "$PROJ"
-ok_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-00-00.json'")
-miss_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-01-00.json'")
-bad_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/2026-05-10T01-02-00.json'")
-none_status=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$STORE/trust/does-not-exist.json' || true")
-assert_eq "verified artifact"           "verified"           "$ok_status"
-assert_eq "integrity_missing artifact"  "integrity_missing"  "$miss_status"
-assert_eq "integrity_mismatch artifact" "integrity_mismatch" "$bad_status"
-assert_eq "not_found artifact"          "not_found"          "$none_status"
+cell_trust_statuses() {
+  local store; store=$(nf_new_store "$(nf_new_git_project trust1)")
+  nf_write_artifact "$store" trust verified  2026-05-10T01-00-00 "$store" >/dev/null
+  nf_write_artifact "$store" trust integrity_missing  2026-05-10T01-01-00 "$store" >/dev/null
+  nf_write_artifact "$store" trust integrity_mismatch 2026-05-10T01-02-00 "$store" >/dev/null
+  local ok miss bad none
+  ok=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$store/trust/2026-05-10T01-00-00.json'")
+  miss=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$store/trust/2026-05-10T01-01-00.json'")
+  bad=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$store/trust/2026-05-10T01-02-00.json'")
+  none=$(bash -c "source '$REPO/bin/lib/artifact-trust.sh'; nano_artifact_trust '$store/trust/does-not-exist.json' || true")
+  nh_assert_eq "verified artifact"           "verified"           "$ok"
+  nh_assert_eq "integrity_missing artifact"  "integrity_missing"  "$miss"
+  nh_assert_eq "integrity_mismatch artifact" "integrity_mismatch" "$bad"
+  nh_assert_eq "not_found artifact"          "not_found"          "$none"
+}
 
-# Cell 2: find-artifact.sh without --verify returns the newest artifact
-# regardless of trust state. This preserves the historical default.
-echo "[2] find-artifact.sh default returns newest regardless of trust"
-NANOSTACK_STORE="$STORE" out=$( NANOSTACK_STORE="$STORE" "$REPO/bin/find-artifact.sh" trust 30 2>/dev/null || true )
-assert_eq "default returns the newest (mismatch) artifact" "2026-05-10T01-02-00.json" "$(basename "${out:-}")"
+# Cell 2: find-artifact.sh default returns the newest regardless of trust.
+cell_find_default() {
+  local proj store; proj=$(nf_new_git_project trust2); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_write_artifact "$store" trust verified           2026-05-10T01-00-00 "$proj" >/dev/null
+  nf_write_artifact "$store" trust integrity_mismatch 2026-05-10T01-02-00 "$proj" >/dev/null
+  local out
+  out=$( NANOSTACK_STORE="$store" "$FIND" trust 30 2>/dev/null || true )
+  nh_assert_eq "default returns the newest (mismatch) artifact" "2026-05-10T01-02-00.json" "$(basename "${out:-}")"
+}
 
-# Cell 3: find-artifact.sh --verify keeps the legacy lenient contract:
-# integrity_missing passes, integrity_mismatch fails.
-echo "[3] find-artifact.sh --verify is lenient on missing integrity"
-PROJ2="$TMP_ROOT/project2"
-STORE2="$PROJ2/.nanostack"
-mkdir -p "$PROJ2" "$STORE2"
-cd "$PROJ2"
-git init -q
-mk_artifact "$STORE2" review verified 2026-05-10T02-00-00 "$PROJ2"
-set +e
-out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
-rc=$?
-set -e
-assert_eq "verified passes --verify (rc 0)" "0" "$rc"
-assert_eq "verified path returned"          "2026-05-10T02-00-00.json" "$(basename "${out:-}")"
-mk_artifact "$STORE2" review missing 2026-05-10T02-01-00 "$PROJ2"
-set +e
-out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
-rc=$?
-set -e
-assert_eq "integrity_missing passes --verify (rc 0)" "0" "$rc"
-assert_eq "newest missing-integrity path returned"   "2026-05-10T02-01-00.json" "$(basename "${out:-}")"
-mk_artifact "$STORE2" review mismatch 2026-05-10T02-02-00 "$PROJ2"
-set +e
-out=$( NANOSTACK_STORE="$STORE2" "$REPO/bin/find-artifact.sh" review 30 --verify 2>&1 )
-rc=$?
-set -e
-assert_eq "integrity_mismatch fails --verify (rc 1)" "1" "$rc"
-echo "$out" | grep -qE '^INTEGRITY FAILED:' && \
-  assert_eq "stderr labelled INTEGRITY FAILED" "yes" "yes" || \
-  assert_eq "stderr labelled INTEGRITY FAILED" "yes" "no"
+# Cell 3: find-artifact.sh --verify is lenient on missing integrity.
+cell_find_verify_lenient() {
+  local proj store; proj=$(nf_new_git_project trust3); store=$(nf_new_store "$proj"); cd "$proj"
+  local out rc
+  nf_write_artifact "$store" review verified 2026-05-10T02-00-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" review 30 --verify
+  nh_assert_eq "verified passes --verify (rc 0)" "0" "$rc"
+  nh_assert_eq "verified path returned" "2026-05-10T02-00-00.json" "$(basename "$(printf '%s\n' "$out" | tail -1)")"
+  nf_write_artifact "$store" review integrity_missing 2026-05-10T02-01-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" review 30 --verify
+  nh_assert_eq "integrity_missing passes --verify (rc 0)" "0" "$rc"
+  nh_assert_eq "newest missing-integrity path returned" "2026-05-10T02-01-00.json" "$(basename "$(printf '%s\n' "$out" | tail -1)")"
+  nf_write_artifact "$store" review integrity_mismatch 2026-05-10T02-02-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" review 30 --verify
+  nh_assert_eq "integrity_mismatch fails --verify (rc 1)" "1" "$rc"
+  nh_assert_contains "stderr labelled INTEGRITY FAILED" "$out" "INTEGRITY FAILED:"
+}
 
-# Cell 4: find-artifact.sh --require-integrity is strict: integrity_missing
-# also fails, with a distinct stderr category.
-echo "[4] find-artifact.sh --require-integrity is strict on missing + mismatch"
-PROJ3="$TMP_ROOT/project3"
-STORE3="$PROJ3/.nanostack"
-mkdir -p "$PROJ3" "$STORE3"
-cd "$PROJ3"
-git init -q
-mk_artifact "$STORE3" qa verified 2026-05-10T03-00-00 "$PROJ3"
-set +e
-out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
-rc=$?
-set -e
-assert_eq "verified passes --require-integrity (rc 0)" "0" "$rc"
-mk_artifact "$STORE3" qa missing 2026-05-10T03-01-00 "$PROJ3"
-set +e
-out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
-rc=$?
-set -e
-assert_eq "integrity_missing fails --require-integrity (rc 1)" "1" "$rc"
-echo "$out" | grep -qE '^INTEGRITY MISSING:' && \
-  assert_eq "stderr labelled INTEGRITY MISSING" "yes" "yes" || \
-  assert_eq "stderr labelled INTEGRITY MISSING" "yes" "no"
-mk_artifact "$STORE3" qa mismatch 2026-05-10T03-02-00 "$PROJ3"
-set +e
-out=$( NANOSTACK_STORE="$STORE3" "$REPO/bin/find-artifact.sh" qa 30 --require-integrity 2>&1 )
-rc=$?
-set -e
-assert_eq "integrity_mismatch fails --require-integrity (rc 1)" "1" "$rc"
+# Cell 4: find-artifact.sh --require-integrity is strict on missing + mismatch.
+cell_find_require_integrity() {
+  local proj store; proj=$(nf_new_git_project trust4); store=$(nf_new_store "$proj"); cd "$proj"
+  local out rc
+  nf_write_artifact "$store" qa verified 2026-05-10T03-00-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" qa 30 --require-integrity
+  nh_assert_eq "verified passes --require-integrity (rc 0)" "0" "$rc"
+  nf_write_artifact "$store" qa integrity_missing 2026-05-10T03-01-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" qa 30 --require-integrity
+  nh_assert_eq "integrity_missing fails --require-integrity (rc 1)" "1" "$rc"
+  nh_assert_contains "stderr labelled INTEGRITY MISSING" "$out" "INTEGRITY MISSING:"
+  nf_write_artifact "$store" qa integrity_mismatch 2026-05-10T03-02-00 "$proj" >/dev/null
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" qa 30 --require-integrity
+  nh_assert_eq "integrity_mismatch fails --require-integrity (rc 1)" "1" "$rc"
+}
 
 # Cell 5: resolve.sh exposes upstream_status for every declared upstream.
-# /ship pulls review, security, qa — one of each trust state.
-echo "[5] resolve.sh upstream_status reports every declared upstream"
-PROJ4="$TMP_ROOT/project4"
-STORE4="$PROJ4/.nanostack"
-mkdir -p "$PROJ4" "$STORE4"
-cd "$PROJ4"
-git init -q
-mk_artifact "$STORE4" review   verified 2026-05-10T04-00-00 "$PROJ4"
-mk_artifact "$STORE4" security missing  2026-05-10T04-00-00 "$PROJ4"
-mk_artifact "$STORE4" qa       mismatch 2026-05-10T04-00-00 "$PROJ4"
-resolved=$( NANOSTACK_STORE="$STORE4" "$REPO/bin/resolve.sh" ship 2>/dev/null )
-status_review=$( echo "$resolved"   | jq -r '.upstream_status.review // ""' )
-status_security=$( echo "$resolved" | jq -r '.upstream_status.security // ""' )
-status_qa=$( echo "$resolved"       | jq -r '.upstream_status.qa // ""' )
-assert_eq "upstream_status.review == verified"            "verified"           "$status_review"
-assert_eq "upstream_status.security == integrity_missing" "integrity_missing"  "$status_security"
-assert_eq "upstream_status.qa == integrity_mismatch"      "integrity_mismatch" "$status_qa"
+cell_resolve_upstream_status() {
+  local proj store; proj=$(nf_new_git_project trust5); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_write_artifact "$store" review   verified           2026-05-10T04-00-00 "$proj" >/dev/null
+  nf_write_artifact "$store" security integrity_missing  2026-05-10T04-00-00 "$proj" >/dev/null
+  nf_write_artifact "$store" qa       integrity_mismatch 2026-05-10T04-00-00 "$proj" >/dev/null
+  local resolved
+  resolved=$( NANOSTACK_STORE="$store" "$RESOLVE" ship 2>/dev/null )
+  nh_assert_eq "upstream_status.review == verified"            "verified"           "$(echo "$resolved" | jq -r '.upstream_status.review // ""')"
+  nh_assert_eq "upstream_status.security == integrity_missing" "integrity_missing"  "$(echo "$resolved" | jq -r '.upstream_status.security // ""')"
+  nh_assert_eq "upstream_status.qa == integrity_mismatch"      "integrity_mismatch" "$(echo "$resolved" | jq -r '.upstream_status.qa // ""')"
+}
 
-# Cell 6: upstream_artifacts shape stays backward compatible. Verified
-# and integrity_missing artifacts include their path so legacy stores
-# load; mismatched artifacts are omitted (current --verify behavior).
-echo "[6] upstream_artifacts shape: verified + missing-integrity load, mismatch omitted"
-has_review=$( echo "$resolved"   | jq -e '.upstream_artifacts.review != null' >/dev/null 2>&1 && echo yes || echo no )
-has_security=$( echo "$resolved" | jq -e '.upstream_artifacts.security != null' >/dev/null 2>&1 && echo yes || echo no )
-has_qa=$( echo "$resolved"       | jq -e '.upstream_artifacts.qa != null' >/dev/null 2>&1 && echo yes || echo no )
-assert_eq "verified artifact loads"          "yes" "$has_review"
-assert_eq "integrity_missing artifact loads" "yes" "$has_security"
-assert_eq "integrity_mismatch artifact omitted from upstream_artifacts" "no" "$has_qa"
+# Cell 6: upstream_artifacts shape stays backward compatible.
+cell_resolve_artifacts_shape() {
+  local proj store; proj=$(nf_new_git_project trust6); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_write_artifact "$store" review   verified           2026-05-10T04-00-00 "$proj" >/dev/null
+  nf_write_artifact "$store" security integrity_missing  2026-05-10T04-00-00 "$proj" >/dev/null
+  nf_write_artifact "$store" qa       integrity_mismatch 2026-05-10T04-00-00 "$proj" >/dev/null
+  local resolved
+  resolved=$( NANOSTACK_STORE="$store" "$RESOLVE" ship 2>/dev/null )
+  nh_assert_eq "verified artifact loads"          "yes" "$(echo "$resolved" | jq -e '.upstream_artifacts.review != null'   >/dev/null 2>&1 && echo yes || echo no)"
+  nh_assert_eq "integrity_missing artifact loads" "yes" "$(echo "$resolved" | jq -e '.upstream_artifacts.security != null' >/dev/null 2>&1 && echo yes || echo no)"
+  nh_assert_eq "integrity_mismatch artifact omitted from upstream_artifacts" "no" "$(echo "$resolved" | jq -e '.upstream_artifacts.qa != null' >/dev/null 2>&1 && echo yes || echo no)"
+}
 
 # Cell 7: missing upstream (never saved) is reported as "missing".
-echo "[7] never-saved upstream reports status=missing"
-PROJ5="$TMP_ROOT/project5"
-STORE5="$PROJ5/.nanostack"
-mkdir -p "$PROJ5" "$STORE5"
-cd "$PROJ5"
-git init -q
-mk_artifact "$STORE5" review verified 2026-05-10T05-00-00 "$PROJ5"
-# security and qa are deliberately not created
-resolved=$( NANOSTACK_STORE="$STORE5" "$REPO/bin/resolve.sh" ship 2>/dev/null )
-status_security=$( echo "$resolved" | jq -r '.upstream_status.security // ""' )
-status_qa=$( echo "$resolved"       | jq -r '.upstream_status.qa // ""' )
-assert_eq "missing security reports status=missing" "missing" "$status_security"
-assert_eq "missing qa reports status=missing"       "missing" "$status_qa"
+cell_resolve_missing() {
+  local proj store; proj=$(nf_new_git_project trust7); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_write_artifact "$store" review verified 2026-05-10T05-00-00 "$proj" >/dev/null
+  local resolved
+  resolved=$( NANOSTACK_STORE="$store" "$RESOLVE" ship 2>/dev/null )
+  nh_assert_eq "missing security reports status=missing" "missing" "$(echo "$resolved" | jq -r '.upstream_status.security // ""')"
+  nh_assert_eq "missing qa reports status=missing"       "missing" "$(echo "$resolved" | jq -r '.upstream_status.qa // ""')"
+}
 
 # Cell 8a: find-artifact.sh parses flags even when max-age is omitted.
-# Codex caught this on the PR 2 first pass: `find-artifact.sh plan
-# --require-integrity` (the documented optional-age form) used to
-# assign the flag string to MAX_AGE and the strict gate silently
-# no-oped. Locked here so the regression cannot return.
-echo "[8a] find-artifact.sh detects flags in the max-age slot"
-PROJ_FLAG="$TMP_ROOT/project-flag"
-STORE_FLAG="$PROJ_FLAG/.nanostack"
-mkdir -p "$PROJ_FLAG" "$STORE_FLAG"
-cd "$PROJ_FLAG"
-git init -q
-mk_artifact "$STORE_FLAG" plan missing 2026-05-10T08-00-00 "$PROJ_FLAG"
-set +e
-out=$( NANOSTACK_STORE="$STORE_FLAG" "$REPO/bin/find-artifact.sh" plan --require-integrity 2>&1 )
-rc=$?
-set -e
-assert_eq "no max-age + --require-integrity fails on missing (rc 1)" "1" "$rc"
-echo "$out" | grep -qE '^INTEGRITY MISSING:' && \
-  assert_eq "no max-age + --require-integrity emits INTEGRITY MISSING" "yes" "yes" || \
-  assert_eq "no max-age + --require-integrity emits INTEGRITY MISSING" "yes" "no"
-set +e
-out=$( NANOSTACK_STORE="$STORE_FLAG" "$REPO/bin/find-artifact.sh" plan --verify 2>&1 )
-rc=$?
-set -e
-assert_eq "no max-age + --verify is lenient (rc 0)" "0" "$rc"
+cell_find_flag_detection() {
+  local proj store; proj=$(nf_new_git_project trust8a); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_write_artifact "$store" plan integrity_missing 2026-05-10T08-00-00 "$proj" >/dev/null
+  local out rc
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" plan --require-integrity
+  nh_assert_eq "no max-age + --require-integrity fails on missing (rc 1)" "1" "$rc"
+  nh_assert_contains "no max-age + --require-integrity emits INTEGRITY MISSING" "$out" "INTEGRITY MISSING:"
+  nh_capture out rc env NANOSTACK_STORE="$store" "$FIND" plan --verify
+  nh_assert_eq "no max-age + --verify is lenient (rc 0)" "0" "$rc"
+}
 
-# Cell 8: custom phases also get upstream_status. The custom dep graph
-# resolves through phase_graph or SKILL.md frontmatter, same as before.
-echo "[8] custom phase upstream_status follows the dep graph"
-PROJ6="$TMP_ROOT/project6"
-STORE6="$PROJ6/.nanostack"
-mkdir -p "$PROJ6" "$STORE6/skills/license-audit"
-cd "$PROJ6"
-git init -q
-cat > "$STORE6/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_graph": [
+# Cell 8: custom phases also get upstream_status via the dep graph.
+cell_custom_upstream() {
+  local proj store; proj=$(nf_new_git_project trust8); store=$(nf_new_store "$proj"); cd "$proj"
+  nf_register_custom_phase "$store" license-audit read
+  nf_register_phase_graph "$store" '[
     {"name":"think","depends_on":[]},
     {"name":"plan","depends_on":["think"]},
     {"name":"build","depends_on":["plan"]},
     {"name":"license-audit","depends_on":["build","review"]},
     {"name":"review","depends_on":["build"]},
     {"name":"ship","depends_on":["license-audit"]}
-  ]
+  ]'
+  nf_write_artifact "$store" review verified 2026-05-10T06-00-00 "$proj" >/dev/null
+  local resolved
+  resolved=$( NANOSTACK_STORE="$store" "$RESOLVE" license-audit 2>/dev/null )
+  nh_assert_eq "custom phase_kind = custom"                 "custom"          "$(echo "$resolved" | jq -r '.phase_kind // ""')"
+  nh_assert_eq "custom upstream_status.review = verified"   "verified"        "$(echo "$resolved" | jq -r '.upstream_status.review // ""')"
+  nh_assert_eq "custom upstream_status.build = not_applicable" "not_applicable" "$(echo "$resolved" | jq -r '.upstream_status.build // ""')"
 }
-EOF
-cat > "$STORE6/skills/license-audit/SKILL.md" <<'EOF'
----
-name: license-audit
-description: license check
-concurrency: read
----
-body
-EOF
-mk_artifact "$STORE6" review verified 2026-05-10T06-00-00 "$PROJ6"
-# build has no artifact directory; it should resolve to not_applicable
-resolved=$( NANOSTACK_STORE="$STORE6" "$REPO/bin/resolve.sh" license-audit 2>/dev/null )
-status_review=$(  echo "$resolved" | jq -r '.upstream_status.review // ""' )
-status_build=$(   echo "$resolved" | jq -r '.upstream_status.build // ""' )
-phase_kind=$(     echo "$resolved" | jq -r '.phase_kind // ""' )
-assert_eq "custom phase_kind = custom"                 "custom"          "$phase_kind"
-assert_eq "custom upstream_status.review = verified"   "verified"        "$status_review"
-assert_eq "custom upstream_status.build = not_applicable" "not_applicable" "$status_build"
 
-# =====================================================================
-# PR 3 of the 2026-05-28 architecture follow-up: the commit/push phase
-# gate must consume TRUSTED artifacts. It rejects missing-integrity and
-# tampered artifacts (via find-artifact --require-integrity) and judges
-# freshness by the filename timestamp, not mtime, so a touched stale
-# artifact cannot satisfy it. NANOSTACK_SKIP_GATE=1 still bypasses.
-# =====================================================================
-GATE="$REPO/guard/bin/phase-gate.sh"
-
-# A project with an active session whose review/security/qa phases have
-# started (so the gate enforces) and one initial commit (so the
-# last-code-change reference resolves through git log).
+# ── Phase-gate trusted-evidence cells (PR 3 of 2026-05-28) ──────────────
+# A project with an active session (review/security/qa enforced) + one
+# commit so the last-code-change reference resolves through git log.
 setup_gate_project() {
-  local name="$1"
-  local proj="$TMP_ROOT/$name"
-  local store="$proj/.nanostack"
-  mkdir -p "$proj" "$store"
-  ( cd "$proj" \
-    && git init -q \
-    && git config user.email t@t.test \
-    && git config user.name tester \
-    && echo code > file.txt \
-    && git add -A \
-    && git commit -qm init ) >/dev/null 2>&1
-  printf '{"workspace":"%s","phase_log":[{"phase":"review","status":"in_progress"},{"phase":"security","status":"in_progress"},{"phase":"qa","status":"in_progress"}]}' \
-    "$proj" > "$store/session.json"
+  local name="$1" proj store
+  proj=$(nf_new_git_project "$name")
+  store=$(nf_new_store "$proj")
+  ( cd "$proj" && echo code > file.txt && git add -A && git commit -qm init ) >/dev/null 2>&1
+  nf_write_session "$store" "$proj" review
   printf '%s' "$proj"
 }
 
-# Run the gate on a "git commit" from inside the project. Extra args are
-# env assignments prepended before the call (e.g. NANOSTACK_SKIP_GATE=1).
 run_gate() {
   local proj="$1"; shift
   local store="$proj/.nanostack"
   ( cd "$proj" && env "$@" NANOSTACK_STORE="$store" "$GATE" "git commit -m x" >/dev/null 2>&1; echo "RC=$?" )
 }
 
-# Cell 7: every required phase present with valid integrity and a fresh
-# filename timestamp -> the gate allows the commit.
-echo "[7] valid trusted artifacts satisfy the phase gate"
-proj=$(setup_gate_project gate-valid)
-FRESH=$(date -u +%Y%m%d-%H%M%S)
-mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" security verified "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" qa       verified "$FRESH" "$proj"
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "valid + integrity allows commit (rc 0)" "0" "$rc"
+# Cell 9: valid trusted artifacts satisfy the gate.
+cell_gate_valid() {
+  local proj fresh; proj=$(setup_gate_project gate-valid); fresh=$(date -u +%Y%m%d-%H%M%S)
+  nf_write_artifact "$proj/.nanostack" review   verified "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" security verified "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" qa       verified "$fresh" "$proj" >/dev/null
+  nh_assert_eq "valid + integrity allows commit (rc 0)" "0" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+}
 
-# Cell 8: a tampered (integrity_mismatch) phase artifact does not satisfy
-# the gate -> commit blocked.
-echo "[8] integrity_mismatch artifact does not satisfy the gate"
-proj=$(setup_gate_project gate-mismatch)
-FRESH=$(date -u +%Y%m%d-%H%M%S)
-mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" security verified "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" qa       mismatch "$FRESH" "$proj"
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "tampered qa artifact blocks commit (rc 1)" "1" "$rc"
+# Cell 10: tampered (integrity_mismatch) artifact blocks.
+cell_gate_mismatch() {
+  local proj fresh; proj=$(setup_gate_project gate-mismatch); fresh=$(date -u +%Y%m%d-%H%M%S)
+  nf_write_artifact "$proj/.nanostack" review   verified "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" security verified "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" qa       integrity_mismatch "$fresh" "$proj" >/dev/null
+  nh_assert_eq "tampered qa artifact blocks commit (rc 1)" "1" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+}
 
-# Cell 9: a phase artifact with no .integrity does not satisfy the gate.
-echo "[9] missing-integrity artifact does not satisfy the gate"
-proj=$(setup_gate_project gate-missing)
-FRESH=$(date -u +%Y%m%d-%H%M%S)
-mk_artifact "$proj/.nanostack" review   verified "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" security missing  "$FRESH" "$proj"
-mk_artifact "$proj/.nanostack" qa       verified "$FRESH" "$proj"
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "missing-integrity security artifact blocks commit (rc 1)" "1" "$rc"
+# Cell 11: missing-integrity artifact blocks.
+cell_gate_missing() {
+  local proj fresh; proj=$(setup_gate_project gate-missing); fresh=$(date -u +%Y%m%d-%H%M%S)
+  nf_write_artifact "$proj/.nanostack" review   verified "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" security integrity_missing "$fresh" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" qa       verified "$fresh" "$proj" >/dev/null
+  nh_assert_eq "missing-integrity security artifact blocks commit (rc 1)" "1" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+}
 
-# Cell 10: an OLD artifact whose mtime is freshened by `touch` does not
-# satisfy freshness, because freshness reads the filename timestamp. Under
-# the previous mtime-based check this would have passed; now it blocks.
-echo "[10] touching an old artifact to freshen mtime does not satisfy freshness"
-proj=$(setup_gate_project gate-touch-old)
-OLD=20200101-000000
-mk_artifact "$proj/.nanostack" review   verified "$OLD" "$proj"
-mk_artifact "$proj/.nanostack" security verified "$OLD" "$proj"
-mk_artifact "$proj/.nanostack" qa       verified "$OLD" "$proj"
-# Freshen mtimes so find-artifact's discovery window still sees them and
-# an mtime-based freshness check would (wrongly) accept them.
-touch "$proj/.nanostack/review/$OLD.json" "$proj/.nanostack/security/$OLD.json" "$proj/.nanostack/qa/$OLD.json"
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "touched old artifacts still block commit (rc 1)" "1" "$rc"
+# Cell 12: an OLD artifact whose mtime is freshened does not satisfy
+# freshness, because freshness reads the filename timestamp.
+cell_gate_touch_old() {
+  local proj old; proj=$(setup_gate_project gate-touch-old); old=20200101-000000
+  nf_write_artifact "$proj/.nanostack" review   verified "$old" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" security verified "$old" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" qa       verified "$old" "$proj" >/dev/null
+  touch "$proj/.nanostack/review/$old.json" "$proj/.nanostack/security/$old.json" "$proj/.nanostack/qa/$old.json"
+  nh_assert_eq "touched old artifacts still block commit (rc 1)" "1" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+}
 
-# Cell 11: NANOSTACK_SKIP_GATE=1 bypasses the gate even when artifacts are
-# absent. The control (no skip) confirms the same setup blocks.
-echo "[11] NANOSTACK_SKIP_GATE=1 still bypasses the gate"
-proj=$(setup_gate_project gate-skip)
-# No artifacts at all -> would block without the bypass.
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "control: no artifacts blocks commit (rc 1)" "1" "$rc"
-rc=$(run_gate "$proj" NANOSTACK_SKIP_GATE=1 | sed -n 's/^RC=//p')
-assert_eq "NANOSTACK_SKIP_GATE=1 allows commit (rc 0)" "0" "$rc"
+# Cell 13: NANOSTACK_SKIP_GATE=1 bypasses; control confirms the same setup blocks.
+cell_gate_skip() {
+  local proj; proj=$(setup_gate_project gate-skip)
+  nh_assert_eq "control: no artifacts blocks commit (rc 1)" "1" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+  nh_assert_eq "NANOSTACK_SKIP_GATE=1 allows commit (rc 0)" "0" "$(run_gate "$proj" NANOSTACK_SKIP_GATE=1 | sed -n 's/^RC=//p')"
+}
 
-# Cell 12: an impossible calendar date in the filename must fail freshness
-# closed. nano_artifact_filename_epoch's round-trip guard returns 0 for a
-# digit-shaped but invalid stamp that BSD `date -j` would otherwise
-# normalize to a real date. The direct helper assertions are
-# date-independent; the gate integration uses a stamp that normalizes to a
-# FUTURE date (Feb 31 2099 -> Mar 3 2099) so that, without the guard, the
-# normalized time would read as fresh and the gate would wrongly allow the
-# commit. That makes the cell a real regression lock regardless of when CI
-# runs.
-echo "[12] impossible calendar date in the filename fails freshness closed"
-helper_epoch() { bash -c "source '$REPO/bin/lib/portable.sh'; nano_artifact_filename_epoch '$1'"; }
-assert_eq "helper: valid stamp parses to non-zero" "ok" \
-  "$([ "$(helper_epoch /x/20260528-143012.json)" -gt 0 ] 2>/dev/null && echo ok || echo no)"
-assert_eq "helper: Feb 31 returns 0"      "0" "$(helper_epoch /x/20260231-120000.json)"
-assert_eq "helper: month 13 returns 0"    "0" "$(helper_epoch /x/20261301-120000.json)"
-assert_eq "helper: hour 25 returns 0"     "0" "$(helper_epoch /x/20260528-250000.json)"
-assert_eq "helper: non-canonical name 0"  "0" "$(helper_epoch /x/2026-05-10T01-00-00.json)"
-proj=$(setup_gate_project gate-bad-date)
-BAD=20990231-120000   # Feb 31 2099 -> BSD normalizes to a FUTURE date
-mk_artifact "$proj/.nanostack" review   verified "$BAD" "$proj"
-mk_artifact "$proj/.nanostack" security verified "$BAD" "$proj"
-mk_artifact "$proj/.nanostack" qa       verified "$BAD" "$proj"
-rc=$(run_gate "$proj" | sed -n 's/^RC=//p')
-assert_eq "impossible-date artifact blocks commit (rc 1)" "1" "$rc"
+# Cell 14: impossible calendar date in the filename fails freshness closed.
+cell_gate_bad_date() {
+  helper_epoch() { bash -c "source '$REPO/bin/lib/portable.sh'; nano_artifact_filename_epoch '$1'"; }
+  nh_assert_eq "helper: valid stamp parses to non-zero" "ok" \
+    "$([ "$(helper_epoch /x/20260528-143012.json)" -gt 0 ] 2>/dev/null && echo ok || echo no)"
+  nh_assert_eq "helper: Feb 31 returns 0"     "0" "$(helper_epoch /x/20260231-120000.json)"
+  nh_assert_eq "helper: month 13 returns 0"   "0" "$(helper_epoch /x/20261301-120000.json)"
+  nh_assert_eq "helper: hour 25 returns 0"    "0" "$(helper_epoch /x/20260528-250000.json)"
+  nh_assert_eq "helper: non-canonical name 0" "0" "$(helper_epoch /x/2026-05-10T01-00-00.json)"
+  local proj bad; proj=$(setup_gate_project gate-bad-date); bad=20990231-120000
+  nf_write_artifact "$proj/.nanostack" review   verified "$bad" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" security verified "$bad" "$proj" >/dev/null
+  nf_write_artifact "$proj/.nanostack" qa       verified "$bad" "$proj" >/dev/null
+  nh_assert_eq "impossible-date artifact blocks commit (rc 1)" "1" "$(run_gate "$proj" | sed -n 's/^RC=//p')"
+}
 
-cd "$TMP_ROOT"
+nh_cell trust-statuses        cell_trust_statuses
+nh_cell find-default          cell_find_default
+nh_cell find-verify-lenient   cell_find_verify_lenient
+nh_cell find-require-integrity cell_find_require_integrity
+nh_cell resolve-upstream-status cell_resolve_upstream_status
+nh_cell resolve-artifacts-shape cell_resolve_artifacts_shape
+nh_cell resolve-missing       cell_resolve_missing
+nh_cell find-flag-detection   cell_find_flag_detection
+nh_cell custom-upstream       cell_custom_upstream
+nh_cell gate-valid            cell_gate_valid
+nh_cell gate-mismatch         cell_gate_mismatch
+nh_cell gate-missing          cell_gate_missing
+nh_cell gate-touch-old        cell_gate_touch_old
+nh_cell gate-skip             cell_gate_skip
+nh_cell gate-bad-date         cell_gate_bad_date
 
-echo
-echo "====================="
-TOTAL=$((PASS + FAIL))
-if [ "$FAIL" -eq 0 ]; then
-  printf "${GREEN}Artifact Trust v2 E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
-  exit 0
-else
-  printf "${RED}Artifact Trust v2 E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
-  exit 1
-fi
+nh_summary

--- a/ci/e2e-custom-routing.sh
+++ b/ci/e2e-custom-routing.sh
@@ -5,66 +5,47 @@
 #
 #   - A custom phase with no phase_context block keeps the existing
 #     dependency-only behavior (routing.declared = false).
-#   - phase_context.trust = strict drops integrity_missing artifacts
-#     so a custom skill that asked for strict evidence never sees a
-#     path it cannot verify.
-#   - phase_context.upstream_required / upstream_optional surface in
-#     routing so consumers can read declared intent.
+#   - phase_context.trust = strict drops integrity_missing artifacts.
+#   - phase_context.upstream_required / upstream_optional surface in routing.
 #   - phase_context.max_age_days overrides the per-phase default.
-#   - phase_context.solutions.tags loads matching solutions filtered
-#     by content match, limited to solutions.limit.
-#   - phase_context.diarizations.paths / keywords loads matching
-#     diarizations without depending on git diff.
+#   - phase_context.solutions.tags loads matching solutions (literal match).
+#   - phase_context.diarizations.paths / keywords loads matching diarizations.
 #
-# Spec acceptance, verbatim:
-#   "A custom skill can ask for strict upstream artifacts without
-#    local helper code."
-#   "A custom skill can request solution search tags."
-#   "A custom skill can request diarizations by path or keyword."
-#   "Missing required upstreams are explicit in upstream_status, not
-#    silently null."
-#   "Backward compatibility: custom skills with no context: block
-#    keep current behavior."
+# Migrated onto ci/lib/harness.sh + ci/lib/fixtures.sh (Harness vNext
+# PR 2). Same cells, same check count (35). Supports --filter <pattern>.
 set -e
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-TMP_ROOT=$(mktemp -d /tmp/nanostack-custom-routing.XXXXXX)
-trap 'rm -rf "$TMP_ROOT"' EXIT
+. "$REPO/ci/lib/harness.sh"
+. "$REPO/ci/lib/fixtures.sh"
 
-PASS=0
-FAIL=0
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-DIM='\033[0;90m'
-NC='\033[0m'
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
 
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}expected: %s${NC}\n" "$expected"
-    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
-  fi
-}
+nh_init custom-routing nanostack-custom-routing
+nh_require_cmd git jq
 
-new_project() {
-  local name="$1"
-  local proj="$TMP_ROOT/$name"
-  mkdir -p "$proj/.nanostack/skills/license-audit" \
-           "$proj/.nanostack/know-how/solutions" \
-           "$proj/.nanostack/know-how/diarizations" \
-           "$proj/.nanostack/review"
+RESOLVE="$REPO/bin/resolve.sh"
+
+# A routing project: git repo + exported store + the license-audit custom
+# skill (depends_on review) + know-how dirs. Uses the shared git/store
+# fixtures; the skill frontmatter and know-how layout are suite-specific.
+routing_project() {
+  local name="$1" proj
+  proj=$(nf_new_git_project "$name")
+  # Call nf_export_store directly (not in $()) so the NANOSTACK_STORE export
+  # lands in this shell, not a command-substitution subshell.
+  nf_export_store "$proj" >/dev/null
   cd "$proj"
-  git init -q
-  git config user.email "ci@routing.test"
-  git config user.name  "ci"
-  export NANOSTACK_STORE="$proj/.nanostack"
-  cat > "$proj/.nanostack/skills/license-audit/SKILL.md" <<'EOF'
+  mkdir -p "$NANOSTACK_STORE/skills/license-audit" "$NANOSTACK_STORE/know-how/solutions" \
+           "$NANOSTACK_STORE/know-how/diarizations" "$NANOSTACK_STORE/review"
+  cat > "$NANOSTACK_STORE/skills/license-audit/SKILL.md" <<'EOF'
 ---
 name: license-audit
 description: custom skill for routing tests
@@ -72,421 +53,229 @@ concurrency: read
 depends_on: [review]
 ---
 EOF
+  printf '%s' "$proj"
 }
 
-# Save a "verified" review artifact via the real save-artifact path.
 save_verified_review() {
-  "$REPO/bin/save-artifact.sh" review \
+  nf_save_artifact review \
     '{"phase":"review","summary":{"v":1,"blocking":0},"scope_drift":{"status":"clean"},"findings":[],"context_checkpoint":{"summary":"routing test"}}' >/dev/null
 }
 
-# Save a review artifact WITHOUT .integrity (legacy / stripped).
+# A review artifact with no .integrity, via the shared fixture.
 save_integrity_missing_review() {
-  local ts="$(date -u +%Y%m%dT%H%M%S)"
-  printf '%s\n' '{"phase":"review","project":"'"$(pwd)"'","summary":"missing integrity"}' > "$NANOSTACK_STORE/review/${ts}.json"
+  nf_write_artifact "$NANOSTACK_STORE" review integrity_missing "$(date -u +%Y%m%dT%H%M%S)" "$(pwd)" >/dev/null
 }
 
-echo "Custom Routing Contract E2E"
-echo "==========================="
-echo "Tmp root: $TMP_ROOT"
-echo
-
-# Cell 1: backward compat — no phase_context keeps the existing
-# dependency-only behavior. routing.declared = false.
-echo "[1] backward compat: no phase_context keeps current behavior"
-new_project "cell1-backcompat"
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{"custom_phases": ["license-audit"]}
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "routing.declared = false" "false" "$(echo "$out" | jq -r '.routing.declared')"
-assert_eq "routing.trust = normal (default)" "normal" "$(echo "$out" | jq -r '.routing.trust')"
-assert_eq "solutions empty (no tags)" "0" "$(echo "$out" | jq '.solutions | length')"
-assert_eq "diarizations empty (no paths)" "0" "$(echo "$out" | jq '.diarizations | length')"
-
-# Cell 2: missing required upstream surfaces explicitly. Spec says
-# upstream_status reports the state, not silently null.
-echo "[2] missing required upstream is explicit in upstream_status"
-new_project "cell2-missing"
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "upstream_required": ["review"]
-    }
-  }
+# Cell 1: backward compat — no phase_context keeps dependency-only behavior.
+cell_backcompat() {
+  routing_project "cell1-backcompat" >/dev/null
+  printf '%s\n' '{"custom_phases": ["license-audit"]}' > "$NANOSTACK_STORE/config.json"
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "routing.declared = false"        "false"  "$(echo "$out" | jq -r '.routing.declared')"
+  nh_assert_eq "routing.trust = normal (default)" "normal" "$(echo "$out" | jq -r '.routing.trust')"
+  nh_assert_eq "solutions empty (no tags)"        "0"      "$(echo "$out" | jq '.solutions | length')"
+  nh_assert_eq "diarizations empty (no paths)"    "0"      "$(echo "$out" | jq '.diarizations | length')"
 }
+
+# Cell 2: missing required upstream surfaces explicitly.
+cell_missing_required() {
+  routing_project "cell2-missing" >/dev/null
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"upstream_required":["review"]}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "upstream_status.review = missing" "missing" \
-  "$(echo "$out" | jq -r '.upstream_status.review')"
-assert_eq "routing.upstream_required lists review" '["review"]' \
-  "$(echo "$out" | jq -c '.routing.upstream_required')"
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "upstream_status.review = missing" "missing" "$(echo "$out" | jq -r '.upstream_status.review')"
+  nh_assert_eq "routing.upstream_required lists review" '["review"]' "$(echo "$out" | jq -c '.routing.upstream_required')"
+}
 
 # Cell 3: strict trust drops integrity_missing artifacts.
-echo "[3] strict trust drops integrity_missing artifacts"
-new_project "cell3-strict"
-save_integrity_missing_review
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": { "trust": "strict" }
-  }
-}
+cell_strict_drops() {
+  routing_project "cell3-strict" >/dev/null
+  save_integrity_missing_review
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"trust":"strict"}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "strict: upstream_status.review = integrity_missing (diagnostic preserved)" \
-  "integrity_missing" "$(echo "$out" | jq -r '.upstream_status.review')"
-assert_eq "strict: upstream_artifacts.review = null (artifact dropped)" \
-  "null" "$(echo "$out" | jq -r '.upstream_artifacts.review')"
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "strict: upstream_status.review = integrity_missing (diagnostic preserved)" \
+    "integrity_missing" "$(echo "$out" | jq -r '.upstream_status.review')"
+  nh_assert_eq "strict: upstream_artifacts.review = null (artifact dropped)" \
+    "null" "$(echo "$out" | jq -r '.upstream_artifacts.review')"
+}
 
-# Cell 4: normal trust keeps the integrity_missing artifact in
-# upstream_artifacts so legacy stores continue to load.
-echo "[4] normal trust keeps integrity_missing artifact (legacy compat)"
-new_project "cell4-normal"
-save_integrity_missing_review
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": { "trust": "normal" }
-  }
-}
+# Cell 4: normal trust keeps the integrity_missing artifact.
+cell_normal_keeps() {
+  routing_project "cell4-normal" >/dev/null
+  save_integrity_missing_review
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"trust":"normal"}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "normal: upstream_status.review = integrity_missing" \
-  "integrity_missing" "$(echo "$out" | jq -r '.upstream_status.review')"
-# upstream_artifacts.review should be a string path (not null), since
-# legacy artifacts still load under normal trust.
-art=$(echo "$out" | jq -r '.upstream_artifacts.review // ""')
-assert_eq "normal: upstream_artifacts.review is the stored path" \
-  "true" "$( [ -n "$art" ] && echo "true" || echo "false" )"
+  local out art; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "normal: upstream_status.review = integrity_missing" \
+    "integrity_missing" "$(echo "$out" | jq -r '.upstream_status.review')"
+  art=$(echo "$out" | jq -r '.upstream_artifacts.review // ""')
+  nh_assert_eq "normal: upstream_artifacts.review is the stored path" \
+    "true" "$( [ -n "$art" ] && echo "true" || echo "false" )"
+}
 
-# Cell 5: max_age_days overrides the default per-phase age. We mark
-# an artifact 90 days old; the default is 30, so max_age_days = 120
-# is required to load it.
-echo "[5] max_age_days overrides the per-phase age"
-new_project "cell5-age"
-save_verified_review
-art_path=$(ls "$NANOSTACK_STORE/review/"*.json | head -1)
-# Touch the artifact's mtime 90 days into the past.
-touch -t "$(date -u -v-90d +%Y%m%d%H%M.%S 2>/dev/null || date -u --date='90 days ago' +%Y%m%d%H%M.%S)" "$art_path" 2>/dev/null || true
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": { "max_age_days": 120 }
-  }
-}
+# Cell 5: max_age_days overrides the default per-phase age.
+cell_max_age() {
+  routing_project "cell5-age" >/dev/null
+  save_verified_review
+  local art_path; art_path=$(ls "$NANOSTACK_STORE/review/"*.json | head -1)
+  touch -t "$(date -u -v-90d +%Y%m%d%H%M.%S 2>/dev/null || date -u --date='90 days ago' +%Y%m%d%H%M.%S)" "$art_path" 2>/dev/null || true
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"max_age_days":120}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "max_age_days = 120 loads a 90-day-old verified artifact" \
-  "verified" "$(echo "$out" | jq -r '.upstream_status.review')"
-assert_eq "routing.max_age_days = 120 reported" "120" \
-  "$(echo "$out" | jq -r '.routing.max_age_days')"
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "max_age_days = 120 loads a 90-day-old verified artifact" \
+    "verified" "$(echo "$out" | jq -r '.upstream_status.review')"
+  nh_assert_eq "routing.max_age_days = 120 reported" "120" "$(echo "$out" | jq -r '.routing.max_age_days')"
+}
 
-# Cell 6: solution_tags loads matching solutions filtered by content.
-echo "[6] solution_tags filters know-how/solutions"
-new_project "cell6-solutions"
-cat > "$NANOSTACK_STORE/know-how/solutions/license-resolution.md" <<'EOF'
----
-tags: [license, oss]
----
-license stuff
+# Cell 6: solution_tags filters know-how/solutions.
+cell_solution_tags() {
+  routing_project "cell6-solutions" >/dev/null
+  printf '%s\n' '---' 'tags: [license, oss]' '---' 'license stuff' > "$NANOSTACK_STORE/know-how/solutions/license-resolution.md"
+  printf '%s\n' '---' 'tags: [debug]' '---' 'unrelated content' > "$NANOSTACK_STORE/know-how/solutions/random.md"
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"solutions":{"tags":["license"],"limit":5}}}}
 EOF
-cat > "$NANOSTACK_STORE/know-how/solutions/random.md" <<'EOF'
----
-tags: [debug]
----
-unrelated content
-EOF
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "solutions": { "tags": ["license"], "limit": 5 }
-    }
-  }
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "solutions filtered to license-tagged file" "1" "$(echo "$out" | jq '.solutions | length')"
+  nh_assert_contains "selected solution is license-resolution.md" "$(echo "$out" | jq -r '.solutions[0] // ""')" "license-resolution.md"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-sol_count=$(echo "$out" | jq '.solutions | length')
-sol_first=$(echo "$out" | jq -r '.solutions[0] // ""')
-assert_eq "solutions filtered to license-tagged file" "1" "$sol_count"
-case "$sol_first" in
-  *license-resolution.md) PASS=$((PASS+1)); printf "    ${GREEN}OK${NC}    %s\n" "selected solution is license-resolution.md" ;;
-  *) FAIL=$((FAIL+1)); printf "    ${RED}FAIL${NC}  %s (got %s)\n" "selected solution is license-resolution.md" "$sol_first" ;;
-esac
 
-# Cell 7: diarization paths / keywords. A diarization whose subject
-# matches one of the declared paths is loaded.
-echo "[7] diarization paths load matching subjects"
-new_project "cell7-diarizations"
-cat > "$NANOSTACK_STORE/know-how/diarizations/2026-04-01-pkg.md" <<'EOF'
----
-subject: package.json
-date: 2026-04-01
----
-notes about package.json
+# Cell 7: diarization paths load matching subjects.
+cell_diarization_paths() {
+  routing_project "cell7-diarizations" >/dev/null
+  printf '%s\n' '---' 'subject: package.json' 'date: 2026-04-01' '---' 'notes' > "$NANOSTACK_STORE/know-how/diarizations/2026-04-01-pkg.md"
+  printf '%s\n' '---' 'subject: src/unrelated' 'date: 2026-04-01' '---' 'unrelated' > "$NANOSTACK_STORE/know-how/diarizations/2026-04-01-other.md"
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"diarizations":{"paths":["package.json"],"keywords":[]}}}}
 EOF
-cat > "$NANOSTACK_STORE/know-how/diarizations/2026-04-01-other.md" <<'EOF'
----
-subject: src/unrelated
-date: 2026-04-01
----
-unrelated notes
-EOF
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "diarizations": { "paths": ["package.json"], "keywords": [] }
-    }
-  }
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "diarizations filtered to package.json subject" "1" "$(echo "$out" | jq '.diarizations | length')"
+  nh_assert_eq "diarization subject = package.json" "package.json" "$(echo "$out" | jq -r '.diarizations[0].subject // ""')"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-diar_count=$(echo "$out" | jq '.diarizations | length')
-diar_subj=$(echo "$out" | jq -r '.diarizations[0].subject // ""')
-assert_eq "diarizations filtered to package.json subject" "1" "$diar_count"
-assert_eq "diarization subject = package.json" "package.json" "$diar_subj"
 
-# Cell 7a: a routed upstream that is NOT in depends_on still gets
-# its artifact looked up. The routing contract is supposed to give
-# skills a way to ask for context outside the dependency edges;
-# Codex caught the missing wiring on the PR 5 first review pass
-# (declaring upstream_optional: ["security"] without depends_on
-# left security absent from upstream_status entirely).
-echo "[7a] routed upstreams not in depends_on are still resolved"
-new_project "cell7a-routed-only"
-"$REPO/bin/save-artifact.sh" security \
-  '{"phase":"security","summary":{"v":1},"findings":[],"context_checkpoint":{"summary":"routing test"}}' >/dev/null
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "upstream_optional": ["security"]
-    }
-  }
-}
+# Cell 7a: routed upstreams not in depends_on are still resolved.
+cell_routed_only() {
+  routing_project "cell7a-routed-only" >/dev/null
+  nf_save_artifact security '{"phase":"security","summary":{"v":1},"findings":[],"context_checkpoint":{"summary":"routing test"}}' >/dev/null
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"upstream_optional":["security"]}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "upstream_status.security present even though only routed" \
-  "verified" "$(echo "$out" | jq -r '.upstream_status.security')"
-sec_art=$(echo "$out" | jq -r '.upstream_artifacts.security // ""')
-assert_eq "upstream_artifacts.security is the resolved path" \
-  "true" "$( [ -n "$sec_art" ] && echo "true" || echo "false" )"
+  local out sec_art; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "upstream_status.security present even though only routed" \
+    "verified" "$(echo "$out" | jq -r '.upstream_status.security')"
+  sec_art=$(echo "$out" | jq -r '.upstream_artifacts.security // ""')
+  nh_assert_eq "upstream_artifacts.security is the resolved path" \
+    "true" "$( [ -n "$sec_art" ] && echo "true" || echo "false" )"
+}
 
-# Cell 7b: phase_context can live in the global ~/.nanostack/
-# config.json. nano_phase_kind already consults the global file as a
-# fallback; resolve.sh now uses the same config-resolution path so
-# routing intent is honored even when the project has no local
-# config.json. Codex caught the missed fallback on the PR 5 second
-# review pass.
-echo "[7b] phase_context in the global ~/.nanostack/config.json is honored"
-GLOBAL_HOME="$TMP_ROOT/global-home"
-GLOBAL_PROJ="$TMP_ROOT/global-proj"
-mkdir -p "$GLOBAL_HOME/.nanostack" \
-         "$GLOBAL_PROJ/.nanostack/skills/license-audit"
-cat > "$GLOBAL_HOME/.nanostack/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "trust": "strict",
-      "upstream_required": ["review"]
-    }
-  }
-}
+# Cell 7b: phase_context in the global ~/.nanostack/config.json is honored.
+cell_global_config() {
+  local gh gp
+  gh="$NH_TMP/global-home"; gp="$NH_TMP/global-proj"
+  mkdir -p "$gh/.nanostack" "$gp/.nanostack/skills/license-audit"
+  cat > "$gh/.nanostack/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"trust":"strict","upstream_required":["review"]}}}
 EOF
-cat > "$GLOBAL_PROJ/.nanostack/skills/license-audit/SKILL.md" <<'EOF'
+  cat > "$gp/.nanostack/skills/license-audit/SKILL.md" <<'EOF'
 ---
 name: license-audit
 description: routed via global config
 concurrency: read
 ---
 EOF
-cd "$GLOBAL_PROJ"
-git init -q
-out=$(HOME="$GLOBAL_HOME" NANOSTACK_STORE="$GLOBAL_PROJ/.nanostack" \
-  "$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "global config: routing.declared = true" "true" \
-  "$(echo "$out" | jq -r '.routing.declared')"
-assert_eq "global config: routing.trust = strict" "strict" \
-  "$(echo "$out" | jq -r '.routing.trust')"
-
-# Cell 7c: diarization paths and keywords are matched literally, not
-# as regex. A subject like app/users/[id]/page.tsx must not match a
-# decoy app/users/i/page.tsx even though [id] reads as a character
-# class under default grep. Codex caught the regex-vs-literal bug on
-# the PR 5 second review pass.
-echo "[7c] diarization paths are literal substrings, not regex"
-new_project "cell7c-literal"
-cat > "$NANOSTACK_STORE/know-how/diarizations/exact.md" <<'EOF'
----
-subject: app/users/[id]/page.tsx
-date: 2026-04-01
----
-EOF
-cat > "$NANOSTACK_STORE/know-how/diarizations/decoy.md" <<'EOF'
----
-subject: app/users/i/page.tsx
-date: 2026-04-01
----
-EOF
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "diarizations": { "paths": ["app/users/[id]/page.tsx"], "keywords": [] }
-    }
-  }
+  cd "$gp"; git init -q
+  local out; out=$(HOME="$gh" NANOSTACK_STORE="$gp/.nanostack" "$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "global config: routing.declared = true" "true"   "$(echo "$out" | jq -r '.routing.declared')"
+  nh_assert_eq "global config: routing.trust = strict"  "strict" "$(echo "$out" | jq -r '.routing.trust')"
 }
+
+# Cell 7c: diarization paths are literal substrings, not regex.
+cell_diar_literal() {
+  routing_project "cell7c-literal" >/dev/null
+  printf '%s\n' '---' 'subject: app/users/[id]/page.tsx' 'date: 2026-04-01' '---' > "$NANOSTACK_STORE/know-how/diarizations/exact.md"
+  printf '%s\n' '---' 'subject: app/users/i/page.tsx' 'date: 2026-04-01' '---' > "$NANOSTACK_STORE/know-how/diarizations/decoy.md"
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"diarizations":{"paths":["app/users/[id]/page.tsx"],"keywords":[]}}}}
 EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-diar_subjects=$(echo "$out" | jq -c '.diarizations | map(.subject) | sort')
-assert_eq "literal match: only the exact subject is loaded" \
-  '["app/users/[id]/page.tsx"]' "$diar_subjects"
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "literal match: only the exact subject is loaded" \
+    '["app/users/[id]/page.tsx"]' "$(echo "$out" | jq -c '.diarizations | map(.subject) | sort')"
+}
 
 # Cell 7d: solution_tags are also matched literally, not as regex.
-# A tag like next.js or app/users/[id] must not match unrelated
-# files because of the `.` or `[id]` characters. Codex caught the
-# regex interpretation on the PR 5 third review pass.
-echo "[7d] solution_tags are literal substrings, not regex"
-new_project "cell7d-tag-literal"
-cat > "$NANOSTACK_STORE/know-how/solutions/exact.md" <<'EOF'
----
-tags: [next.js]
----
-next.js notes
+cell_tag_literal() {
+  routing_project "cell7d-tag-literal" >/dev/null
+  printf '%s\n' '---' 'tags: [next.js]' '---' 'next.js notes' > "$NANOSTACK_STORE/know-how/solutions/exact.md"
+  printf '%s\n' '---' 'tags: [nextxjs]' '---' 'nextxjs notes' > "$NANOSTACK_STORE/know-how/solutions/decoy.md"
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"solutions":{"tags":["next.js"],"limit":5}}}}
 EOF
-cat > "$NANOSTACK_STORE/know-how/solutions/decoy.md" <<'EOF'
----
-tags: [nextxjs]
----
-nextxjs notes (decoy must contain neither the literal tag nor a regex-equivalent)
-EOF
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "solutions": { "tags": ["next.js"], "limit": 5 }
-    }
-  }
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "literal tag: only the exact tag file matches" "1" "$(echo "$out" | jq '.solutions | length')"
+  nh_assert_contains "selected solution is exact.md" "$(echo "$out" | jq -r '.solutions[0] // ""')" "exact.md"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-sol_count=$(echo "$out" | jq '.solutions | length')
-sol_first=$(echo "$out" | jq -r '.solutions[0] // ""')
-assert_eq "literal tag: only the exact tag file matches" "1" "$sol_count"
-case "$sol_first" in
-  *exact.md) PASS=$((PASS+1)); printf "    ${GREEN}OK${NC}    %s\n" "selected solution is exact.md" ;;
-  *) FAIL=$((FAIL+1)); printf "    ${RED}FAIL${NC}  %s (got %s)\n" "selected solution is exact.md" "$sol_first" ;;
-esac
 
-# Cell 7e: diarization subjects/paths containing JSON metacharacters
-# (quotes, backslashes) must still produce valid JSON. The previous
-# string-concat path emitted invalid JSON for a subject like
-# app/"weird"/path.tsx; the resolver now builds the array through jq
-# so the escape is automatic. Codex caught the injection on the PR 5
-# third review pass.
-echo "[7e] diarization subjects with JSON metacharacters parse cleanly"
-new_project "cell7e-json-safe"
-cat > "$NANOSTACK_STORE/know-how/diarizations/quoted.md" <<'EOF'
----
-subject: app/"weird"/path.tsx
-date: 2026-04-01
----
+# Cell 7e: diarization subjects with JSON metacharacters parse cleanly.
+cell_json_safe() {
+  routing_project "cell7e-json-safe" >/dev/null
+  printf '%s\n' '---' 'subject: app/"weird"/path.tsx' 'date: 2026-04-01' '---' > "$NANOSTACK_STORE/know-how/diarizations/quoted.md"
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"diarizations":{"paths":["weird"],"keywords":[]}}}}
 EOF
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "diarizations": { "paths": ["weird"], "keywords": [] }
-    }
-  }
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "quote in subject lands intact" 'app/"weird"/path.tsx' "$(echo "$out" | jq -r '.diarizations[0].subject // ""')"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-diar_subject=$(echo "$out" | jq -r '.diarizations[0].subject // ""')
-assert_eq "quote in subject lands intact" 'app/"weird"/path.tsx' "$diar_subject"
 
-# Cell 8: routing block surfaces every applied field so consumers
-# can audit what the resolver did.
-echo "[8] routing block surfaces every applied field"
-new_project "cell8-routing-shape"
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "trust": "strict",
-      "upstream_required": ["review"],
-      "upstream_optional": ["security"],
-      "max_age_days": 7,
-      "solutions": { "tags": ["compliance"], "limit": 3 },
-      "diarizations": { "paths": ["src/privacy"], "keywords": ["pii"] }
-    }
-  }
+# Cell 8: routing block surfaces every applied field.
+cell_routing_shape() {
+  routing_project "cell8-routing-shape" >/dev/null
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"trust":"strict","upstream_required":["review"],"upstream_optional":["security"],"max_age_days":7,"solutions":{"tags":["compliance"],"limit":3},"diarizations":{"paths":["src/privacy"],"keywords":["pii"]}}}}
+EOF
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "routing.declared = true" "true" "$(echo "$out" | jq -r '.routing.declared')"
+  nh_assert_eq "routing.trust = strict" "strict" "$(echo "$out" | jq -r '.routing.trust')"
+  nh_assert_eq "routing.upstream_required" '["review"]' "$(echo "$out" | jq -c '.routing.upstream_required')"
+  nh_assert_eq "routing.upstream_optional" '["security"]' "$(echo "$out" | jq -c '.routing.upstream_optional')"
+  nh_assert_eq "routing.max_age_days" "7" "$(echo "$out" | jq -r '.routing.max_age_days')"
+  nh_assert_eq "routing.solutions.tags" '["compliance"]' "$(echo "$out" | jq -c '.routing.solutions.tags')"
+  nh_assert_eq "routing.solutions.limit" "3" "$(echo "$out" | jq -r '.routing.solutions.limit')"
+  nh_assert_eq "routing.diarizations.paths" '["src/privacy"]' "$(echo "$out" | jq -c '.routing.diarizations.paths')"
+  nh_assert_eq "routing.diarizations.keywords" '["pii"]' "$(echo "$out" | jq -c '.routing.diarizations.keywords')"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "routing.declared = true" "true" "$(echo "$out" | jq -r '.routing.declared')"
-assert_eq "routing.trust = strict" "strict" "$(echo "$out" | jq -r '.routing.trust')"
-assert_eq "routing.upstream_required" '["review"]' "$(echo "$out" | jq -c '.routing.upstream_required')"
-assert_eq "routing.upstream_optional" '["security"]' "$(echo "$out" | jq -c '.routing.upstream_optional')"
-assert_eq "routing.max_age_days" "7" "$(echo "$out" | jq -r '.routing.max_age_days')"
-assert_eq "routing.solutions.tags" '["compliance"]' "$(echo "$out" | jq -c '.routing.solutions.tags')"
-assert_eq "routing.solutions.limit" "3" "$(echo "$out" | jq -r '.routing.solutions.limit')"
-assert_eq "routing.diarizations.paths" '["src/privacy"]' "$(echo "$out" | jq -c '.routing.diarizations.paths')"
-assert_eq "routing.diarizations.keywords" '["pii"]' "$(echo "$out" | jq -c '.routing.diarizations.keywords')"
 
-# Cell 8a: when tags are declared but limit is omitted, the routing
-# block reports the documented default (10) instead of null so
-# consumers auditing the routing output see what actually applied.
-# Codex flagged the silent default on the PR 5 fourth review pass.
-echo "[8a] routing.solutions.limit reports the documented default"
-new_project "cell8a-default-limit"
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{
-  "custom_phases": ["license-audit"],
-  "phase_context": {
-    "license-audit": {
-      "solutions": { "tags": ["any"] }
-    }
-  }
+# Cell 8a: routing.solutions.limit reports the documented default.
+cell_default_limit() {
+  routing_project "cell8a-default-limit" >/dev/null
+  cat > "$NANOSTACK_STORE/config.json" <<'EOF'
+{"custom_phases":["license-audit"],"phase_context":{"license-audit":{"solutions":{"tags":["any"]}}}}
+EOF
+  local out; out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "limit omitted with tags declared reports default 10" "10" "$(echo "$out" | jq -r '.routing.solutions.limit')"
+  routing_project "cell8a-no-context" >/dev/null
+  printf '%s\n' '{"custom_phases": ["license-audit"]}' > "$NANOSTACK_STORE/config.json"
+  out=$("$RESOLVE" license-audit 2>/dev/null)
+  nh_assert_eq "no phase_context: routing.solutions.limit stays null" "null" "$(echo "$out" | jq -r '.routing.solutions.limit')"
 }
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "limit omitted with tags declared reports default 10" "10" \
-  "$(echo "$out" | jq -r '.routing.solutions.limit')"
-# Sanity: a config without phase_context at all stays null (no
-# default leaks when nothing was declared).
-new_project "cell8a-no-context"
-cat > "$NANOSTACK_STORE/config.json" <<'EOF'
-{"custom_phases": ["license-audit"]}
-EOF
-out=$("$REPO/bin/resolve.sh" license-audit 2>/dev/null)
-assert_eq "no phase_context: routing.solutions.limit stays null" "null" \
-  "$(echo "$out" | jq -r '.routing.solutions.limit')"
 
-cd "$TMP_ROOT"
+nh_cell backcompat        cell_backcompat
+nh_cell missing-required  cell_missing_required
+nh_cell strict-drops      cell_strict_drops
+nh_cell normal-keeps      cell_normal_keeps
+nh_cell max-age           cell_max_age
+nh_cell solution-tags     cell_solution_tags
+nh_cell diarization-paths cell_diarization_paths
+nh_cell routed-only       cell_routed_only
+nh_cell global-config     cell_global_config
+nh_cell diar-literal      cell_diar_literal
+nh_cell tag-literal       cell_tag_literal
+nh_cell json-safe         cell_json_safe
+nh_cell routing-shape     cell_routing_shape
+nh_cell default-limit     cell_default_limit
 
-echo
-echo "==========================="
-TOTAL=$((PASS + FAIL))
-if [ "$FAIL" -eq 0 ]; then
-  printf "${GREEN}Custom Routing E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
-  exit 0
-else
-  printf "${RED}Custom Routing E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
-  exit 1
-fi
+nh_summary

--- a/ci/e2e-custom-stack-flows.sh
+++ b/ci/e2e-custom-stack-flows.sh
@@ -1,444 +1,327 @@
 #!/usr/bin/env bash
 # e2e-custom-stack-flows.sh — Custom Stack Framework v1, end-to-end.
 #
-# Runs the full new-user journey on a real /tmp project:
-#   1. Scaffold a custom skill with bin/create-skill.sh.
-#   2. Validate it with bin/check-custom-skill.sh.
-#   3. Run its helper script.
-#   4. Save and find an artifact.
-#   5. Resolve the custom phase (phase_kind=custom).
-#   6. Generate a sprint journal (custom phase appears).
-#   7. Run analytics --json (custom phase counted).
-#   8. Default discard --dry-run (custom artifact listed).
-#   9. Start a conductor sprint with --phases that includes the custom phase.
-#  10. Conductor batch reads concurrency=read from the custom skill.
-#  11. agents/openai.yaml is present and parses.
-#  12. The copied skill has no repo-relative example paths.
-#  13. Scaffolding from a git subdirectory lands in the repo root store.
-#  14. Scaffolding outside any git repo lands in $HOME/.nanostack.
-#  15. Validator rejects mismatched frontmatter name.
-#  16. Guard blocks writes during a read-only custom phase.
-#  17. Custom write phase does not trigger the concurrency block.
-#  18. Built-in review phase still blocks (regression check).
-#  19. Guard finds repo-bundled non-core skills (feature, doctor).
-#  20. Registered custom skill wins over bundled non-core fallback.
-#  21. Unrelated user-installed skill does not shadow a bundled phase.
-#  22. Guard still works when the store path contains a space.
+# Runs the full new-user journey on a real /tmp project: scaffold a custom
+# skill, validate it, run its helper, save/find/resolve an artifact, sprint
+# journal, analytics, discard, conductor sprint + batch, agents/openai.yaml,
+# store resolution (git root / subdir / no-git / spaces), and guard
+# concurrency (read blocks, write allows, built-in still blocks, bundled
+# precedence, no-shadow).
 #
-# This harness is the contract Codex's spec calls for in PR 6: a clean
-# sandbox user can complete the entire workflow without reading source.
+# Migrated onto ci/lib/harness.sh + ci/lib/fixtures.sh (Harness vNext
+# PR 2). Same cells, same check count (40). Git projects come from
+# nf_new_git_project; the create-skill / conductor / guard flows and the
+# minimal current_phase-only sessions (which are themselves under test)
+# stay explicit. Cells 1-12 are a sequential journey over one project;
+# cells 13-22 build their own. Supports --filter <pattern>.
 set -e
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-TMP_ROOT=$(mktemp -d /tmp/nanostack-cs-flows.XXXXXX)
-trap 'rm -rf "$TMP_ROOT"' EXIT
+. "$REPO/ci/lib/harness.sh"
+. "$REPO/ci/lib/fixtures.sh"
 
-PASS=0
-FAIL=0
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-DIM='\033[0;90m'
-NC='\033[0m'
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
 
-assert_true() {
-  local name="$1"; shift
-  if "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd: %s${NC}\n" "$*"
-  fi
-}
+nh_init custom-stack nanostack-cs-flows
+nh_require_cmd git jq node
 
-assert_false() {
-  local name="$1"; shift
-  if ! "$@" >/dev/null 2>&1; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}cmd unexpectedly succeeded: %s${NC}\n" "$*"
-  fi
-}
-
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    PASS=$((PASS+1))
-    printf "    ${GREEN}OK${NC}    %s\n" "$name"
-  else
-    FAIL=$((FAIL+1))
-    printf "    ${RED}FAIL${NC}  %s\n" "$name"
-    printf "          ${DIM}expected: %s${NC}\n" "$expected"
-    printf "          ${DIM}actual:   %s${NC}\n" "$actual"
-  fi
-}
-
-echo "Custom Stack Framework v1 E2E"
-echo "============================="
-echo "Tmp root: $TMP_ROOT"
-echo
-
-PROJ="$TMP_ROOT/project"
-mkdir -p "$PROJ"
+# Shared project for the sequential journey (cells 1-12).
+PROJ=$(nf_new_git_project project)
 cd "$PROJ"
-git init -q
 
 # Cell 1: scaffold a new custom skill via bin/create-skill.sh.
-echo "[1] scaffold custom skill"
-"$REPO/bin/create-skill.sh" license-audit --concurrency read --depends-on build >/dev/null
-assert_true "skill directory exists" \
-  test -d ".nanostack/skills/license-audit"
-assert_true "phase registered in config" \
-  bash -c 'jq -e ".custom_phases | index(\"license-audit\")" .nanostack/config.json >/dev/null'
+cell_scaffold() {
+  cd "$PROJ"
+  "$REPO/bin/create-skill.sh" license-audit --concurrency read --depends-on build >/dev/null
+  nh_assert_true "skill directory exists" test -d ".nanostack/skills/license-audit"
+  nh_assert_true "phase registered in config" \
+    bash -c 'jq -e ".custom_phases | index(\"license-audit\")" .nanostack/config.json >/dev/null'
+}
 
 # Cell 2: bin/check-custom-skill.sh passes on the scaffolded skill.
-echo "[2] check-custom-skill validates the scaffolded skill"
-out=$( "$REPO/bin/check-custom-skill.sh" .nanostack/skills/license-audit 2>&1 )
-last_line=$(echo "$out" | tail -1)
-assert_true "check-custom-skill ends with OK summary" \
-  bash -c "echo '$last_line' | grep -qE '^OK:'"
+cell_validate() {
+  cd "$PROJ"
+  local out; out=$( "$REPO/bin/check-custom-skill.sh" .nanostack/skills/license-audit 2>&1 )
+  nh_assert_true "check-custom-skill ends with OK summary" \
+    bash -c "printf '%s\n' '$out' | tail -1 | grep -qE '^OK:'"
+}
 
 # Cell 3: helper script runs from its copied location.
-echo "[3] helper runs from copied location"
-printf '%s\n' '{"name":"e2e","dependencies":{"lodash":"4.17.21"}}' > package.json
-audit_json=$( ".nanostack/skills/license-audit/bin/audit.sh" node 2>/dev/null )
-assert_true "helper emits .counts" \
-  bash -c "echo '$audit_json' | jq -e '.counts' >/dev/null"
+cell_helper_runs() {
+  cd "$PROJ"
+  printf '%s\n' '{"name":"e2e","dependencies":{"lodash":"4.17.21"}}' > package.json
+  local audit_json; audit_json=$( ".nanostack/skills/license-audit/bin/audit.sh" node 2>/dev/null )
+  nh_assert_true "helper emits .counts" bash -c "echo '$audit_json' | jq -e '.counts' >/dev/null"
+}
 
 # Cell 4: save + find artifact.
-echo "[4] save and find an artifact"
-"$REPO/bin/save-artifact.sh" license-audit \
-  '{"phase":"license-audit","summary":{"status":"OK","headline":"e2e smoke"},"context_checkpoint":{"summary":"saved"}}' \
-  >/dev/null
-found=$( "$REPO/bin/find-artifact.sh" license-audit 30 2>/dev/null )
-assert_true "find-artifact returns a file" test -f "$found"
-assert_true "saved artifact has phase=license-audit" \
-  bash -c "jq -e '.phase == \"license-audit\"' '$found' >/dev/null"
+cell_save_find() {
+  cd "$PROJ"
+  "$REPO/bin/save-artifact.sh" license-audit \
+    '{"phase":"license-audit","summary":{"status":"OK","headline":"e2e smoke"},"context_checkpoint":{"summary":"saved"}}' >/dev/null
+  local found; found=$( "$REPO/bin/find-artifact.sh" license-audit 30 2>/dev/null )
+  nh_assert_true "find-artifact returns a file" test -f "$found"
+  nh_assert_true "saved artifact has phase=license-audit" \
+    bash -c "jq -e '.phase == \"license-audit\"' '$found' >/dev/null"
+}
 
 # Cell 5: resolver classifies the phase as custom.
-echo "[5] resolver returns phase_kind=custom"
-resolved=$( "$REPO/bin/resolve.sh" license-audit 2>/dev/null )
-kind=$( echo "$resolved" | jq -r '.phase_kind' )
-assert_eq "phase_kind == custom" "custom" "$kind"
+cell_resolve_kind() {
+  cd "$PROJ"
+  local resolved; resolved=$( "$REPO/bin/resolve.sh" license-audit 2>/dev/null )
+  nh_assert_eq "phase_kind == custom" "custom" "$( echo "$resolved" | jq -r '.phase_kind' )"
+}
 
 # Cell 6: sprint journal includes a /<phase> section.
-echo "[6] sprint-journal emits /license-audit section"
-journal=$( "$REPO/bin/sprint-journal.sh" )
-assert_true "journal file exists" test -f "$journal"
-assert_true "journal includes /license-audit" \
-  bash -c "grep -qF '## /license-audit' '$journal'"
-assert_true "journal mentions e2e smoke headline" \
-  bash -c "grep -qF 'e2e smoke' '$journal'"
+cell_journal() {
+  cd "$PROJ"
+  local journal; journal=$( "$REPO/bin/sprint-journal.sh" )
+  nh_assert_true "journal file exists" test -f "$journal"
+  nh_assert_true "journal includes /license-audit" bash -c "grep -qF '## /license-audit' '$journal'"
+  nh_assert_true "journal mentions e2e smoke headline" bash -c "grep -qF 'e2e smoke' '$journal'"
+}
 
 # Cell 7: analytics --json includes the custom count.
-echo "[7] analytics --json includes custom count"
-analytics=$( "$REPO/bin/analytics.sh" --json )
-assert_true "analytics.sprints.custom.license-audit >= 1" \
-  bash -c "echo '$analytics' | jq -e '.sprints.\"custom\".\"license-audit\" >= 1' >/dev/null"
-assert_true "analytics.sprints.total >= 1" \
-  bash -c "echo '$analytics' | jq -e '.sprints.total >= 1' >/dev/null"
+cell_analytics() {
+  cd "$PROJ"
+  local analytics; analytics=$( "$REPO/bin/analytics.sh" --json )
+  nh_assert_true "analytics.sprints.custom.license-audit >= 1" \
+    bash -c "echo '$analytics' | jq -e '.sprints.\"custom\".\"license-audit\" >= 1' >/dev/null"
+  nh_assert_true "analytics.sprints.total >= 1" \
+    bash -c "echo '$analytics' | jq -e '.sprints.total >= 1' >/dev/null"
+}
 
 # Cell 8: default discard --dry-run lists the custom artifact.
-echo "[8] default discard --dry-run lists the custom artifact"
-discard_out=$( "$REPO/bin/discard-sprint.sh" --dry-run )
-assert_true "dry-run includes license-audit" \
-  bash -c "echo '$discard_out' | grep -qF 'license-audit'"
+cell_discard() {
+  cd "$PROJ"
+  local discard_out; discard_out=$( "$REPO/bin/discard-sprint.sh" --dry-run )
+  nh_assert_true "dry-run includes license-audit" bash -c "echo '$discard_out' | grep -qF 'license-audit'"
+}
 
 # Cell 9: conductor sprint includes the custom phase via --phases.
-echo "[9] conductor sprint includes the custom phase"
-"$REPO/conductor/bin/sprint.sh" start \
-  --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"license-audit","depends_on":["build"]},{"name":"ship","depends_on":["license-audit"]}]' \
-  >/dev/null
-sprint_status=$( "$REPO/conductor/bin/sprint.sh" status )
-assert_true "conductor.phases has license-audit" \
-  bash -c "echo '$sprint_status' | jq -e '.phases | has(\"license-audit\")' >/dev/null"
-assert_true "conductor sprint has 5 phases" \
-  bash -c "echo '$sprint_status' | jq -e '.phases | length == 5' >/dev/null"
+cell_conductor_sprint() {
+  cd "$PROJ"
+  "$REPO/conductor/bin/sprint.sh" start \
+    --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"license-audit","depends_on":["build"]},{"name":"ship","depends_on":["license-audit"]}]' \
+    >/dev/null
+  local sprint_status; sprint_status=$( "$REPO/conductor/bin/sprint.sh" status )
+  nh_assert_true "conductor.phases has license-audit" \
+    bash -c "echo '$sprint_status' | jq -e '.phases | has(\"license-audit\")' >/dev/null"
+  nh_assert_true "conductor sprint has 5 phases" \
+    bash -c "echo '$sprint_status' | jq -e '.phases | length == 5' >/dev/null"
+}
 
 # Cell 10: cmd_batch reads the custom skill's concurrency.
-echo "[10] conductor batch reads custom skill concurrency=read"
-batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
-assert_true "license-audit appears in a type=read batch" \
-  bash -c "echo '$batch_out' | grep -qE '\"phases\":\\[[^]]*\"license-audit\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"license-audit\"'"
+cell_conductor_batch() {
+  cd "$PROJ"
+  local batch_out; batch_out=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+  nh_assert_true "license-audit appears in a type=read batch" \
+    bash -c "echo '$batch_out' | grep -qE '\"phases\":\\[[^]]*\"license-audit\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"license-audit\"'"
+}
 
 # Cell 11: agents/openai.yaml is present with the three discovery keys.
-# Narrow grep beats PyYAML here — keep the harness portable on any
-# machine with bash + jq + node.
-echo "[11] agents/openai.yaml present with required keys"
-SKILLS_ROOT_FOR_CHECK="${NANOSTACK_STORE:-$PROJ/.nanostack}/skills"
-[ -d "$SKILLS_ROOT_FOR_CHECK/license-audit/agents" ] || \
-  SKILLS_ROOT_FOR_CHECK="$PROJ/.nanostack/skills"
-assert_true "openai.yaml exists" \
-  test -f "$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml"
-assert_true "openai.yaml has display_name + short_description + default_prompt" \
-  bash -c "grep -qE '^[[:space:]]+display_name:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+short_description:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+default_prompt:' '$SKILLS_ROOT_FOR_CHECK/license-audit/agents/openai.yaml'"
+cell_openai_yaml() {
+  cd "$PROJ"
+  local root="${NANOSTACK_STORE:-$PROJ/.nanostack}/skills"
+  [ -d "$root/license-audit/agents" ] || root="$PROJ/.nanostack/skills"
+  nh_assert_true "openai.yaml exists" test -f "$root/license-audit/agents/openai.yaml"
+  nh_assert_true "openai.yaml has display_name + short_description + default_prompt" \
+    bash -c "grep -qE '^[[:space:]]+display_name:' '$root/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+short_description:' '$root/license-audit/agents/openai.yaml' && grep -qE '^[[:space:]]+default_prompt:' '$root/license-audit/agents/openai.yaml'"
+}
 
 # Cell 12: copied skill has no repo-relative example paths.
-echo "[12] copied skill has no repo-relative example paths"
-assert_true "SKILL.md has no ./examples/custom-skill-template/ leak" \
-  bash -c "! grep -qE '\\./examples/custom-skill-template/' .nanostack/skills/license-audit/SKILL.md"
+cell_no_example_leak() {
+  cd "$PROJ"
+  nh_assert_true "SKILL.md has no ./examples/custom-skill-template/ leak" \
+    bash -c "! grep -qE '\\./examples/custom-skill-template/' .nanostack/skills/license-audit/SKILL.md"
+}
 
-# Cell 13: scaffolding from a git subdirectory must land in the repo
-# root's .nanostack, not the subdir's. Codex caught a regression here:
-# create-skill.sh used cwd-relative paths so a user invoking the tool
-# from src/ wrote .nanostack/ inside src/, then check-custom-skill.sh
-# (which resolves the store via store-path.sh -> repo root) failed
-# the registration check.
-echo "[13] create-skill resolves the store from a subdirectory"
-SUB_PROJ="$TMP_ROOT/subdir-project"
-mkdir -p "$SUB_PROJ/src/feature"
-cd "$SUB_PROJ"
-git init -q
-cd "$SUB_PROJ/src/feature"
-"$REPO/bin/create-skill.sh" subdir-skill --concurrency read >/dev/null
-assert_true "skill landed in repo root, not in src/feature" \
-  test -f "$SUB_PROJ/.nanostack/skills/subdir-skill/SKILL.md"
-assert_true "no rogue .nanostack inside src/feature" \
-  bash -c "! test -d '$SUB_PROJ/src/feature/.nanostack'"
-out=$( "$REPO/bin/check-custom-skill.sh" "$SUB_PROJ/.nanostack/skills/subdir-skill" 2>&1 )
-assert_true "check-custom-skill passes from a subdir scaffold" \
-  bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
-# Conductor invoked from the subdir must still read the scaffolded
-# SKILL.md from the resolved store. Without the lookup-roots fix, batch
-# silently defaults to concurrency=write because nano_phase_skill_path
-# only searched .nanostack/skills relative to cwd.
-"$REPO/conductor/bin/sprint.sh" start \
-  --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"subdir-skill","depends_on":["build"]},{"name":"ship","depends_on":["subdir-skill"]}]' \
-  >/dev/null
-sub_batch=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
-assert_true "subdir conductor reads SKILL.md (no 'no SKILL.md' warning)" \
-  bash -c "! echo '$sub_batch' | grep -qF 'no SKILL.md found'"
-assert_true "subdir conductor schedules subdir-skill as type=read" \
-  bash -c "echo '$sub_batch' | grep -qE '\"phases\":\\[[^]]*\"subdir-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"subdir-skill\"'"
+# Cell 13: create-skill resolves the store from a subdirectory.
+cell_store_subdir() {
+  local sub; sub=$(nf_new_git_project subdir-project)
+  mkdir -p "$sub/src/feature"
+  cd "$sub/src/feature"
+  "$REPO/bin/create-skill.sh" subdir-skill --concurrency read >/dev/null
+  nh_assert_true "skill landed in repo root, not in src/feature" \
+    test -f "$sub/.nanostack/skills/subdir-skill/SKILL.md"
+  nh_assert_true "no rogue .nanostack inside src/feature" \
+    bash -c "! test -d '$sub/src/feature/.nanostack'"
+  local out; out=$( "$REPO/bin/check-custom-skill.sh" "$sub/.nanostack/skills/subdir-skill" 2>&1 )
+  nh_assert_true "check-custom-skill passes from a subdir scaffold" \
+    bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+  "$REPO/conductor/bin/sprint.sh" start \
+    --phases '[{"name":"think","depends_on":[]},{"name":"plan","depends_on":["think"]},{"name":"build","depends_on":["plan"]},{"name":"subdir-skill","depends_on":["build"]},{"name":"ship","depends_on":["subdir-skill"]}]' \
+    >/dev/null
+  local sub_batch; sub_batch=$( "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+  nh_assert_true "subdir conductor reads SKILL.md (no 'no SKILL.md' warning)" \
+    bash -c "! echo '$sub_batch' | grep -qF 'no SKILL.md found'"
+  nh_assert_true "subdir conductor schedules subdir-skill as type=read" \
+    bash -c "echo '$sub_batch' | grep -qE '\"phases\":\\[[^]]*\"subdir-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"subdir-skill\"'"
+}
 
-# Cell 14: scaffolding outside any git repo. lib/store-path.sh falls
-# back to $HOME/.nanostack, so create-skill must too. Use a fake HOME
-# inside TMP_ROOT so the test does not touch the real ~/.nanostack.
-echo "[14] create-skill resolves the store outside git (fake HOME)"
-NOGIT_HOME="$TMP_ROOT/nogit-home"
-NOGIT_PROJ="$TMP_ROOT/nogit-project"
-mkdir -p "$NOGIT_HOME" "$NOGIT_PROJ"
-cd "$NOGIT_PROJ"
-HOME="$NOGIT_HOME" "$REPO/bin/create-skill.sh" nogit-skill --concurrency read >/dev/null
-assert_true "skill landed in fake-HOME store, not cwd" \
-  test -f "$NOGIT_HOME/.nanostack/skills/nogit-skill/SKILL.md"
-assert_true "no rogue .nanostack inside the cwd" \
-  bash -c "! test -d '$NOGIT_PROJ/.nanostack'"
-out=$( HOME="$NOGIT_HOME" "$REPO/bin/check-custom-skill.sh" "$NOGIT_HOME/.nanostack/skills/nogit-skill" 2>&1 )
-assert_true "check-custom-skill passes outside git" \
-  bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
-# Conductor outside git must read the scaffolded SKILL.md from
-# $HOME/.nanostack/skills, not fall through to ~/.claude/skills or
-# the cwd-relative legacy root.
-HOME="$NOGIT_HOME" "$REPO/conductor/bin/sprint.sh" start \
-  --phases '[{"name":"think","depends_on":[]},{"name":"build","depends_on":["think"]},{"name":"nogit-skill","depends_on":["build"]},{"name":"ship","depends_on":["nogit-skill"]}]' \
-  >/dev/null
-nogit_batch=$( HOME="$NOGIT_HOME" "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
-assert_true "no-git conductor reads SKILL.md (no 'no SKILL.md' warning)" \
-  bash -c "! echo '$nogit_batch' | grep -qF 'no SKILL.md found'"
-assert_true "no-git conductor schedules nogit-skill as type=read" \
-  bash -c "echo '$nogit_batch' | grep -qE '\"phases\":\\[[^]]*\"nogit-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"nogit-skill\"'"
+# Cell 14: create-skill resolves the store outside git (fake HOME).
+cell_store_nogit() {
+  local nh np; nh="$NH_TMP/nogit-home"; np="$NH_TMP/nogit-project"
+  mkdir -p "$nh" "$np"
+  cd "$np"
+  HOME="$nh" "$REPO/bin/create-skill.sh" nogit-skill --concurrency read >/dev/null
+  nh_assert_true "skill landed in fake-HOME store, not cwd" \
+    test -f "$nh/.nanostack/skills/nogit-skill/SKILL.md"
+  nh_assert_true "no rogue .nanostack inside the cwd" bash -c "! test -d '$np/.nanostack'"
+  local out; out=$( HOME="$nh" "$REPO/bin/check-custom-skill.sh" "$nh/.nanostack/skills/nogit-skill" 2>&1 )
+  nh_assert_true "check-custom-skill passes outside git" \
+    bash -c "echo '$out' | tail -1 | grep -qE '^OK:'"
+  HOME="$nh" "$REPO/conductor/bin/sprint.sh" start \
+    --phases '[{"name":"think","depends_on":[]},{"name":"build","depends_on":["think"]},{"name":"nogit-skill","depends_on":["build"]},{"name":"ship","depends_on":["nogit-skill"]}]' \
+    >/dev/null
+  local nogit_batch; nogit_batch=$( HOME="$nh" "$REPO/conductor/bin/sprint.sh" batch 2>&1 )
+  nh_assert_true "no-git conductor reads SKILL.md (no 'no SKILL.md' warning)" \
+    bash -c "! echo '$nogit_batch' | grep -qF 'no SKILL.md found'"
+  nh_assert_true "no-git conductor schedules nogit-skill as type=read" \
+    bash -c "echo '$nogit_batch' | grep -qE '\"phases\":\\[[^]]*\"nogit-skill\"[^]]*\\].*\"type\":\"read\"|\"type\":\"read\".*\"phases\":\\[[^]]*\"nogit-skill\"'"
+}
 
-# Cell 15: validator catches a frontmatter name that does not match
-# the directory basename. Codex hit a false-positive OK after a
-# manual copy that left `name: audit-licenses` inside a
-# license-audit/ folder; the agent would have exposed the wrong
-# slash command.
-echo "[15] validator rejects mismatched frontmatter name"
-DRIFT_HOME="$TMP_ROOT/drift-home"
-DRIFT_PROJ="$TMP_ROOT/drift-project"
-mkdir -p "$DRIFT_HOME" "$DRIFT_PROJ"
-cd "$DRIFT_PROJ"
-HOME="$DRIFT_HOME" "$REPO/bin/create-skill.sh" license-audit >/dev/null
-# Sabotage the SKILL.md so the frontmatter still says the source
-# template name. This is the "user copied by hand and forgot to
-# rename" path.
-DRIFT_SKILL="$DRIFT_HOME/.nanostack/skills/license-audit"
-sed 's/^name:.*/name: audit-licenses/' "$DRIFT_SKILL/SKILL.md" > "$DRIFT_SKILL/SKILL.md.tmp"
-mv "$DRIFT_SKILL/SKILL.md.tmp" "$DRIFT_SKILL/SKILL.md"
-assert_false "check-custom-skill rejects mismatched frontmatter name" \
-  bash -c "HOME='$DRIFT_HOME' '$REPO/bin/check-custom-skill.sh' '$DRIFT_SKILL'"
+# Cell 15: validator rejects a mismatched frontmatter name.
+cell_validator_name_mismatch() {
+  local dh dp; dh="$NH_TMP/drift-home"; dp="$NH_TMP/drift-project"
+  mkdir -p "$dh" "$dp"
+  cd "$dp"
+  HOME="$dh" "$REPO/bin/create-skill.sh" license-audit >/dev/null
+  local skill="$dh/.nanostack/skills/license-audit"
+  sed 's/^name:.*/name: audit-licenses/' "$skill/SKILL.md" > "$skill/SKILL.md.tmp"
+  mv "$skill/SKILL.md.tmp" "$skill/SKILL.md"
+  nh_assert_false "check-custom-skill rejects mismatched frontmatter name" \
+    env HOME="$dh" "$REPO/bin/check-custom-skill.sh" "$skill"
+}
 
-cd "$PROJ"
+# Build a guard fixture: a git project with the license-audit custom phase
+# (concurrency: read) registered via create-skill, and a current_phase
+# session. Sets GUARD_PROJ / GUARD_STORE / GUARD_HOME so each guard cell is
+# self-contained (works standalone under --filter).
+make_guard_project() {
+  local name="$1"
+  GUARD_HOME="$NH_TMP/$name-home"
+  GUARD_PROJ=$(nf_new_git_project "$name")
+  cd "$GUARD_PROJ"  # create-skill resolves the store from the git root of cwd
+  HOME="$GUARD_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
+  GUARD_STORE="$GUARD_PROJ/.nanostack"
+  [ -d "$GUARD_STORE/skills/license-audit" ] || GUARD_STORE="$GUARD_HOME/.nanostack"
+  echo '{"current_phase":"license-audit"}' > "$GUARD_STORE/session.json"
+}
 
-# Cell 16: guard concurrency is registry-aware. A read-only custom phase
-# must block writes the same way a built-in read phase does. Without the
-# registry lookup, guard fell back to $NANOSTACK_ROOT/<phase>/SKILL.md
-# and silently no-oped for every custom skill (which lives under the
-# store's skills/, not the repo). Also exercises the in-project bypass
-# (./ prefix + absolute in-project path) that Codex flagged on the
-# PR 1 review — Tier 2.4 must run before the in-project fast-path or
-# `touch ./x` inside a git worktree slips through.
-echo "[16] guard blocks writes during a read-only custom phase"
-GUARD_HOME="$TMP_ROOT/guard-home"
-GUARD_PROJ="$TMP_ROOT/guard-project"
-mkdir -p "$GUARD_HOME" "$GUARD_PROJ"
-cd "$GUARD_PROJ"
-git init -q
-HOME="$GUARD_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
-GUARD_STORE="$GUARD_PROJ/.nanostack"
-[ -d "$GUARD_STORE/skills/license-audit" ] || GUARD_STORE="$GUARD_HOME/.nanostack"
-echo '{"current_phase":"license-audit"}' > "$GUARD_STORE/session.json"
-for case_cmd in "touch should-not-pass" "touch ./should-not-pass" "touch $GUARD_PROJ/should-not-pass"; do
-  set +e
-  NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
-    "$REPO/guard/bin/check-dangerous.sh" "$case_cmd" >/dev/null 2>&1
-  guard_rc=$?
-  set -e
-  assert_eq "blocks: $case_cmd" "1" "$guard_rc"
-done
+# Cell 16: guard blocks writes during a read-only custom phase (incl. the
+# in-project bypass: ./ prefix + absolute in-project path).
+cell_guard_custom_read() {
+  make_guard_project guard-read
+  cd "$GUARD_PROJ"
+  local c
+  for c in "touch should-not-pass" "touch ./should-not-pass" "touch $GUARD_PROJ/should-not-pass"; do
+    nh_assert_exit "blocks: $c" 1 env NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" "$REPO/guard/bin/check-dangerous.sh" "$c"
+  done
+}
 
-# Cell 17: switching the same custom phase to concurrency: write lifts
-# the concurrency block. (Other guard tiers may still object to specific
-# commands; here we use a path outside the project so Tier 2 in-project
-# fast-path does not auto-pass.)
-echo "[17] custom write phase does not trigger the concurrency block"
-sed_target="$GUARD_STORE/skills/license-audit/SKILL.md"
-sed 's/^concurrency: read$/concurrency: write/' "$sed_target" > "$sed_target.tmp"
-mv "$sed_target.tmp" "$sed_target"
-OUT_TMP=$(mktemp -d /tmp/guard-outside.XXXXXX)
-set +e
-NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch $OUT_TMP/x" >/dev/null 2>&1
-guard_rc=$?
-set -e
-rm -rf "$OUT_TMP"
-assert_eq "custom write phase does not block on concurrency (exit 0)" "0" "$guard_rc"
+# Cell 17: switching the same phase to concurrency: write lifts the block.
+cell_guard_custom_write() {
+  make_guard_project guard-write
+  local t="$GUARD_STORE/skills/license-audit/SKILL.md"
+  sed 's/^concurrency: read$/concurrency: write/' "$t" > "$t.tmp"; mv "$t.tmp" "$t"
+  local outdir; outdir=$(mktemp -d /tmp/guard-outside.XXXXXX)
+  nh_assert_exit "custom write phase does not block on concurrency (exit 0)" 0 \
+    env NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" "$REPO/guard/bin/check-dangerous.sh" "touch $outdir/x"
+  rm -rf "$outdir"
+}
 
-# Cell 18: built-in read phases keep working unchanged. /review is the
-# canonical case: it must keep blocking touch even after the lookup
-# moved through the phase registry.
-echo "[18] built-in review phase still blocks writes"
-echo '{"current_phase":"review"}' > "$GUARD_STORE/session.json"
-set +e
-NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
-guard_rc=$?
-set -e
-assert_eq "built-in review phase blocks write (exit 1)" "1" "$guard_rc"
+# Cell 18: built-in read phases keep working unchanged.
+cell_guard_builtin() {
+  make_guard_project guard-builtin
+  echo '{"current_phase":"review"}' > "$GUARD_STORE/session.json"
+  nh_assert_exit "built-in review phase blocks write (exit 1)" 1 \
+    env NANOSTACK_STORE="$GUARD_STORE" HOME="$GUARD_HOME" "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass"
+}
 
-# Cell 19: repo-bundled non-core skills (feature, doctor, help, ...)
-# also have concurrency: read frontmatter. The guard's previous raw
-# lookup at $NANOSTACK_ROOT/<phase>/SKILL.md saw them directly; the
-# registry-aware lookup must keep finding them. Codex caught the
-# regression on PR 1's fourth pass — without the repo-root fallback,
-# `current_phase=feature` left SKILL_CONC empty and the guard allowed
-# writes.
-echo "[19] guard finds repo-bundled non-core skills"
-BUNDLED_PROJ="$TMP_ROOT/bundled-project"
-mkdir -p "$BUNDLED_PROJ/.nanostack"
-cd "$BUNDLED_PROJ"
-git init -q
-for bundled in feature doctor; do
-  echo "{\"current_phase\":\"$bundled\"}" > "$BUNDLED_PROJ/.nanostack/session.json"
-  set +e
-  NANOSTACK_STORE="$BUNDLED_PROJ/.nanostack" \
-    "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
-  guard_rc=$?
-  set -e
-  assert_eq "bundled $bundled phase blocks write" "1" "$guard_rc"
-done
-cd "$PROJ"
+# Cell 19: guard finds repo-bundled non-core skills (feature, doctor).
+cell_guard_bundled() {
+  local bp; bp=$(nf_new_git_project bundled-project)
+  nf_new_store "$bp" >/dev/null
+  cd "$bp"
+  local b
+  for b in feature doctor; do
+    echo "{\"current_phase\":\"$b\"}" > "$bp/.nanostack/session.json"
+    nh_assert_exit "bundled $b phase blocks write" 1 \
+      env NANOSTACK_STORE="$bp/.nanostack" "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass"
+  done
+}
 
-# Cell 20: a registered custom phase that reuses a repo-bundled
-# directory name (feature, doctor, ...) must win over the bundled
-# fallback. create-skill.sh does not reserve bundled names, so a
-# user can legitimately register `feature` themselves with their own
-# concurrency. Codex caught the precedence regression on the PR 1
-# fifth pass; this cell locks the correct order.
-echo "[20] registered custom skill wins over bundled non-core fallback"
-PREC_PROJ="$TMP_ROOT/precedence-project"
-mkdir -p "$PREC_PROJ/.nanostack/skills/feature"
-cd "$PREC_PROJ"
-git init -q
-cat > "$PREC_PROJ/.nanostack/config.json" <<'EOF'
-{"custom_phases":["feature"]}
-EOF
-cat > "$PREC_PROJ/.nanostack/skills/feature/SKILL.md" <<'EOF'
----
-name: feature
-description: user-registered feature override
-concurrency: write
----
-body
-EOF
-echo '{"current_phase":"feature"}' > "$PREC_PROJ/.nanostack/session.json"
-PREC_OUT=$(mktemp -d /tmp/precedence-out.XXXXXX)
-set +e
-NANOSTACK_STORE="$PREC_PROJ/.nanostack" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch $PREC_OUT/x" >/dev/null 2>&1
-guard_rc=$?
-set -e
-rm -rf "$PREC_OUT"
-cd "$PROJ"
-assert_eq "custom feature (write) shadows bundled feature (read)" "0" "$guard_rc"
+# Cell 20: a registered custom phase that reuses a bundled name wins.
+cell_guard_precedence() {
+  local pp; pp=$(nf_new_git_project precedence-project)
+  mkdir -p "$pp/.nanostack/skills/feature"
+  printf '%s\n' '{"custom_phases":["feature"]}' > "$pp/.nanostack/config.json"
+  printf '%s\n' '---' 'name: feature' 'description: user-registered feature override' 'concurrency: write' '---' 'body' \
+    > "$pp/.nanostack/skills/feature/SKILL.md"
+  echo '{"current_phase":"feature"}' > "$pp/.nanostack/session.json"
+  local outdir; outdir=$(mktemp -d /tmp/precedence-out.XXXXXX)
+  nh_assert_exit "custom feature (write) shadows bundled feature (read)" 0 \
+    env NANOSTACK_STORE="$pp/.nanostack" "$REPO/guard/bin/check-dangerous.sh" "touch $outdir/x"
+  rm -rf "$outdir"
+}
 
-# Cell 21: an unrelated user-installed skill under ~/.claude/skills or
-# ~/.agents/skills that happens to share a name with a bundled non-core
-# phase must NOT silently shadow the bundled SKILL.md. Only an
-# explicitly registered custom phase (in .nanostack/config.json's
-# custom_phases) is allowed to override. Codex caught this on the
-# PR 1 sixth pass.
-echo "[21] unrelated user-installed skill does not shadow bundled phase"
-SHADOW_HOME="$TMP_ROOT/shadow-home"
-SHADOW_PROJ="$TMP_ROOT/shadow-project"
-mkdir -p "$SHADOW_HOME/.claude/skills/feature" "$SHADOW_PROJ/.nanostack"
-cat > "$SHADOW_HOME/.claude/skills/feature/SKILL.md" <<'EOF'
----
-name: feature
-description: unrelated user-installed skill (no registration)
-concurrency: write
----
-body
-EOF
-cd "$SHADOW_PROJ"
-git init -q
-echo '{"current_phase":"feature"}' > "$SHADOW_PROJ/.nanostack/session.json"
-set +e
-HOME="$SHADOW_HOME" NANOSTACK_STORE="$SHADOW_PROJ/.nanostack" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch x" >/dev/null 2>&1
-guard_rc=$?
-set -e
-cd "$PROJ"
-assert_eq "bundled feature still wins when no registered custom" "1" "$guard_rc"
+# Cell 21: an unrelated user-installed skill does not shadow a bundled phase.
+cell_guard_no_shadow() {
+  local sh sp; sh="$NH_TMP/shadow-home"; sp=$(nf_new_git_project shadow-project)
+  nf_new_store "$sp" >/dev/null
+  mkdir -p "$sh/.claude/skills/feature"
+  printf '%s\n' '---' 'name: feature' 'description: unrelated user-installed skill (no registration)' 'concurrency: write' '---' 'body' \
+    > "$sh/.claude/skills/feature/SKILL.md"
+  cd "$sp"
+  echo '{"current_phase":"feature"}' > "$sp/.nanostack/session.json"
+  nh_assert_exit "bundled feature still wins when no registered custom" 1 \
+    env HOME="$sh" NANOSTACK_STORE="$sp/.nanostack" "$REPO/guard/bin/check-dangerous.sh" "touch x"
+}
 
-# Cell 22: a HOME (or store) path that contains a space must not break
-# the guard. The previous space-separated root iteration in
-# nano_phase_skill_path silently dropped path halves and made the
-# concurrency block a no-op for these users. Codex caught the
-# regression on PR 1 of the architecture round; this cell locks it.
-echo "[22] guard works when store path contains a space"
-SPACE_TMP=$(mktemp -d /tmp/nanostack-space.XXXXXX)
-SPACE_HOME="$SPACE_TMP/home with space"
-SPACE_PROJ="$SPACE_TMP/nogit"
-mkdir -p "$SPACE_HOME" "$SPACE_PROJ"
-cd "$SPACE_PROJ"
-HOME="$SPACE_HOME" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
-SPACE_STORE="$SPACE_HOME/.nanostack"
-echo '{"current_phase":"license-audit"}' > "$SPACE_STORE/session.json"
-set +e
-NANOSTACK_STORE="$SPACE_STORE" HOME="$SPACE_HOME" \
-  "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass" >/dev/null 2>&1
-guard_rc=$?
-set -e
-cd "$PROJ"
-rm -rf "$SPACE_TMP"
-assert_eq "store path with space still blocks (exit 1)" "1" "$guard_rc"
+# Cell 22: a store path containing a space must not break the guard.
+cell_guard_space_path() {
+  local stmp sh sp; stmp=$(mktemp -d /tmp/nanostack-space.XXXXXX)
+  sh="$stmp/home with space"; sp="$stmp/nogit"
+  mkdir -p "$sh" "$sp"
+  cd "$sp"
+  HOME="$sh" "$REPO/bin/create-skill.sh" license-audit --concurrency read >/dev/null
+  local store="$sh/.nanostack"
+  echo '{"current_phase":"license-audit"}' > "$store/session.json"
+  nh_assert_exit "store path with space still blocks (exit 1)" 1 \
+    env NANOSTACK_STORE="$store" HOME="$sh" "$REPO/guard/bin/check-dangerous.sh" "touch should-not-pass"
+  rm -rf "$stmp"
+}
 
-cd "$PROJ"
 
-echo
-echo "============================="
-TOTAL=$((PASS + FAIL))
-if [ "$FAIL" -eq 0 ]; then
-  printf "${GREEN}Custom Stack E2E: %d checks passed, 0 failed${NC}\n" "$PASS"
-  exit 0
-else
-  printf "${RED}Custom Stack E2E: %d failed of %d total${NC}\n" "$FAIL" "$TOTAL"
-  exit 1
-fi
+nh_cell scaffold              cell_scaffold
+nh_cell validate             cell_validate
+nh_cell helper-runs          cell_helper_runs
+nh_cell save-find            cell_save_find
+nh_cell resolve-kind         cell_resolve_kind
+nh_cell journal              cell_journal
+nh_cell analytics            cell_analytics
+nh_cell discard              cell_discard
+nh_cell conductor-sprint     cell_conductor_sprint
+nh_cell conductor-batch      cell_conductor_batch
+nh_cell openai-yaml          cell_openai_yaml
+nh_cell no-example-leak      cell_no_example_leak
+nh_cell store-subdir         cell_store_subdir
+nh_cell store-nogit          cell_store_nogit
+nh_cell validator-name-mismatch cell_validator_name_mismatch
+nh_cell guard-custom-read    cell_guard_custom_read
+nh_cell guard-custom-write   cell_guard_custom_write
+nh_cell guard-builtin        cell_guard_builtin
+nh_cell guard-bundled        cell_guard_bundled
+nh_cell guard-precedence     cell_guard_precedence
+nh_cell guard-no-shadow      cell_guard_no_shadow
+nh_cell guard-space-path     cell_guard_space_path
+
+nh_summary

--- a/ci/lib/fixtures.sh
+++ b/ci/lib/fixtures.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# fixtures.sh — Shared fixture builders for nanostack CI harnesses.
+#
+# Harness Architecture vNext PR 2 (2026-05-28). Several suites built the
+# same fixtures by hand: a temp git project, a .nanostack store, valid /
+# tampered / missing-integrity artifacts, custom-phase config, sessions.
+# When the integrity/hash setup drifts from production, negative tests can
+# end up testing a fixture quirk instead of real behavior. This library is
+# the single fixture surface; the artifact hashing here reuses the SAME
+# canonical path as production (bin/lib/portable.sh's nano_sha256 over
+# `jq -Sc 'del(.integrity)'`), so a "verified" fixture verifies under
+# bin/lib/artifact-trust.sh exactly as a save-artifact.sh output would.
+#
+# Source AFTER ci/lib/harness.sh (fixtures use the suite's $NH_TMP root).
+# portable.sh is sourced here if the caller has not already loaded it.
+#
+# Public API:
+#   nf_new_git_project <name>                 -> echoes the project path
+#   nf_new_store <project_path>               -> mkdir store, echoes path
+#   nf_export_store <project_path>            -> export NANOSTACK_STORE, echo
+#   nf_save_artifact <phase> <json>           -> real save-artifact.sh, echo path
+#   nf_write_artifact <store> <phase> <trust_state> <timestamp> <project>
+#                                             -> hand-write an artifact, echo path
+#   nf_register_custom_phase <store> <phase> <concurrency>
+#   nf_register_phase_graph <store> <json_graph>
+#   nf_write_session <store> <workspace> [current_phase]
+#   nf_install_example_stack <project> <stack_path>
+#
+# Trust states for nf_write_artifact: verified | integrity_missing |
+# integrity_mismatch.
+
+if [ "${_NF_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NF_LOADED=1
+
+_NF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_NF_REPO="$(cd "$_NF_DIR/../.." && pwd)"
+# Canonical hashing comes from production's portable.sh, never a parallel
+# shasum/sha256sum branch re-implemented per harness.
+if ! declare -F nano_sha256 >/dev/null 2>&1; then
+  [ -f "$_NF_REPO/bin/lib/portable.sh" ] && . "$_NF_REPO/bin/lib/portable.sh"
+fi
+NF_SAVE="$_NF_REPO/bin/save-artifact.sh"
+
+# A temp git project under the suite's $NH_TMP. Does not cd or export;
+# the caller decides (use nf_export_store for the store env). Echoes path.
+nf_new_git_project() {
+  local name="${1:?nf_new_git_project requires a name}"
+  local proj="${NH_TMP:?nf_new_git_project requires nh_init first}/$name"
+  mkdir -p "$proj"
+  ( cd "$proj" && git init -q && git config user.email ci@nf.test && git config user.name ci )
+  printf '%s' "$proj"
+}
+
+nf_new_store() {
+  local store="${1:?nf_new_store requires a project path}/.nanostack"
+  mkdir -p "$store"
+  printf '%s' "$store"
+}
+
+nf_export_store() {
+  export NANOSTACK_STORE="${1:?nf_export_store requires a project path}/.nanostack"
+  mkdir -p "$NANOSTACK_STORE"
+  printf '%s' "$NANOSTACK_STORE"
+}
+
+# Write an artifact through the real save-artifact.sh path (validates +
+# stamps integrity). Honors the current NANOSTACK_STORE. Echoes the path.
+nf_save_artifact() {
+  "$NF_SAVE" "${1:?phase}" "${2:?json}"
+}
+
+# Hand-write an artifact in a chosen trust state at a chosen filename
+# timestamp. Used to exercise trust/freshness paths in isolation. The
+# "verified" hash is the production canonical hash, so the file passes
+# nano_artifact_trust without a parallel hashing contract.
+nf_write_artifact() {
+  local store="${1:?store}" phase="${2:?phase}" mode="${3:?trust_state}"
+  local ts="${4:?timestamp}" project="${5:?project}"
+  mkdir -p "$store/$phase"
+  local out="$store/$phase/$ts.json" body
+  body=$(printf '{"phase":"%s","project":"%s","summary":"x"}' "$phase" "$project")
+  case "$mode" in
+    verified)
+      local h
+      h=$(printf '%s' "$body" | jq -Sc 'del(.integrity)' | nano_sha256 | cut -d' ' -f1)
+      printf '%s' "$body" | jq --arg h "$h" '. + {integrity:$h}' > "$out"
+      ;;
+    integrity_missing)
+      printf '%s' "$body" > "$out"
+      ;;
+    integrity_mismatch)
+      printf '%s' "$body" \
+        | jq '. + {integrity:"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}' > "$out"
+      ;;
+    *)
+      echo "nf_write_artifact: unknown trust state '$mode' (verified|integrity_missing|integrity_mismatch)" >&2
+      return 1
+      ;;
+  esac
+  printf '%s' "$out"
+}
+
+# Register a custom phase: write its SKILL.md (with concurrency) under the
+# store's skills/ and add it to config.json custom_phases (merge-safe).
+nf_register_custom_phase() {
+  local store="${1:?store}" phase="${2:?phase}" conc="${3:?concurrency}"
+  mkdir -p "$store/skills/$phase"
+  printf '%s\n' '---' "name: $phase" "description: custom phase $phase" \
+    "concurrency: $conc" '---' 'Body.' > "$store/skills/$phase/SKILL.md"
+  local cfg="$store/config.json"
+  if [ -f "$cfg" ]; then
+    jq --arg p "$phase" '.custom_phases = ((.custom_phases // []) + [$p] | unique)' \
+      "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+  else
+    jq -n --arg p "$phase" '{custom_phases:[$p]}' > "$cfg"
+  fi
+}
+
+# Set the phase_graph in the store's config.json (merge-safe).
+nf_register_phase_graph() {
+  local store="${1:?store}" graph="${2:?json_graph}" cfg
+  cfg="$store/config.json"
+  if [ -f "$cfg" ]; then
+    jq --argjson g "$graph" '.phase_graph = $g' "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+  else
+    jq -n --argjson g "$graph" '{phase_graph:$g}' > "$cfg"
+  fi
+}
+
+# Write a session.json. With a current_phase, seeds a single in_progress
+# phase_log entry (enough for the guard concurrency check and to mark a
+# sprint active for the phase gate). Without one, writes an empty log.
+nf_write_session() {
+  local store="${1:?store}" ws="${2:?workspace}" phase="${3:-}"
+  if [ -n "$phase" ]; then
+    jq -n --arg w "$ws" --arg p "$phase" \
+      '{workspace:$w, current_phase:$p, phase_log:[{phase:$p, status:"in_progress"}]}' \
+      > "$store/session.json"
+  else
+    jq -n --arg w "$ws" '{workspace:$w, phase_log:[]}' > "$store/session.json"
+  fi
+}
+
+# Copy an example custom-stack into a project's store skills/ so a suite
+# can exercise an installed third-party stack.
+nf_install_example_stack() {
+  local project="${1:?project}" stack="${2:?stack_path}"
+  local store="$project/.nanostack"
+  mkdir -p "$store/skills"
+  cp -R "$stack"/. "$store/skills/" 2>/dev/null || cp -R "$stack" "$store/skills/"
+  printf '%s' "$store/skills"
+}


### PR DESCRIPTION
## Summary

PR 2 of the Harness Architecture vNext round. Several suites built the
same fixtures by hand (temp git project, store, valid/tampered/missing-
integrity artifacts, custom-phase config, sessions). When the integrity
setup drifts from production, a negative test can end up testing a fixture
quirk instead of real behavior. This adds one fixture surface and migrates
the three fixture-heavy suites onto it. No coverage is removed.

## What changed

- **`ci/lib/fixtures.sh`** (new) — `nf_` API: `new_git_project`,
  `new_store`, `export_store`, `save_artifact`, `write_artifact`
  (`verified` / `integrity_missing` / `integrity_mismatch`),
  `register_custom_phase`, `register_phase_graph`, `write_session`,
  `install_example_stack`. `nf_write_artifact`'s `verified` hash reuses the
  production canonical path (`bin/lib/portable.sh` `nano_sha256` over
  `jq -Sc 'del(.integrity)'`), so a fixture verifies under
  `bin/lib/artifact-trust.sh` exactly as a `save-artifact.sh` output does.
  No parallel hashing contract.

- Migrated onto `ci/lib/harness.sh` + `ci/lib/fixtures.sh`, cells as
  functions with `--filter`:
  - `ci/e2e-artifact-trust.sh` (41 checks)
  - `ci/e2e-custom-routing.sh` (35 checks)
  - `ci/e2e-custom-stack-flows.sh` (40 checks)

## Metrics

- Suites migrated: 3.
- Check counts preserved: 41 / 35 / 40.
- Net: +851 / -1185 (the three suites shed duplicated assert/counter/color
  helpers and per-suite fixture builders); `fixtures.sh` is 154 reusable
  lines.
- Workflow / job names touched: none. Tier behavior: unchanged (all three
  stay opt-in in `e2e.yml`). Adapter evidence job names: unchanged.

## Validation

- Full runs: artifact-trust 41/41, custom-routing 35/35, custom-stack
  40/40. Harness self-test still 24/24.
- `nf_write_artifact verified` confirmed to resolve to `verified` under
  `nano_artifact_trust` (production hash), `integrity_missing` and
  `integrity_mismatch` to their states.
- Negative controls preserved (each migrated suite still fails on a real
  product regression): neutering `resolve.sh` strict-drop fails
  custom-routing; neutering `phase-gate` `--require-integrity` fails
  artifact-trust; neutering the `check-dangerous` read-only block fails
  custom-stack.
- Guard cells are self-contained under `--filter` (run standalone).
- bash 3.2 clean; no workflow or public-doc changes; codex review clean.

Coverage acceptance: artifact trust still covers verified / integrity_missing
/ integrity_mismatch / not_found; the custom phase fixture proves both
read and write concurrency paths; store-path behavior stays covered for git
root, subdir, no-git, and spaces-in-path.

Harness Architecture vNext PR 2 of 6.
