### PR TITLE
safety: keep cleanup and archive helpers inside their own folders

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2178,6 +2178,19 @@ jobs:
       - name: Run release-surface doc locks
         run: ci/check-release-docs-locks.sh
 
+  helper-path-containment:
+    name: Helper scripts stay within their folders
+    runs-on: ubuntu-latest
+    # A few helpers build a path from a value they do not fully control (a
+    # session_id from session.json, a conductor phase argument, the discard
+    # selectors, the screenshot name). This job confirms each helper keeps its
+    # writes and deletes inside the folder it manages, and still accepts
+    # ordinary inputs.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run helper path-containment check
+        run: ci/check-helper-path-containment.sh
+
   examples-library:
     name: Examples library contract
     runs-on: ubuntu-latest

--- a/bin/discard-sprint.sh
+++ b/bin/discard-sprint.sh
@@ -32,10 +32,33 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# If --phase given, only clean that phase
+# If --phase given, only clean that phase. Validate it against the registered
+# phases first so a traversal or unknown selector cannot redirect the delete
+# loop at "$STORE/$phase" outside the store.
 if [ -n "$PHASE" ]; then
+  # A phase is a single token. Reject whitespace, newlines, slashes, or ".."
+  # first so a multiline value cannot slip a second word past the membership
+  # check below (grep treats newlines as separate lines) and then split into a
+  # path in the delete loop.
+  case "$PHASE" in
+    *[[:space:]]*|*/*|*..*)
+      echo "ERROR: invalid phase '$PHASE' (expected a single phase name)" >&2
+      exit 1
+      ;;
+  esac
+  if ! printf '%s\n' $PHASES | grep -qxF -- "$PHASE"; then
+    echo "ERROR: unknown phase '$PHASE' (not a registered phase)" >&2
+    exit 1
+  fi
   PHASES="$PHASE"
 fi
+
+# A date selector must be an exact YYYY-MM-DD so it cannot widen the filename
+# match (e.g. "*") or carry path characters into the prefix.
+case "$DATE" in
+  [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+  *) echo "ERROR: --date must be YYYY-MM-DD" >&2; exit 1 ;;
+esac
 
 # Convert date to prefix for matching artifact filenames (YYYYMMDD)
 DATE_PREFIX=$(echo "$DATE" | tr -d '-')

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -21,6 +21,18 @@ PROJECT="$(pwd)"
 PROJECT_NAME=$(basename "$PROJECT")
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+# Reduce a session_id read from session.json to a safe filename segment.
+# session.json is mutable local state; a poisoned session_id like
+# "../../tmp/evil" would otherwise redirect the archive mv/write outside the
+# sessions directory. Strip any path components and keep only filename-safe
+# characters; fall back to "unknown" if nothing safe remains.
+nano_safe_id() {
+  local id="${1##*/}"
+  id=$(printf '%s' "$id" | tr -cd 'A-Za-z0-9._-')
+  case "$id" in ''|.|..) id="unknown" ;; esac
+  printf '%s' "$id"
+}
+
 # ─── host + capability detection ────────────────────────────
 # Used by cmd_init to snapshot what the running host can actually
 # enforce. Resolution order: explicit flag > NANOSTACK_HOST env >
