### PR TITLE
safety: have gates and context loaders use verified evidence

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2191,6 +2191,18 @@ jobs:
       - name: Run helper path-containment check
         run: ci/check-helper-path-containment.sh
 
+  trusted-evidence:
+    name: Gates and context loaders use verified artifacts
+    runs-on: ubuntu-latest
+    # The /feature commit gate, restore-context, and conductor complete all
+    # consume phase artifacts. This job confirms a tampered artifact is treated
+    # as missing by the gate, skipped by the context loader, and that conductor
+    # only links a real in-scope JSON file, while intact evidence keeps working.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run trusted-evidence check
+        run: ci/check-trusted-evidence.sh
+
   examples-library:
     name: Examples library contract
     runs-on: ubuntu-latest

--- a/bin/restore-context.sh
+++ b/bin/restore-context.sh
@@ -39,7 +39,7 @@ CHECKPOINT_ONLY=false
 if [ "$TOKEN_BUDGET" -gt 0 ]; then
   TOTAL_ESTIMATED=0
   for phase in $PHASES; do
-    ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" 2>/dev/null) || continue
+    ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" --verify --no-session-sync 2>/dev/null) || continue
     # Read estimated_tokens from the skill's SKILL.md, fall back to artifact size estimate
     NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
     SKILL_MD=""
@@ -64,8 +64,13 @@ fi
 FOUND=0
 JSON_ARRAY="["
 
+# Restored content is fed back into agent context, so pass --verify: a phase
+# artifact whose recomputed hash does not match its .integrity field is skipped
+# instead of printed. Legacy artifacts saved before integrity existed (no
+# .integrity field) are still read for human and context use; this is a context
+# loader, not a release gate, so it does not require --require-integrity.
 for phase in $PHASES; do
-  ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" 2>/dev/null) || continue
+  ARTIFACT=$("$SCRIPT_DIR/find-artifact.sh" "$phase" "$MAX_AGE" --verify --no-session-sync 2>/dev/null) || continue
 
   # Check if artifact has a context_checkpoint
   HAS_CHECKPOINT=$(jq -e '.context_checkpoint.summary' "$ARTIFACT" >/dev/null 2>&1 && echo "yes" || echo "no")

