### PR TITLE
ci: make graph-aware session wording test deterministic

### DIFF
--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -711,11 +711,12 @@ rc=$?
 set -e
 assert_eq "ship-less graph blocks commit (rc 1, legacy fallback)" "1" "$rc"
 
-# Cell 10: default sprint user_message remains exactly the historical
-# wording. No regression for built-in flows.
-echo "[10] default sprint user_message is unchanged"
+# Cell 10: default sprint professional user_message remains exactly
+# the historical wording. Pin the profile explicitly so this cell is
+# deterministic in clean containers where no enforcing host is present.
+echo "[10] default sprint professional user_message is unchanged"
 new_project "cell7-default-msg"
-"$SESSION_SH" init development >/dev/null
+"$SESSION_SH" init development --profile professional >/dev/null
 for ph in think plan; do
   "$SESSION_SH" phase-start "$ph" >/dev/null
   "$SESSION_SH" phase-complete "$ph" >/dev/null


### PR DESCRIPTION
Fixes a non-deterministic harness assertion found during Docker deep QA. Harness-only; no product behavior changes.

## What changed

Cell 10 of `ci/e2e-graph-aware-session.sh` checked the default sprint `user_message` against the historical professional wording, but called `session.sh init development` without pinning a profile. In a clean container with no enforcing host, `init` correctly defaults to guided wording, so the assertion failed on the wording difference rather than on any product behavior.

The fix pins `--profile professional` on that init call, so the cell is deterministic across local, dev, CI, and Docker.

## Validation

`bash -n` clean. The graph-aware-session suite passes via `ci/run-harness.sh --suite graph-aware-session` (61 checks). Harness manifest consistency green. Originally found in Docker deep QA: PR-tier and full opt-in harness pass after this fix, and the manual end-to-end smoke (scaffold `--from`, validate, trusted artifact save, `--require-integrity` resolve, `--strict --interactive` render, stack DAG, read-phase Write/Edit guard) passed.
