### PR TITLE
ci: promote graph and concurrency runtime contracts to PR tier

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,22 +21,10 @@ jobs:
       - name: Run end-to-end harness
         run: ci/run-harness.sh --suite user-flows
 
-  e2e-concurrency-parity:
-    name: E2E read-only phase write parity
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # Locks that BOTH guard hooks (check-dangerous.sh for Bash,
-    # check-write.sh for Write/Edit/MultiEdit) enforce the read-only
-    # phase block through the shared nano_active_phase_concurrency
-    # helper. Includes custom-phase sabotage cells so the block stays
-    # registry-driven, not a hardcoded built-in list. Run after touching
-    # either guard hook or bin/lib/phases.sh concurrency helpers.
-    steps:
-      - uses: actions/checkout@v4
-      - name: jq is present
-        run: jq --version
-      - name: Run concurrency parity matrix
-        run: ci/run-harness.sh --suite concurrency-parity
+  # concurrency-parity and graph-aware-session were promoted to the
+  # PR-tier runtime-contracts job in lint.yml after #249. They run on
+  # every pull request now; dispatching this workflow no longer covers
+  # them.
 
   e2e-delivery-matrix:
     name: E2E delivery matrix (9 cells)
@@ -202,22 +190,6 @@ jobs:
         run: jq --version
       - name: Run custom routing E2E
         run: ci/run-harness.sh --suite custom-routing
-
-  e2e-graph-aware-session:
-    name: E2E Graph-aware Session + Next-step (10 cells)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # PR 4 of the 2026-05-10 architecture audit. Locks the graph-aware
-    # session lifecycle: session.json snapshots phase_graph at init,
-    # phase-complete fills next_phase + ready_phases from the snapshot,
-    # next-step.sh surfaces custom required_before_ship and keeps
-    # guided wording free of phase-graph jargon.
-    steps:
-      - uses: actions/checkout@v4
-      - name: jq is present
-        run: jq --version
-      - name: Run graph-aware session E2E
-        run: ci/run-harness.sh --suite graph-aware-session
 
   e2e-structured-artifacts:
     name: E2E Structured Artifact Contract (9 cells)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3858,3 +3858,32 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run visual artifact public-copy locks
         run: ci/check-visual-artifact-public-copy.sh
+
+  runtime-contracts:
+    name: Runtime contracts (graph-aware session + concurrency parity)
+    # These two suites protect the runtime wiring most likely to break
+    # silently: the graph-aware session lifecycle (phase_graph snapshot,
+    # next_phase / ready_phases / required_before_ship derivation) and
+    # the read-only phase write block shared by both guard hooks. They
+    # used to be opt-in in e2e.yml, which meant a PR could land a
+    # regression in either contract and CI would stay green until a
+    # maintainer remembered to dispatch the e2e workflow. Promoted to
+    # PR-tier after the canonical-sprint-order reconciliation (#249) so
+    # the order the graph now encodes is locked on every merge.
+    #
+    # The remaining e2e.yml suites stay opt-in on purpose: they are
+    # slower full-install flows, and user-flows in particular carries a
+    # known macOS-local write_guard false-block that is tracked
+    # separately and out of scope here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq is present
+        run: jq --version
+      - name: Run graph-aware session E2E
+        run: ci/run-harness.sh --suite graph-aware-session
+      - name: Run concurrency parity matrix
+        run: ci/run-harness.sh --suite concurrency-parity

--- a/adapters/claude.json
+++ b/adapters/claude.json
@@ -4,7 +4,7 @@
   "last_verified": "2026-05-28",
   "verification": {
     "method": "ci",
-    "evidence": ".github/workflows/lint.yml: guard-regression and write-guard-regression jobs exercise check-dangerous.sh and check-write.sh on every pull_request and push. The phase gate is additionally exercised by e2e-user-flows and e2e-concurrency-parity in .github/workflows/e2e.yml, which is workflow_dispatch-only (run before release), so those are not listed as continuous ci_jobs.",
+    "evidence": ".github/workflows/lint.yml: guard-regression and write-guard-regression jobs exercise check-dangerous.sh and check-write.sh on every pull_request and push. The read-only phase write block is additionally exercised on every pull_request by the runtime-contracts job (concurrency-parity suite). The phase gate is further exercised by e2e-user-flows in .github/workflows/e2e.yml, which is workflow_dispatch-only (run before release), so it is not listed as a continuous ci_job.",
     "ci_jobs": ["guard-regression", "write-guard-regression"]
   },
   "skill_discovery": "native",

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -42,13 +42,13 @@
       "id": "concurrency-parity",
       "path": "ci/e2e-concurrency-parity.sh",
       "kind": "runtime-e2e",
-      "tier": "opt-in",
+      "tier": "pr",
       "surface": ["guard", "phases", "concurrency"],
       "deps": ["bash", "jq", "git"],
       "expected_checks": 10,
       "timeout_minutes": 3,
-      "workflow": ".github/workflows/e2e.yml",
-      "job": "e2e-concurrency-parity"
+      "workflow": ".github/workflows/lint.yml",
+      "job": "runtime-contracts"
     },
     {
       "id": "structured-artifacts",
@@ -114,13 +114,13 @@
       "id": "graph-aware-session",
       "path": "ci/e2e-graph-aware-session.sh",
       "kind": "runtime-e2e",
-      "tier": "opt-in",
+      "tier": "pr",
       "surface": ["session", "phases", "phase-graph", "conductor"],
       "deps": ["bash", "jq", "git"],
       "expected_checks": 61,
       "timeout_minutes": 6,
-      "workflow": ".github/workflows/e2e.yml",
-      "job": "e2e-graph-aware-session"
+      "workflow": ".github/workflows/lint.yml",
+      "job": "runtime-contracts"
     },
     {
       "id": "delivery-matrix",


### PR DESCRIPTION
## Summary

The graph-aware session lifecycle and the read-only phase write block are the two runtime contracts most likely to break silently. Until now both were exercised only by opt-in workflow_dispatch jobs in e2e.yml, so a PR could regress phase_graph wiring or guard parity and CI stayed green until a maintainer remembered to dispatch the workflow before a release.

This PR makes both contracts run on every pull request. It is sequenced after #249 on purpose: promoting these suites earlier would have locked the contradictory sprint order into every PR run.

## Changes

- `.github/workflows/lint.yml`: new `runtime-contracts` job runs `ci/run-harness.sh --suite graph-aware-session` (61 checks) and `ci/run-harness.sh --suite concurrency-parity` (10 checks) on pull_request and push.
- `ci/harnesses.json`: both suites move to `tier: pr` with workflow and job updated, so `check-harness-manifest` keeps validating that the declared job actually invokes each suite.
- `.github/workflows/e2e.yml`: the two promoted jobs are removed, with a pointer comment, so the suites are not double-wired across workflows.
- `adapters/claude.json`: the evidence prose said the concurrency suite was dispatch-only, which this PR makes false; the sentence now reflects that the read-only phase block is continuously exercised. `ci_jobs` entries are unchanged.

## Out of scope

The remaining e2e.yml suites stay opt-in: they are slower full-install flows. `user-flows` in particular carries the known macOS-local `write_guard` false-block (pre-existing, fails identically on main), which is tracked separately.

## Validation

- `ci/check-harness-manifest.sh`: 31 suites consistent with scripts and workflows
- Both promoted suites pass through the runner: 61/61 and 10/10
- `bin/check-adapters.sh` and the adapter-freshness suite: 74/74
- YAML parse verified on both workflow files