### PR TITLE
docs/runtime: align journal and analytics phase order

### DIFF
--- a/bin/analytics.sh
+++ b/bin/analytics.sh
@@ -185,8 +185,8 @@ echo "  ─────────────"
 echo "  think       $THINK"
 echo "  plan        $PLAN"
 echo "  review      $REVIEW"
-echo "  qa          $QA"
 echo "  security    $SECURITY"
+echo "  qa          $QA"
 echo "  ship        $SHIP"
 if [ -n "$CUSTOM_PHASES" ]; then
   for phase in $CUSTOM_PHASES; do
@@ -256,8 +256,8 @@ if $OBSIDIAN_OUTPUT; then
     echo "| think | $THINK |"
     echo "| plan | $PLAN |"
     echo "| review | $REVIEW |"
-    echo "| qa | $QA |"
     echo "| security | $SECURITY |"
+    echo "| qa | $QA |"
     echo "| ship | $SHIP |"
     if [ -n "$CUSTOM_PHASES" ]; then
       for phase in $CUSTOM_PHASES; do

--- a/bin/sprint-journal.sh
+++ b/bin/sprint-journal.sh
@@ -112,24 +112,6 @@ numfield() {
     echo ""
   fi
 
-  # QA
-  QA_FILE=$(find_latest qa)
-  if [ -n "$QA_FILE" ]; then
-    echo "## /qa"
-    echo ""
-    STATUS=$(field '.summary.status' "$QA_FILE")
-    TESTS_RUN=$(numfield '.summary.tests_run' "$QA_FILE")
-    PASSED=$(numfield '.summary.tests_passed' "$QA_FILE")
-    FAILED=$(numfield '.summary.tests_failed' "$QA_FILE")
-    BUGS=$(numfield '.summary.bugs_found' "$QA_FILE")
-    FIXED=$(numfield '.summary.bugs_fixed' "$QA_FILE")
-    WTF=$(numfield '.summary.wtf_likelihood' "$QA_FILE")
-    echo "**Status:** $STATUS | **Tests:** $TESTS_RUN ($PASSED passed, $FAILED failed)"
-    echo "**Bugs:** $BUGS found, $FIXED fixed"
-    [ "$WTF" -gt 0 ] && echo "**WTF likelihood:** ${WTF}%"
-    echo ""
-  fi
-
   # Security
   SEC_FILE=$(find_latest security)
   if [ -n "$SEC_FILE" ]; then
@@ -151,6 +133,24 @@ numfield() {
 
     [ -n "$MODE" ] && echo "**Mode:** $MODE | **Score:** $GRADE" || echo "**Score:** $GRADE"
     echo "**Findings:** CRITICAL=$CRIT HIGH=$HIGH MEDIUM=$MED LOW=$LOW (total: $TOTAL)"
+    echo ""
+  fi
+
+  # QA
+  QA_FILE=$(find_latest qa)
+  if [ -n "$QA_FILE" ]; then
+    echo "## /qa"
+    echo ""
+    STATUS=$(field '.summary.status' "$QA_FILE")
+    TESTS_RUN=$(numfield '.summary.tests_run' "$QA_FILE")
+    PASSED=$(numfield '.summary.tests_passed' "$QA_FILE")
+    FAILED=$(numfield '.summary.tests_failed' "$QA_FILE")
+    BUGS=$(numfield '.summary.bugs_found' "$QA_FILE")
+    FIXED=$(numfield '.summary.bugs_fixed' "$QA_FILE")
+    WTF=$(numfield '.summary.wtf_likelihood' "$QA_FILE")
+    echo "**Status:** $STATUS | **Tests:** $TESTS_RUN ($PASSED passed, $FAILED failed)"
+    echo "**Bugs:** $BUGS found, $FIXED fixed"
+    [ "$WTF" -gt 0 ] && echo "**WTF likelihood:** ${WTF}%"
     echo ""
   fi
 


### PR DESCRIPTION
## Summary

Aligns the sprint journal and analytics display order with the canonical sprint order.

The runtime, README, release notes, and CI locks now use `review -> security -> qa`. Two display-only helpers still printed `qa` before `security`, which made generated reports look stale even though the runtime was correct.

## What changed

- Sprint journal sections now render `/security` before `/qa`.
- Analytics text and markdown tables now print `review`, `security`, `qa`.
- Structured analytics JSON was already correct and is unchanged.

## Validation

Ran journal and analytics smoke checks to confirm the displayed order.
No runtime behavior changed.