### PR TITLE
docs: expand v1.1.0 release notes to full scope

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,47 +6,94 @@ adds and why it matters. Newest first.
 
 ## v1.1.0 (2026-05-29)
 
-Changes since v1.0.0.
+The largest release since v1.0.0: 76 merged PRs. It grows Nanostack from a
+fixed sprint into a composable framework, adds a way to read any phase as
+local HTML, and hardens the safety and CI contracts. Everything stays local.
 
-### What changed
+### Custom workflow stacks
 
-- **Custom workflow stacks.** Build a domain-specific workflow on top of
-  Nanostack, not just a one-off skill. `bin/create-skill.sh` scaffolds a
-  skill, `.nanostack/config.json` registers it (`custom_phases`,
-  `phase_graph`), and `bin/check-custom-skill.sh` validates it. The
-  `compliance-release` example shows three skills composing into one release
-  gate before `/ship`.
-- **Visual artifacts.** `bin/render-artifact.sh` turns the JSON a phase
-  saved into a local HTML view: plans, reviews, security and QA output,
-  sprint journals, and workflow-stack graphs. The HTML is offline (its own
-  CSS, no network), `--strict` refuses unverifiable evidence, and
-  `--interactive` adds copy-only buttons on `/plan` and `/review`. The JSON
-  stays canonical; the HTML is a layer you can delete and regenerate.
-- **Stronger safety contracts.** Read-only phases now block mutations
-  through Write/Edit/MultiEdit, not just Bash, so `/review`, `/security`, and
-  `/qa` are safe to run as one parallel batch. Release gates require
-  trusted artifacts (integrity-checked, filename-dated), and README
-  enforcement levels are locked to the adapter JSON and CI evidence.
-- **Cleaner contributor harness.** The CI test suites share one core
-  library and fixtures, an inventory (`ci/harnesses.json`) that fails when it
-  drifts from the real scripts, and a single local runner. The big visual
-  suite is split into reviewable sections.
+Nanostack is no longer only the built-in sprint. You can declare your own
+phases and compose them into a domain-specific workflow with the same
+lifecycle support as the default sprint.
 
-### What this means in practice
+- `bin/create-skill.sh` scaffolds a phase skill (`--from` starts from a
+  template).
+- `.nanostack/config.json` registers phases (`custom_phases`, `phase_graph`).
+  A shared phase registry drives the conductor, guard, session, resolver, and
+  next-step, so a custom workflow stack gets graph-aware progression,
+  concurrency enforcement, artifact trust, schema validation, and routing
+  through `phase_context`.
+- `bin/check-custom-skill.sh` validates a stack. The `compliance-release`
+  example composes `/license-audit`, `/privacy-check`, and
+  `/release-readiness` into one gate before `/ship`, with static, smoke, and
+  runtime end-to-end coverage.
 
-- Easier to inspect what the agent actually did, in a browser.
-- Easier to extend Nanostack into a real, domain-specific workflow.
-- Safer parallel review/security/QA phases.
-- More reliable release gates that fail closed on tampered evidence.
-- Easier contributor debugging when CI fails, via one runner.
+### Visual artifacts
+
+- `bin/render-artifact.sh` renders any phase artifact, sprint journal, or
+  workflow-stack graph as an offline local HTML view (its own CSS, no
+  network).
+- `--strict` refuses unverifiable evidence; `--interactive` adds copy-only
+  buttons (prompt / Markdown / JSON patch) on `/plan` and `/review`, with no
+  writes and no network calls.
+- JSON stays canonical; the HTML is a derived view you can delete and
+  regenerate. Registered custom phases render too.
+
+### Architecture and safety hardening
+
+- Read-only phases (`/review`, `/security`, `/qa`) now block file mutations
+  through Write/Edit/MultiEdit, not just Bash, so they are safe to run as one
+  parallel batch.
+- A shared artifact-trust primitive adds SHA-256 integrity to saved
+  artifacts; release gates require trusted (integrity-checked,
+  filename-dated) artifacts and fail closed on tampered evidence.
+- Per-phase structured artifact schemas, a graph-aware session lifecycle, and
+  a `phase_context` routing contract for custom skills.
+- Guard blocks credential JSON at write time and on Bash. Adapter enforcement
+  claims are locked to named CI evidence so the docs cannot overclaim.
+
+### /think and onboarding
+
+- `/think` vNext: a structured think artifact, session-first flow, an
+  autopilot minimum-viable-brief gate, quiet preset loading, and search modes
+  with a privacy boundary (local_only / private / public).
+- Guided Archetypes: `/think` detects the kind of work (founder validation,
+  CLI tooling, API backend, landing) and routes the matching lens.
+- `/nano-run` vNext: a schema-enforced setup artifact, a session-first
+  rewrite, and a legacy detector that refuses silent migration.
+
+### Examples library
+
+- A normalized examples index with four starter apps (todo, CLI notes, API
+  healthcheck, static landing) plus the `compliance-release` custom workflow
+  stack, each tied to the delivery workflow and covered by per-archetype
+  sprint end-to-end runs.
+
+### Contributor experience
+
+- The CI harness subsystem shares one core library and fixtures, an inventory
+  (`ci/harnesses.json`) that fails when it drifts from the real scripts, and a
+  single local runner (`ci/run-harness.sh --all`). The large visual suite is
+  split into reviewable sections, and long lint contracts are extracted into
+  reusable checks.
+- Reliability fixes: real user-flow end-to-end coverage, a macOS write-guard
+  symlink bypass closed, and a delivery-matrix harness for per-adapter
+  coverage.
 
 ### Honest scope
 
-Hard enforcement is host-dependent. Claude Code has the strongest
-continuous hook coverage; the other verified adapters (Cursor,
-OpenAI Codex, OpenCode, Gemini CLI) run the same workflow as guided
-instructions unless their `adapters/<host>.json` proves otherwise.
-Nanostack has no cloud or backend; everything is local under
-`.nanostack/`. The heavier runtime end-to-end suites run in the opt-in
-E2E workflow (`workflow_dispatch`), not on every PR; lighter contract
-checks, including the visual-artifact contract, do run on every PR.
+Hard enforcement is host-dependent. Claude Code has the strongest continuous
+hook coverage; the other verified adapters (Cursor, OpenAI Codex, OpenCode,
+Gemini CLI) run the same workflow as guided instructions unless their
+`adapters/<host>.json` proves otherwise. Nanostack has no cloud or backend;
+everything is local under `.nanostack/`. The heavier runtime end-to-end suites
+run in the opt-in E2E workflow (`workflow_dispatch`), not on every PR; lighter
+contract checks, including the visual-artifact contract, do run on every PR.
+
+### Install
+
+```
+npx create-nanostack
+```
+
+Full changelog: https://github.com/garagon/nanostack/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
Expands the v1.1.0 section of `RELEASE_NOTES.md` so it matches the GitHub release.

The section previously listed only the final rounds. It now covers everything shipped since v1.0.0 (76 PRs), grouped by theme: the custom workflow stack framework, visual artifacts, architecture and safety hardening, `/think` and `/nano-run` vNext, the examples library, and the contributor harness. Benefit-first, with the honest host-dependent scope and a full changelog link.

## Validation

Passes `ci/check-release-docs-locks.sh` (version heading, required tokens, no forbidden claims), no em-dashes, and matches the published v1.1.0 release body.
