### PR TITLE
docs: release-ready README + release notes

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -1,6 +1,6 @@
 # Extending Nanostack
 
-Add your own skills that plug into Nanostack's workflow. Your skills save artifacts, read what other skills produced, and compose with `/think`, `/review`, and `/ship`. Multiple skills can compose into a domain workflow stack that gates `/ship` on its own evidence.
+Add your own skills that plug into Nanostack's workflow. Your skills save artifacts, read what other skills produced, and compose with `/think`, `/review`, and `/ship`. Multiple skills can compose into a custom workflow stack that gates `/ship` on its own evidence.
 
 ## Two starting points
 
@@ -17,6 +17,8 @@ Add your own skills that plug into Nanostack's workflow. Your skills save artifa
 > ```
 >
 > The first command scaffolds a working skill from the bundled template, registers it as a custom phase, and rewrites every helper path to be self-contained. It writes to the same store path the lifecycle scripts read from (your repo root's `.nanostack/`, or `$HOME/.nanostack/` outside git), so the skill is visible whether you invoke the tool from the project root or a subdirectory. The second runs a check that covers `SKILL.md` frontmatter shape, the frontmatter `name:` matches the directory, `agents/openai.yaml` has the required discovery keys, the `display_name` is consistent with the skill, `bash -n` on helpers, registration in config, no leaked example paths, and a `save-artifact` + `find-artifact` round-trip. Restart your agent and `/license-audit` is live.
+>
+> To scaffold from a different template instead of the bundled default, pass `--from <template-dir>` (for example `bin/create-skill.sh my-skill --from path/to/template`).
 >
 > The contract those tools enforce lives in [`reference/custom-stack-contract.md`](reference/custom-stack-contract.md). The 15-cell end-to-end harness that proves the journey works (including subdir-scaffold and no-git scaffold paths) is at [`ci/e2e-custom-stack-flows.sh`](ci/e2e-custom-stack-flows.sh).
 
@@ -80,17 +82,29 @@ Only include categories you want to override. Everything else uses nanostack def
 
 If the project already has dependencies (package.json, go.mod, etc.), /nano uses the existing stack regardless of any config.
 
-## Example: build a /deploy skill in 5 minutes
+## Advanced: skill anatomy by hand
 
-Let's create a skill that verifies a deploy after /ship creates the PR.
+Most skills should be scaffolded with `bin/create-skill.sh` (see [Two
+starting points](#two-starting-points) above). It generates the SKILL.md,
+registers the custom phase, writes the `agents/openai.yaml` discovery file,
+places the skill in the right store path, and passes
+`bin/check-custom-skill.sh`. This section walks the core pieces by hand
+(SKILL.md plus phase registration) so you understand how a skill reads and
+writes artifacts, using a `/deploy` skill that verifies a deploy after
+`/ship` creates the PR. It is illustrative, not a complete skill: a
+validated skill also needs the `agents/openai.yaml` file the scaffolder
+writes, so use `bin/create-skill.sh` for anything you intend to ship.
 
 ### 1. Create the skill file
 
+Custom skills live under the store's `skills/` directory (the scaffolder
+puts them there automatically):
+
 ```bash
-mkdir -p ~/.claude/skills/nanostack/deploy
+mkdir -p .nanostack/skills/deploy
 ```
 
-Create `deploy/SKILL.md`:
+Create `.nanostack/skills/deploy/SKILL.md`:
 
 ```yaml
 ---
@@ -423,3 +437,20 @@ Removes artifacts from a bad session. Works with custom phases.
 ```
 
 Register custom phases so `save-artifact.sh` accepts them. Without this, only the 6 core phases are accepted (think, plan, review, qa, security, ship).
+
+## Contributing: running the checks
+
+The CI suites are inventoried in [`ci/harnesses.json`](ci/harnesses.json)
+and run through one local runner. The full local gauntlet is:
+
+```bash
+ci/run-harness.sh --all          # run every registered suite
+ci/run-harness.sh --list         # see what exists
+ci/run-harness.sh --suite artifact-trust   # run one suite
+ci/run-harness.sh --tier pr      # just the always-on PR checks
+```
+
+`ci/check-harness-manifest.sh` keeps the inventory honest: it fails if a
+suite is unregistered, a path is missing, or a workflow job no longer runs
+the suite it claims. The heavier end-to-end suites are opt-in (they run via
+`workflow_dispatch`, not on every PR).

--- a/README.es.md
+++ b/README.es.md
@@ -278,7 +278,7 @@ Un equipo de marketing arma `/audience` y `/campaign`. Un equipo de datos arma `
 
 Walkthrough completo: [`EXTENDING.md`](EXTENDING.md).
 