@@ -170,6 +182,7 @@ cmd_init() {
   if [ -f "$SESSION_FILE" ]; then
     local old_id
     old_id=$(jq -r '.session_id // "unknown"' "$SESSION_FILE")
+    old_id=$(nano_safe_id "$old_id")
     local archive_dir="$NANOSTACK_STORE/sessions"
     mkdir -p "$archive_dir"
     mv "$SESSION_FILE" "$archive_dir/${old_id}.json"
@@ -651,6 +664,7 @@ cmd_archive() {
 
   local session_id
   session_id=$(jq -r '.session_id' "$SESSION_FILE")
+  session_id=$(nano_safe_id "$session_id")
   local archive_dir="$NANOSTACK_STORE/sessions"
   mkdir -p "$archive_dir"
 

--- a/ci/check-helper-path-containment.sh
+++ b/ci/check-helper-path-containment.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# check-helper-path-containment.sh — helper scripts stay within their folders.
+#
+# A few helpers build a filesystem path from a value they do not fully control:
+# a session_id read from session.json, a phase argument passed to the conductor,
+# the --phase / --date selectors of discard-sprint, and the screenshot name.
+# This check confirms each helper keeps its writes and deletes inside the folder
+# it manages, and still accepts ordinary inputs. Each negative case is set up so
+# it fails specifically when the guard is missing, not for an unrelated reason.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export NANOSTACK_STORE="$(mktemp -d)/store"
+mkdir -p "$NANOSTACK_STORE"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+miss() { printf '  FAIL %s\n' "$1"; fail=1; }
+
+# ── session.sh archive ──────────────────────────────────────────────────────
+# A session_id of "../escaped" would, without sanitizing, send the archive to
+# $STORE/escaped.json (one level above the sessions/ folder). After the fix it
+# lands inside sessions/ as a plain name.
+printf '{"session_id":"../escaped","status":"active"}\n' > "$NANOSTACK_STORE/session.json"
+bash "$ROOT/bin/session.sh" archive >/dev/null 2>&1
+if [ -e "$NANOSTACK_STORE/escaped.json" ]; then
+  miss "session.sh archive escaped sessions/ (wrote $NANOSTACK_STORE/escaped.json)"
+elif [ -e "$NANOSTACK_STORE/sessions/escaped.json" ]; then
+  pass "session.sh archive stays in sessions/"
+else
+  miss "session.sh archive produced no archive file"
+fi
+
+# ── conductor sprint.sh ─────────────────────────────────────────────────────
+# Start a real sprint so find_sprint succeeds; then a path-like phase must be
+# refused by the guard (specific message), while a real phase is accepted.
+( cd "$ROOT" && bash conductor/bin/sprint.sh start >/dev/null 2>&1 ) || true
+for cmd in abort unstuck; do
+  out=$(cd "$ROOT" && bash conductor/bin/sprint.sh "$cmd" "../../escaped" 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi "invalid phase"; then
+    pass "sprint.sh $cmd refuses a path-like phase"
+  else
+    miss "sprint.sh $cmd did not refuse a path-like phase (rc=$rc)"
+  fi
+done
+if ( cd "$ROOT" && bash conductor/bin/sprint.sh abort "review" >/dev/null 2>&1 ); then
+  pass "sprint.sh abort still accepts a real phase"
+else
+  miss "sprint.sh abort rejected a real phase"
+fi
+
+# ── discard-sprint.sh ───────────────────────────────────────────────────────
+# A path-like phase must be refused. Quote each argument so the wildcard date
+# below reaches discard-sprint literally (an unquoted "*" would glob to repo
+# files first and be rejected for the wrong reason).
+if ( cd "$ROOT" && bash bin/discard-sprint.sh --phase "../../escaped" --dry-run >/dev/null 2>&1 ); then
+  miss "discard-sprint accepted '--phase ../../escaped'"
+else
+  pass "discard-sprint refuses '--phase ../../escaped'"
+fi
+if ( cd "$ROOT" && bash bin/discard-sprint.sh --date "*" --dry-run >/dev/null 2>&1 ); then
+  miss "discard-sprint accepted a wildcard date"
+else
+  pass "discard-sprint refuses a wildcard date"
+fi
+# A multiline phase must be refused before it can split into a path.
+if ( cd "$ROOT" && bash bin/discard-sprint.sh --phase "$(printf 'review\n../outside')" --dry-run >/dev/null 2>&1 ); then
+  miss "discard-sprint accepted a multiline phase"
+else
+  pass "discard-sprint refuses a multiline phase"
+fi
+if ( cd "$ROOT" && bash bin/discard-sprint.sh --phase review --dry-run >/dev/null 2>&1 ); then
+  pass "discard-sprint still accepts a registered phase"
+else
+  miss "discard-sprint rejected a registered phase"
+fi
+if ( cd "$ROOT" && bash bin/discard-sprint.sh --date 2026-03-24 --dry-run >/dev/null 2>&1 ); then
+  pass "discard-sprint still accepts a YYYY-MM-DD date"
+else
+  miss "discard-sprint rejected a valid date"
+fi
+
+# ── screenshot.sh ───────────────────────────────────────────────────────────
+# A path-like name must be refused by the guard message, before the browser is
+# launched, so the result cannot land outside results/.
+out=$(bash "$ROOT/qa/bin/screenshot.sh" "../../escaped" "http://localhost" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi "invalid screenshot name"; then
+  pass "screenshot.sh refuses a path-like name"
+else
+  miss "screenshot.sh did not refuse a path-like name (rc=$rc)"
+fi
+
+# Clean up any sprint state this check created under the temp store.
+rm -rf "$NANOSTACK_STORE/conductor" 2>/dev/null || true
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-helper-path-containment: FAIL"
+  exit 1
+fi
+echo "check-helper-path-containment: OK"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -291,6 +291,18 @@
       "job": "release-docs-locks"
     },
     {
+      "id": "check-helper-path-containment",
+      "path": "ci/check-helper-path-containment.sh",
+      "kind": "static-contract",
+      "tier": "pr",
+      "surface": ["session", "conductor", "discard-sprint", "screenshot"],
+      "deps": ["bash", "jq", "git"],
+      "expected_checks": 10,
+      "timeout_minutes": 2,
+      "workflow": ".github/workflows/lint.yml",
+      "job": "helper-path-containment"
+    },
+    {
       "id": "check-visual-artifact-public-copy",
       "path": "ci/check-visual-artifact-public-copy.sh",
       "kind": "static-contract",

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -30,6 +30,20 @@ else
 fi
 PROJECT_HASH=$(printf '%s' "$PROJECT" | nano_sha256 | cut -c1-12)
 
+# Reject a phase argument that is not a single safe path segment before it is
+# used to build a sprint path. claim/complete/abort/unstuck join the phase into
+# "$sprint_dir/$phase" and remove lock directories with rm -rf, so a phase like
+# "../../foo" would otherwise let cleanup escape the sprint directory. A valid
+# phase is one path segment: no slash, no "..", no leading dash, non-empty.
+require_safe_phase() {
+  case "$1" in
+    ''|-*|*/*|*..*)
+      echo "ERROR: invalid phase name '$1' (expected a single phase segment)" >&2
+      exit 1
+      ;;
+  esac
+}
+
 # Default phases and dependency graph. Node order under review/qa/
 # security and ship.depends_on match bin/lib/phases.sh's default
 # graph so a conductor sprint that mirrors into session.json does
@@ -236,6 +250,7 @@ cmd_start() {
 # ─── claim ───────────────────────────────────────────────────
 cmd_claim() {
   local phase="${1:?Usage: sprint.sh claim <phase> [--agent <name>]}"
+  require_safe_phase "$phase"
   local agent="${3:-$(detect_agent)}"
   local sprint_dir
   sprint_dir=$(find_sprint) || { echo "ERROR: no active sprint" >&2; exit 1; }
@@ -310,6 +325,7 @@ cmd_claim() {
 # ─── complete ────────────────────────────────────────────────
 cmd_complete() {
   local phase="${1:?Usage: sprint.sh complete <phase> [--artifact <path>]}"
+  require_safe_phase "$phase"
   local artifact="${3:-}"
   local agent="$(detect_agent)"
   local sprint_dir
@@ -353,6 +369,7 @@ cmd_complete() {
 # ─── abort ───────────────────────────────────────────────────
 cmd_abort() {
   local phase="${1:?Usage: sprint.sh abort <phase>}"
+  require_safe_phase "$phase"
   local sprint_dir
   sprint_dir=$(find_sprint) || { echo "ERROR: no active sprint" >&2; exit 1; }
 
@@ -435,6 +452,7 @@ cmd_next() {
 # release a lock with a live PID; required when stdin is not a TTY.
 cmd_unstuck() {
   local phase="${1:?Usage: sprint.sh unstuck <phase> [--force]}"
+  require_safe_phase "$phase"
   local force=false
   [ "${2:-}" = "--force" ] && force=true
 

--- a/qa/bin/screenshot.sh
+++ b/qa/bin/screenshot.sh
@@ -9,6 +9,15 @@ URL="${2:?Usage: screenshot.sh <name> <url> [width] [height]}"
 WIDTH="${3:-1280}"
 HEIGHT="${4:-720}"
 
+# The name becomes a filename, so keep it to a single plain basename. This
+# keeps the output inside the results directory.
+case "$NAME" in
+  ''|-*|*/*|*..*)
+    echo "ERROR: invalid screenshot name '$NAME' (use a plain file name)" >&2
+    exit 1
+    ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="${SCRIPT_DIR}/../results"
 mkdir -p "$RESULTS_DIR"


### PR DESCRIPTION
A few helpers build a file path from a value they do not fully control. This keeps each one writing and deleting only inside the folder it manages, while ordinary inputs keep working. No behavior change for normal use.

## What changed

- **Session archive:** a `session_id` read from `session.json` is reduced to a plain file name before the archive moves or writes it, so it always lands in the `sessions/` folder.
- **Conductor (`sprint.sh`):** `claim`, `complete`, `abort`, and `unstuck` require the phase argument to be a single phase name before building a sprint path or removing a lock directory.
- **`discard-sprint`:** `--phase` must be a registered phase and `--date` must be an exact `YYYY-MM-DD`, so cleanup stays scoped to the selected sprint artifacts.
- **QA `screenshot.sh`:** the name must be a plain file name, keeping the PNG inside the `results/` folder.

## Validation

New `ci/check-helper-path-containment.sh` (10 checks) confirms each helper refuses an out-of-folder input for the right reason and still accepts ordinary ones; registered in the harness manifest and wired as a lint job (same job-name and tier conventions as the existing checks, manifest stays consistent). The existing session and conductor harnesses (`graph-aware-session`, `concurrency-parity`, `custom-stack-flows`) still pass.