--- a/ci/check-trusted-evidence.sh
+++ b/ci/check-trusted-evidence.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-trusted-evidence.sh — gates and context loaders use verified artifacts.
+#
+# Phase artifacts carry a SHA-256 .integrity field. This check confirms that:
+#  - the /feature commit gate treats a tampered artifact as missing, and still
+#    passes when the evidence is intact;
+#  - restore-context skips a tampered artifact and keeps a valid one;
+#  - conductor "complete --artifact" only links a real JSON file that lives
+#    inside the store or project (no symlink, no non-JSON, no outside path).
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+# Keep the run hermetic: point HOME at the temp workspace so a developer's
+# global ~/.nanostack/config.json (with a custom phase_graph) cannot change the
+# default sprint phases this check claims and completes.
+export HOME="$WORK"
+cd "$WORK"
+git init -q >/dev/null 2>&1
+git config user.email t@example.com >/dev/null 2>&1
+git config user.name test >/dev/null 2>&1
+export NANOSTACK_STORE="$WORK/.nanostack"
+mkdir -p "$NANOSTACK_STORE"
+echo "console.log(1)" > app.js
+git add -A >/dev/null 2>&1
+git commit -qm init >/dev/null 2>&1
+PROJECT="$WORK"
+
+fail=0
+ck() { if [ "$1" = "$2" ]; then printf '  ok   %s\n' "$3"; else printf '  FAIL %s (got %s, want %s)\n' "$3" "$2" "$1"; fail=1; fi; }
+hash_of() { (sha256sum 2>/dev/null || shasum -a 256) | cut -d' ' -f1; }
+
+# Use a current artifact filename and timestamp (matching how save-artifact.sh
+# names files) so the gate counts the evidence on its own merits, not because of
+# an mtime nudge on an old fixed name.
+TS=$(date -u +%Y%m%d-%H%M%S)
+ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Write a signed phase artifact (integrity over canonical JSON without .integrity).
+sign() {
+  local phase="$1" dir="$NANOSTACK_STORE/$1" f h
+  mkdir -p "$dir"
+  f="$dir/$TS.json"
+  jq -nc --arg p "$PROJECT" --arg ph "$phase" --arg ts "$ISO" \
+    '{phase:$ph, project:$p, timestamp:$ts, summary:{blocking:0}, context_checkpoint:{summary:("did "+$ph)}}' > "$f"
+  h=$(jq -Sc 'del(.integrity)' "$f" | hash_of)
+  jq --arg h "$h" '.integrity=$h' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+}
+tamper() { local f="$NANOSTACK_STORE/$1/$TS.json"; jq '.summary.blocking=99' "$f" > "$f.t" && mv "$f.t" "$f"; }
+
+for p in plan review security qa; do sign "$p"; done
+
+# Already in $WORK (cd above). Call helpers directly so the conductor's
+# per-process agent identity (derived from the parent shell) stays the same
+# across claim and complete; wrapping each call in its own subshell would make
+# claim and complete look like different agents.
+
+# /feature commit gate: passes on intact evidence, blocks on tampered evidence.
+"$ROOT/feature/bin/enforce-sprint.sh" "git commit -m x" >/dev/null 2>&1
+ck 0 $? "feature gate passes when all evidence is intact"
+tamper review
+"$ROOT/feature/bin/enforce-sprint.sh" "git commit -m x" >/dev/null 2>&1
+ck 1 $? "feature gate blocks a commit when an artifact is tampered"
+
+# restore-context skips the tampered artifact, keeps the valid ones.
+OUT=$("$ROOT/bin/restore-context.sh" 2>/dev/null)
+if printf '%s' "$OUT" | grep -q 'did review'; then
+  ck reject keep "restore-context omits the tampered review artifact"
+else
+  ck reject reject "restore-context omits the tampered review artifact"
+fi
+if printf '%s' "$OUT" | grep -q 'did plan'; then
+  ck keep keep "restore-context keeps an intact artifact"
+else
+  ck keep reject "restore-context keeps an intact artifact"
+fi
+
+# conductor complete --artifact only links a real in-scope JSON file.
+"$ROOT/conductor/bin/sprint.sh" start >/dev/null 2>&1
+"$ROOT/conductor/bin/sprint.sh" claim think >/dev/null 2>&1
+echo '{"ok":true}' > "$NANOSTACK_STORE/good.json"
+"$ROOT/conductor/bin/sprint.sh" complete think --artifact "$NANOSTACK_STORE/good.json" >/dev/null 2>&1
+ck 0 $? "complete accepts a real JSON file inside the store"
+"$ROOT/conductor/bin/sprint.sh" claim plan >/dev/null 2>&1
+ln -s /etc/hosts "$NANOSTACK_STORE/link.json"
+"$ROOT/conductor/bin/sprint.sh" complete plan --artifact "$NANOSTACK_STORE/link.json" >/dev/null 2>&1
+ck 1 $? "complete refuses a symlink artifact"
+# A rejected artifact must not mark the phase done (which would unblock
+# dependent phases without trusted evidence).
+if find "$NANOSTACK_STORE/conductor" -path '*/plan/done' 2>/dev/null | grep -q .; then
+  ck nodone done "complete leaves the phase not-done when the artifact is rejected"
+else
+  ck nodone nodone "complete leaves the phase not-done when the artifact is rejected"
+fi
+echo "not json" > "$NANOSTACK_STORE/bad.json"
+"$ROOT/conductor/bin/sprint.sh" complete plan --artifact "$NANOSTACK_STORE/bad.json" >/dev/null 2>&1
+ck 1 $? "complete refuses a non-JSON artifact"
+OUTSIDE="$(mktemp)"; echo '{"x":1}' > "$OUTSIDE"
+"$ROOT/conductor/bin/sprint.sh" complete plan --artifact "$OUTSIDE" >/dev/null 2>&1
+ck 1 $? "complete refuses a file outside the store or project"
+# A path that lexically starts under the store but resolves outside it (here via
+# a symlinked directory in the path) must also be refused: the prefix check runs
+# on the canonical path, not the lexical one.
+EXT="$(mktemp -d)"; echo '{"x":1}' > "$EXT/x.json"
+ln -s "$EXT" "$NANOSTACK_STORE/linkdir"
+"$ROOT/conductor/bin/sprint.sh" complete plan --artifact "$NANOSTACK_STORE/linkdir/x.json" >/dev/null 2>&1
+ck 1 $? "complete refuses a path that resolves outside via a symlinked directory"
+# A real JSON file under the project (but not under the store) is also accepted,
+# so the "store or project" boundary is covered on both sides.
+echo '{"ok":true}' > "$WORK/project-artifact.json"
+"$ROOT/conductor/bin/sprint.sh" complete plan --artifact "$WORK/project-artifact.json" >/dev/null 2>&1
+ck 0 $? "complete accepts a real JSON file under the project"
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-trusted-evidence: FAIL"
+  exit 1
+fi
+echo "check-trusted-evidence: OK"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -303,6 +303,18 @@
       "job": "helper-path-containment"
     },
     {
+      "id": "check-trusted-evidence",
+      "path": "ci/check-trusted-evidence.sh",
+      "kind": "static-contract",
+      "tier": "pr",
+      "surface": ["feature-gate", "restore-context", "conductor", "artifact-trust"],
+      "deps": ["bash", "jq", "git"],
+      "expected_checks": 11,
+      "timeout_minutes": 2,
+      "workflow": ".github/workflows/lint.yml",
+      "job": "trusted-evidence"
+    },
+    {
       "id": "check-visual-artifact-public-copy",
       "path": "ci/check-visual-artifact-public-copy.sh",
       "kind": "static-contract",

--- a/conductor/bin/sprint.sh
+++ b/conductor/bin/sprint.sh
@@ -346,18 +346,59 @@ cmd_complete() {
     exit 1
   fi
 
-  # Write done marker
+  # Validate the artifact BEFORE recording completion. Writing the done marker
+  # unblocks dependent phases and downstream readers treat phase_dir/artifact.json
+  # as trusted phase evidence, so a rejected artifact must stop the command
+  # before anything is marked complete. Reject a symlink (it could point
+  # anywhere), require valid JSON, and require the resolved path to stay under
+  # the nanostack store or the project.
+  local artifact_real=""
+  if [ -n "$artifact" ]; then
+    if [ -L "$artifact" ]; then
+      echo "ERROR: --artifact must not be a symlink" >&2
+      exit 1
+    fi
+    if [ ! -f "$artifact" ]; then
+      echo "ERROR: --artifact '$artifact' not found" >&2
+      exit 1
+    fi
+    if ! jq empty "$artifact" >/dev/null 2>&1; then
+      echo "ERROR: --artifact '$artifact' is not valid JSON" >&2
+      exit 1
+    fi
+    # Canonicalize the containing directory with `cd ... && pwd -P` (portable,
+    # resolves ".." and symlinked path components without depending on realpath)
+    # and fail closed if it cannot be resolved, so a lexical prefix like
+    # "$NANOSTACK_STORE/../../outside.json" cannot pass the check below.
+    local store_real project_real art_dir
+    art_dir=$(cd "$(dirname "$artifact")" 2>/dev/null && pwd -P) || {
+      echo "ERROR: cannot resolve --artifact path" >&2
+      exit 1
+    }
+    artifact_real="$art_dir/$(basename "$artifact")"
+    store_real=$(cd "$NANOSTACK_STORE" 2>/dev/null && pwd -P) || store_real="$NANOSTACK_STORE"
+    project_real=$(cd "$PROJECT" 2>/dev/null && pwd -P) || project_real="$PROJECT"
+    case "$artifact_real" in
+      "$store_real"/*|"$project_real"/*) ;;
+      *)
+        echo "ERROR: --artifact must live under the nanostack store or the project" >&2
+        exit 1
+        ;;
+    esac
+  fi
+
+  # Write done marker (only reached once the artifact, if any, is valid).
   local done_data
   done_data=$(jq -n \
     --arg agent "$agent" \
     --arg date "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --arg artifact "$artifact" \
+    --arg artifact "$artifact_real" \
     '{agent: $agent, completed_at: $date, artifact: $artifact}')
 
   echo "$done_data" > "$phase_dir/done"
 
-  # Symlink artifact if provided
-  [ -n "$artifact" ] && [ -f "$artifact" ] && ln -snf "$artifact" "$phase_dir/artifact.json"
+  # Link the validated artifact so downstream phases can read it.
+  [ -n "$artifact_real" ] && ln -snf "$artifact_real" "$phase_dir/artifact.json"
 
   # Release lock
   rm -rf "$phase_dir/lock"

--- a/feature/bin/enforce-sprint.sh
+++ b/feature/bin/enforce-sprint.sh
@@ -31,9 +31,14 @@ if [ "$LAST_CODE_CHANGE" -eq 0 ]; then
   unset _srcs
 fi
 
-# Check for artifacts that are newer than the last code change
+# Check for artifacts that are newer than the last code change. This is a
+# commit gate, so require trusted evidence: --require-integrity makes
+# find-artifact.sh exit non-zero when the phase artifact is absent, has no
+# .integrity field, or whose recomputed hash does not match. A tampered or
+# unsigned artifact is treated exactly like a missing one, matching the sprint
+# phase gate in guard/bin/phase-gate.sh.
 for phase in plan review security qa; do
-  ARTIFACT=$("$SCRIPT_DIR/bin/find-artifact.sh" "$phase" 2 2>/dev/null) || {
+  ARTIFACT=$("$SCRIPT_DIR/bin/find-artifact.sh" "$phase" 2 --require-integrity --no-session-sync 2>/dev/null) || {
     MISSING="${MISSING:+$MISSING, }$phase"
     continue
   }


### PR DESCRIPTION
New phase artifacts carry a SHA-256 integrity field. This routes the decision and context paths through that check so they rely on evidence that has not changed since it was saved.

## What changed

- **Feature commit gate (`enforce-sprint.sh`):** looks up each phase artifact with integrity verification, so an unsigned or altered artifact is treated as missing and the gate asks for that phase again. Matches the existing sprint phase gate. The lookup runs without session side effects.
- **`restore-context.sh`:** verifies a phase artifact before printing it into agent context, so an altered one is skipped. Artifacts saved before integrity existed are still read for human and context use; this is a context loader, not a gate.
- **Conductor `complete --artifact`:** the link it records as phase evidence must be a real JSON file under the store or project, validated *before* the phase is marked done. It rejects a symlink, a non-JSON file, or a path that resolves outside those folders.

## Validation

New `ci/check-trusted-evidence.sh` (11 checks) confirms an altered artifact is treated as missing by the gate, skipped by the context loader, and that conductor only links a real in-scope JSON file (covering both the store and the project sides), while intact evidence keeps working. Each negative case is set up to fail specifically when its guard is missing. Registered in the harness manifest and wired as a lint job (job-name and tier conventions match the existing checks). The session and conductor harnesses still pass.