-## Artifactos visuales
+## Artefactos visuales
 
 Cada artefacto de fase es JSON. El JSON es lo que leen los skills, lo que firma el hash de integridad y lo que agrega el sprint journal. Esa capa es la canónica.
 
@@ -299,7 +299,7 @@ El renderer es offline: cada página trae su propio CSS, el Content-Security-Pol
 
 `--interactive` suma botones de copia en `/plan` y `/review` (copy as prompt, copy as Markdown, copy as JSON patch). Usan solo el clipboard local. Sin escrituras a disco, sin llamadas de red, sin form submission.
 
-Los artifactos visuales son una capa opcional de inspección. Nada depende de ellos: borrar `.nanostack/visual/` no cambia el comportamiento de ningún skill ni el estado del sprint. El contrato vive en `reference/visual-artifact-contract.md`.
+Los artefactos visuales son una capa opcional de inspección. Nada depende de ellos: borrar `.nanostack/visual/` no cambia el comportamiento de ningún skill ni el estado del sprint. El contrato vive en `reference/visual-artifact-contract.md`.
 
 ## Privacidad
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   <a href="#the-sprint">The Sprint</a> &middot;
   <a href="#know-how">Know-how</a> &middot;
   <a href="#build-on-nanostack">Extend</a> &middot;
+  <a href="RELEASE_NOTES.md">Release notes</a> &middot;
   <a href="README.es.md">Español</a>
 </p>
 
@@ -37,6 +38,8 @@
 Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). Nanostack ships 13 built-in skills, a seven-phase default sprint, and a framework for adding your own skills or workflow stacks. No Nanostack cloud. No build step.
 
 Verified adapters today: **Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI**. The skill files are plain text, so other agents may load them, but only those five have a verified adapter and capability declaration in [`adapters/`](adapters/).
