### PR TITLE
docs/setup: refresh adapter claim evidence

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,7 +41,7 @@ Adapters verificados hoy: **Claude Code, Cursor, OpenAI Codex, OpenCode y Gemini
 npx create-nanostack
 ```
 
-Un solo comando. Detecta tus agentes, instala todo, corre setup. Adapters verificados hoy: Claude Code, Cursor, Codex, OpenCode y Gemini CLI.
+Un solo comando. Detecta tus agentes, instala todo, corre setup. Adapters verificados hoy: Claude Code, Cursor, OpenAI Codex, OpenCode y Gemini CLI.
 
 Después corré `/nano-run` en tu agente para configurar el proyecto a través de una conversación.
 

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ This gap is the single biggest known caveat in the framework. The roadmap is to 
 npx create-nanostack
 ```
 
-Detects your agents, installs all skills, runs setup. Verified adapters today: Claude Code, Cursor, Codex, OpenCode, and Gemini CLI.
+Detects your agents, installs all skills, runs setup. Verified adapters today: Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI.
 
 Update from your agent:
 

--- a/adapters/codex.json
+++ b/adapters/codex.json
@@ -1,10 +1,10 @@
 {
   "host": "codex",
   "schema_version": "1",
-  "last_verified": "2026-04-25",
+  "last_verified": "2026-05-30",
   "verification": {
     "method": "manual",
-    "evidence": "setup install_codex symlinks skill directories under ~/.codex/skills/nanostack-<skill> but does not register any pre-action hook. Verified by reading setup lines 401-427 on 2026-04-25."
+    "evidence": "setup install_codex symlinks skill directories under ~/.codex/skills/nanostack-<skill> but does not register any pre-action hook. Verified with an isolated HOME install smoke on 2026-05-30."
   },
   "skill_discovery": "native",
   "bash_guard": "instructions_only",

--- a/adapters/cursor.json
+++ b/adapters/cursor.json
@@ -1,10 +1,10 @@
 {
   "host": "cursor",
   "schema_version": "1",
-  "last_verified": "2026-04-25",
+  "last_verified": "2026-05-30",
   "verification": {
     "method": "manual",
-    "evidence": "setup install_cursor writes a single rules file at .cursor/rules/nanostack.md telling the agent to read SKILL.md files. No PreToolUse hook integration is configured. Verified by reading setup lines 429-451 on 2026-04-25."
+    "evidence": "setup install_cursor writes a single rules file at .cursor/rules/nanostack.md telling the agent to read this install's SKILL.md files. No PreToolUse hook integration is configured. Verified with an isolated project install smoke on 2026-05-30."
   },
   "skill_discovery": "rules_file",
   "bash_guard": "instructions_only",

--- a/adapters/gemini.json
+++ b/adapters/gemini.json
@@ -1,10 +1,10 @@
 {
   "host": "gemini",
   "schema_version": "1",
-  "last_verified": "2026-04-25",
+  "last_verified": "2026-05-30",
   "verification": {
     "method": "manual",
-    "evidence": "setup install_gemini installs nanostack as a Gemini extension. The extension exposes skills but does not register PreToolUse hooks for shell or write actions. Verified by reading setup lines 466-477 on 2026-04-25."
+    "evidence": "setup install_gemini installs or links nanostack as a Gemini extension. The extension exposes skills but does not register PreToolUse hooks for shell or write actions. Verified with an isolated HOME install smoke on 2026-05-30."
   },
   "skill_discovery": "extension",
   "bash_guard": "instructions_only",

--- a/adapters/opencode.json
+++ b/adapters/opencode.json
@@ -1,10 +1,10 @@
 {
   "host": "opencode",
   "schema_version": "1",
-  "last_verified": "2026-04-25",
+  "last_verified": "2026-05-30",
   "verification": {
     "method": "manual",
-    "evidence": "setup install_opencode symlinks the source dir under ~/.agents/skills/nanostack. OpenCode reads the skill folder natively but no pre-action hook integration exists. Verified by reading setup lines 453-464 on 2026-04-25."
+    "evidence": "setup install_opencode symlinks the source dir under ~/.agents/skills/nanostack. OpenCode reads the skill folder natively but no pre-action hook integration exists. Verified with an isolated HOME install smoke on 2026-05-30."
   },
   "skill_discovery": "skill_folder",
   "bash_guard": "instructions_only",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nanostack",
   "description": "Minimal AI coding agent team skills for the full engineering workflow",
-  "version": "0.2.0",
+  "version": "1.1.1",
   "contextFileName": "GEMINI.md"
 }

--- a/setup
+++ b/setup
@@ -442,7 +442,7 @@ description: "Nanostack engineering workflow skills"
 alwaysApply: true
 ---
 
-You have access to nanostack skills. Read SKILL.md files in ~/.claude/skills/nanostack/ for instructions.
+You have access to nanostack skills. Read SKILL.md files in $SOURCE_DIR for instructions.
 
 Available: /think, /nano, /review, /qa, /security, /ship, /guard, /conductor, /compound, /feature, /nano-run, /nano-help
 Workflow: /think → /nano → build → /review → /qa → /security → /ship


### PR DESCRIPTION
Backs the "works with Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI" claim with current evidence, and fixes one small drift found while testing it. This is the last bit before the claim is used in the announcement.

## What the testing found (and this PR fixes)

- **Cursor rule pointed at a hardcoded path.** `setup` generated `.cursor/rules/nanostack.md` telling the agent to read SKILL.md files in `~/.claude/skills/nanostack`, even when the install lives elsewhere. It now uses the real install dir (`$SOURCE_DIR`, which expands at install time), so the rule references this install's files.
- **Adapter evidence refreshed.** `adapters/{codex,cursor,gemini,opencode}.json` `last_verified` bumped to 2026-05-30, with evidence from an isolated-HOME/project install smoke rather than a setup line-number read.
- **Version parity.** `gemini-extension.json` 0.2.0 -> 1.1.1. README and README.es use "OpenAI Codex" for adapter-name parity.

## What this claim does and does not say

Verified adapters install cleanly on all five hosts, with stronger enforcement where the host supports hooks (Claude Code). It does not claim identical enforcement everywhere. No GUI or real-prompt runs were done per host; the evidence is hermetic install smokes.

## Out of scope (separate follow-up)

The canonical post-build sprint order (`/security` vs `/qa`) is intentionally left untouched here. README and the release-docs locks document `security -> qa`, while the runtime graph in `bin/lib/phases.sh` walks `qa -> security` (locked by `e2e-graph-aware-session`). That is a pre-existing contradiction and a product/architecture decision, not a rider on an adapter-evidence PR. It will get its own PR ("architecture: reconcile canonical sprint order").

## Verification

`check-adapters --require-readme-contracts`, adapter-freshness E2E 74/74, release-docs and README narrative locks, em-dash check, jq, `bash -n setup`, `git diff --check`. No runtime behavior change.