+
+What changed in the latest release (custom workflow stacks, visual artifacts, stronger safety contracts): see [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
 
 ## What is Nanostack?
 
@@ -114,6 +117,7 @@ A detailed per-host matrix (Bash guard, Write/Edit guard, phase gate) lives furt
 | Already shipping with AI agents | Install Nanostack, then start with `/think` or `/feature` |
 | Evaluating safety | Read [Guard](#guard) and the [host enforcement matrix](#what-enforces-on-which-agent) |
 | Building your own workflow | Start with [`EXTENDING.md`](EXTENDING.md) and [`compliance-release`](examples/custom-stack-template/compliance-release/) |
+| Inspecting what the agent did | Render any phase as local HTML with [visual artifacts](#visual-artifacts) (`bin/render-artifact.sh`) |
 
 ## Try it safely first
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,50 @@
+# Nanostack Release Notes
+
+The detailed "what changed" surface for Nanostack. The [README](README.md)
+stays the stable, user-facing overview; this file records what each release
+adds and why it matters. Newest first.
+
+## 2026-05-29 (changes since v1.0.0)
+
+### What changed
+
+- **Custom workflow stacks.** Build a domain-specific workflow on top of
+  Nanostack, not just a one-off skill. `bin/create-skill.sh` scaffolds a
+  skill, `.nanostack/config.json` registers it (`custom_phases`,
+  `phase_graph`), and `bin/check-custom-skill.sh` validates it. The
+  `compliance-release` example shows three skills composing into one release
+  gate before `/ship`.
+- **Visual artifacts.** `bin/render-artifact.sh` turns the JSON a phase
+  saved into a local HTML view: plans, reviews, security and QA output,
+  sprint journals, and workflow-stack graphs. The HTML is offline (its own
+  CSS, no network), `--strict` refuses unverifiable evidence, and
+  `--interactive` adds copy-only buttons on `/plan` and `/review`. The JSON
+  stays canonical; the HTML is a layer you can delete and regenerate.
+- **Stronger safety contracts.** Read-only phases now block mutations
+  through Write/Edit/MultiEdit, not just Bash, so `/review`, `/security`, and
+  `/qa` are safe to run as one parallel batch. Release gates require
+  trusted artifacts (integrity-checked, filename-dated), and README
+  enforcement levels are locked to the adapter JSON and CI evidence.
+- **Cleaner contributor harness.** The CI test suites share one core
+  library and fixtures, an inventory (`ci/harnesses.json`) that fails when it
+  drifts from the real scripts, and a single local runner. The big visual
+  suite is split into reviewable sections.
+
+### What this means in practice
+
+- Easier to inspect what the agent actually did, in a browser.
+- Easier to extend Nanostack into a real, domain-specific workflow.
+- Safer parallel review/security/QA phases.
+- More reliable release gates that fail closed on tampered evidence.
+- Easier contributor debugging when CI fails, via one runner.
+
+### Honest scope
+
+Hard enforcement is host-dependent. Claude Code has the strongest
+continuous hook coverage; the other verified adapters (Cursor, OpenAI
+Codex, OpenCode, Gemini CLI) run the same workflow as guided instructions
+unless their `adapters/<host>.json` proves otherwise. Nanostack has no
+cloud or backend; everything is local under `.nanostack/`. The heavier
+runtime end-to-end suites run in the opt-in E2E workflow
+(`workflow_dispatch`), not on every PR; lighter contract checks, including
+the visual-artifact contract, do run on every PR.


### PR DESCRIPTION
## Summary

Gets the repo docs ready for the next release. The README stays a stable,
one-screen overview; the detailed "what changed" now lives in a dedicated
release-notes file so the README doesn't turn into a changelog.

Docs only. No runtime features, no behavior changes.

## What changed

- **New `RELEASE_NOTES.md`.** A newest-first release surface that leads with
  what improves for users (inspect what the agent did, extend into a real
  workflow, safer parallel phases, more reliable release gates) and keeps the
  technical proof below. It ends with an honest scope note: enforcement is
  host-dependent, there is no Nanostack cloud, and the heavier E2E suites are
  opt-in. The README links to it.
- **README.md.** Added a "Release notes" nav link and a one-line "what
  changed" pointer, plus an "Inspecting what the agent did" row in *Choose
  your path* so visual artifacts are discoverable. The adapter list, sprint
  order, and caveat were already current.
- **README.es.md.** Fixed the stale term `Artifactos visuales` ->
  `Artefactos visuales` (heading and body) so the Spanish page matches the
  rest of its own wording.
- **EXTENDING.md.** The recommended path (`bin/create-skill.sh`) stays up
  top, now with a `--from` note and the exact "custom workflow stack"
  wording. The old hand-written `/deploy` walkthrough is demoted to an
  advanced illustrative section. Its legacy `~/.claude/skills/...` path is
  corrected to the real `.nanostack/skills/` store path, and it now says
  plainly that a shippable skill also needs the `agents/openai.yaml` written
  by the scaffolder. A short *Contributing: running the checks* section
  documents `ci/run-harness.sh --all`.

## What did not change

- No enforcement, privacy, or continuous-E2E claims were strengthened; the
  honest caveats stay.
- llms.txt and AGENTS.md already matched the README (5 adapters, custom
  stacks, visual artifacts), so they were left alone.

## Validation

- Existing doc locks still pass (`check-readme-public-copy`,
  `check-readme-narrative-locks`, `check-visual-artifact-public-copy`).
- No em-dashes; no forbidden/stale tokens; required tokens present; internal
  links/anchors resolve; codex review clean.

Release prep PR 1 of 3 (README + release notes). PR 2 is the site refresh,
PR 3 is content locks + publication.
