### PR TITLE
docs: make the README welcoming for non-technical readers

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,9 @@
 <h1 align="center">Nanostack</h1>
 <p align="center">
-  Convertí tu agente de AI coding en un flujo de delivery local.<br>
-  Nanostack ayuda al agente a cuestionar el alcance, planificar el cambio, construir, revisar, auditar, probar y entregar con un registro de lo ocurrido. Usá el sprint por defecto, o construí tu propio workflow stack arriba.<br>
-  <strong>Skills en texto plano. Artefactos locales. Sin Nanostack cloud. Sin paso de build.</strong>
+  Tu agente de IA escribe código. Nanostack se asegura de que entregue trabajo en el que podés confiar.<br>
+  <em>Flujo de delivery local para agentes de AI coding.</em><br>
+  Alcance, plan, build, review, security, QA, ship. Cada paso deja evidencia que podés leer, en archivos de texto plano en tu disco. Usá el sprint por defecto, o construí tu propio workflow stack arriba.<br>
+  <strong>Open source. Skills en texto plano. Artefactos locales. Adapters verificados. Sin Nanostack cloud.</strong>
 </p>
 
 <br>
@@ -17,6 +18,7 @@
 </p>
 
 <p align="center">
+  <a href="#ejemplo">Ejemplo</a> &middot;
   <a href="#instalacion">Instalación</a> &middot;
   <a href="#dos-perfiles-mismo-rigor">Perfiles</a> &middot;
   <a href="#el-sprint">El sprint</a> &middot;
@@ -29,9 +31,58 @@
 
 > **Nota:** la versión en inglés ([README.md](README.md)) es la canónica. Si encontrás divergencias o algo desactualizado en este documento, por favor abrí un issue.
 
-Inspirado en [gstack](https://github.com/garrytan/gstack) de [Garry Tan](https://x.com/garrytan). Nanostack trae 13 skills built-in, un sprint default de siete fases, y un framework para sumar tus propios skills o workflow stacks. Sin Nanostack cloud. Sin paso de build.
+Inspirado en [gstack](https://github.com/garrytan/gstack) de [Garry Tan](https://x.com/garrytan). Nanostack le da a tu agente el método de trabajo de un equipo de producto chico: cuestiona el alcance, planifica, revisa el código, audita seguridad, prueba y entrega, dejando un registro que podés inspeccionar en cada paso. Todo es texto plano y scripts locales bajo Apache 2.0, así que podés leer cada regla que sigue tu agente. Sin Nanostack cloud, sin daemon, sin paso de build.
 
 Adapters verificados hoy: **Claude Code, Cursor, OpenAI Codex, OpenCode y Gemini CLI**. Los skill files son texto plano, así que otros agentes podrían cargarlos, pero solo esos cinco tienen un adapter verificado y declaración de capabilities en [`adapters/`](adapters/).
+
+## Ejemplo
+
+```
+Vos:    Necesito agregar notificaciones a mi app. Los usuarios se
+        pierden las respuestas a sus posts.
+Vos:    /think
+
+Agente: Antes de construir nada, ¿cómo lo están manejando hoy?
+
+Vos:    Abren la app 3 o 4 veces por día solo para chequear. A veces
+        se pierden las respuestas por horas. Están frustrados.
+
+Agente: Voy a empujar contra "notificaciones". Dijiste que abren la
+        app 3-4 veces por día. Eso es alta interacción. Ya vuelven.
+        El problema no es que no se les pueda avisar. El problema es
+        que cuando llegan, no pueden ver qué cambió.
+
+        Eso es un problema de visibilidad, no de mensajería.
+
+        Un sistema de notificaciones (email, push, in-app, preferencias,
+        digest, unsubscribe) es un proyecto de 3 semanas. Un puntito
+        rojo en el ícono que diga "hay algo nuevo" sale esta tarde.
+
+        RECOMENDACIÓN: Reducir alcance. Publicá el puntito. Ver si bajan
+        los reclamos. Si bajan, te ahorraste 3 semanas. Si no bajan,
+        ahí construís push notifications, pero ya con datos.
+
+Vos:    Tiene sentido. Hagamos el puntito.
+Vos:    /nano
+        [3 pasos, 2 archivos]
+
+Vos:    [construye]
+
+Vos:    /review
+        Review: 2 hallazgos (1 auto-arreglado, 1 detalle menor).
+
+Vos:    /security
+        Sin secretos, cambios de auth o flujos de datos inseguros. Grade A.
+
+Vos:    /qa
+        Abrí la app, posteé una respuesta, refresqué, confirmé que el
+        puntito aparece y se limpia. 4 chequeos OK.
+
+Vos:    /ship
+        Ship: PR creado. Tests pasaron.
+```
+
+Vos dijiste "notificaciones". El agente dijo "tus usuarios tienen un problema de visibilidad" y encontró una solución que sale en una tarde en lugar de tres semanas. El loop de delivery completo, no solo generación de código.
 
 ## Instalación
 
@@ -92,55 +143,6 @@ Guided cambia el lenguaje, no baja el estándar.
 El modo local usa Guiado por defecto. Un proyecto con git también puede usar Guiado si querés explicaciones más simples.
 
 Las reglas de lenguaje viven en [`reference/plain-language-contract.md`](reference/plain-language-contract.md). Los campos de sesión que seleccionan el perfil viven en [`reference/session-state-contract.md`](reference/session-state-contract.md).
-
-## Ejemplo
-
-```
-Vos:    Necesito agregar notificaciones a mi app. Los usuarios se
-        pierden las respuestas a sus posts.
-Vos:    /think
-
-Agente: Antes de construir nada, ¿cómo lo están manejando hoy?
-
-Vos:    Abren la app 3 o 4 veces por día solo para chequear. A veces
-        se pierden las respuestas por horas. Están frustrados.
-
-Agente: Voy a empujar contra "notificaciones". Dijiste que abren la
-        app 3-4 veces por día. Eso es alta interacción. Ya vuelven.
-        El problema no es que no se les pueda avisar. El problema es
-        que cuando llegan, no pueden ver qué cambió.
-
-        Eso es un problema de visibilidad, no de mensajería.
-
-        Un sistema de notificaciones (email, push, in-app, preferencias,
-        digest, unsubscribe) es un proyecto de 3 semanas. Un puntito
-        rojo en el ícono que diga "hay algo nuevo" sale esta tarde.
-
-        RECOMENDACIÓN: Reducir alcance. Publicá el puntito. Ver si bajan
-        los reclamos. Si bajan, te ahorraste 3 semanas. Si no bajan,
-        ahí construís push notifications, pero ya con datos.
-
-Vos:    Tiene sentido. Hagamos el puntito.
-Vos:    /nano
-        [3 pasos, 2 archivos]
-
-Vos:    [construye]
-
-Vos:    /review
-        Review: 2 hallazgos (1 auto-arreglado, 1 detalle menor).
-
-Vos:    /security
-        Sin secretos, cambios de auth o flujos de datos inseguros. Grade A.
-
-Vos:    /qa
-        Abrí la app, posteé una respuesta, refresqué, confirmé que el
-        puntito aparece y se limpia. 4 chequeos OK.
-
-Vos:    /ship
-        Ship: PR creado. Tests pasaron.
-```
-
-Vos dijiste "notificaciones". El agente dijo "tus usuarios tienen un problema de visibilidad" y encontró una solución que sale en una tarde en lugar de tres semanas. El loop de delivery completo, no solo generación de código.
 
 ## El sprint
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 <br>
 
 <p align="center">
-  Local delivery workflow harness for AI coding agents.
+  Your AI agent writes code. Nanostack makes sure it ships work you can trust.
 </p>
 
 <p align="center">
-  Nanostack gives an agent a delivery method: scope, plan, build, review, security, QA, ship. Each step writes local artifacts the next step can read. Use the default sprint, or build your own workflow stack on top.
+  <em>Local delivery workflow harness for AI coding agents.</em>
 </p>
 
-<p align="center"><strong>Plain text skills. Local artifacts. Verified adapters. No Nanostack cloud.</strong></p>
+<p align="center">
+  Scope, plan, build, review, security, QA, ship. Every step leaves evidence you can read, in plain files on your disk. Use the default sprint, or build your own workflow stack on top.
+</p>
+
+<p align="center"><strong>Open source. Plain text skills. Local artifacts. Verified adapters. No Nanostack cloud.</strong></p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -34,125 +38,11 @@
 <br>
 
 
-Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). Nanostack ships 13 built-in skills, a seven-phase default sprint, and a framework for composing your own workflow stacks. It is local files and scripts: no Nanostack cloud, no daemon, no app runtime.
+Inspired by [gstack](https://github.com/garrytan/gstack) from [Garry Tan](https://x.com/garrytan). Nanostack gives your agent the working method of a small product team: it questions the scope, plans, reviews the code, audits security, tests, and ships, leaving a paper trail you can inspect at every step. Everything is plain text and local scripts under Apache 2.0, so you can read every rule your agent follows. No Nanostack cloud, no daemon, no app runtime.
 
 Verified adapters today: **Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI**. The skill files are plain text, so other agents may load them, but only those five have a verified adapter and capability declaration in [`adapters/`](adapters/).
 
 What changed in the latest release (custom workflow stacks, visual artifacts, stronger safety contracts): see [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
-
-## What is Nanostack?
-
-Your agent can already edit files and run commands. Nanostack gives it a method.
-
-The default sprint turns a request into a scoped, reviewed, security-checked, tested change with a PR and a sprint journal. Each phase writes a structured artifact. Later phases read those artifacts instead of depending only on chat history.
-
-The bet is artifact-first delivery:
-
-- Skills are plain text.
-- Artifacts are local JSON.
-- Gates verify evidence before release.
-- Visual artifacts render the same evidence as local HTML.
-- Custom workflow stacks extend the same pipeline with your own phases.
-
-On Claude Code, Nanostack can enforce parts of the workflow through PreToolUse hooks. On other agents, the same workflow runs as guided instructions. See [What enforces on which agent](#what-enforces-on-which-agent) for the honest per-host table.
-
-The built-in sprint is the default stack:
-
-|        | Step              | What the specialist does                                                |
-| ------ | ----------------- | ----------------------------------------------------------------------- |
-| **01** | `/think`          | Challenges scope. Finds the smallest useful version.                    |
-| **02** | `/nano`           | Plans the implementation. Names files, risks, and checks.               |
-| **03** | build             | You or the agent writes the code.                                       |
-| **04** | `/review`         | Two-pass code review. Scope drift detection. Auto-fixes the mechanical. |
-| **05** | `/security`       | OWASP A01-A10 audit + STRIDE threat modeling. Graded A-F.               |
-| **06** | `/qa`             | Tests the thing. Browser, API, CLI, or root-cause debug.                |
-| **07** | `/ship`           | PR creation, CI verification, release notes, sprint journal. Production deployment stays explicit and user-controlled. |
-
-## Two profiles, same rigor
-
-Nanostack adapts the explanation, not the standard.
-
-| Profile | What changes |
-|---------|--------------|
-| **Guided** | Plain language, one next action, safer defaults, no hidden jargon. |
-| **Professional** | Denser output, deeper tradeoffs, explicit files, commands, and risks. |
-
-Local mode uses Guided language by default. A git project can still use Guided if the user wants simpler explanations.
-
-The wording rules live in [`reference/plain-language-contract.md`](reference/plain-language-contract.md). The session fields that select the profile live in [`reference/session-state-contract.md`](reference/session-state-contract.md).
-
-## What is enforced depends on your agent
-
-Nanostack is agent-agnostic, but agent hosts do not expose the same control points. The adapter files in [`adapters/`](adapters/) are the source of truth for each host.
-
-| Level | Meaning |
-|-------|---------|
-| **L0 Guided** | The skill tells the agent what to do but cannot block it. Also covers a capability the host cannot provide at all. |
-| **L1 Checked** | Nanostack can detect and report the issue, but cannot block it. |
-| **L2 Guarded** | The host runs a nanostack hook before the action. |
-| **L3 Enforced** | The hook can block the action and the host honors the block. |
-| **L4 Continuously verified** | A CI job exercises the capability on every change. |
-
-A detailed per-host matrix (Bash guard, Write/Edit guard, phase gate) lives further down in [What enforces on which agent](#what-enforces-on-which-agent).
-
-## What changes after installing Nanostack
-
-| Without Nanostack | With Nanostack |
-| --- | --- |
-| ❌ A vague prompt turns into code immediately. | ✅ `/think` turns the idea into a brief, risk, and smallest useful starting point. |
-| ❌ The plan disappears in chat. | ✅ `/nano` saves a plan with files, risks, checks, and out-of-scope items. |
-| ❌ The agent quietly refactors three things you did not ask for. | ✅ `/review` compares the code against the plan. Scope drift is visible before merge. |
-| ❌ QA and security happen only if someone remembers. | ✅ `/qa` opens your app and exercises it. `/security` runs on every ship and catches the mistakes that make headlines. |
-| ❌ Your PR says "add notifications" and nobody knows what actually changed or why. | ✅ `/ship` explains why the change exists, how it was checked, and what remains. |
-| ❌ You rush-commit Friday 5pm and Monday find out it broke something unrelated. | ✅ The sprint blocks `git commit` until `/review`, `/security`, and `/qa` pass. (Enforcement varies by agent; see honesty matrix below.) |
-| ❌ Every session re-pastes the same context: what we use, what is fragile. | ✅ Every skill reads the artifact the previous skill wrote. Sprint journals preserve decisions in `.nanostack/`. |
-
-## Nanostack is right for you if
-
-- ✅ You have an AI agent open all day and still feel like you ship slowly
-- ✅ You want reviews that catch scope drift, not just typos
-- ✅ You want a security audit before every ship, not once a quarter
-- ✅ You want PR descriptions that explain the WHY, not just list files
-- ✅ You want a process that works across Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI
-- ✅ You want the skills on disk, inspectable, not locked in a SaaS
-
-## Choose your path
-
-| If you are... | Start here |
-|---|---|
-| New to agent workflows | Try [`starter-todo`](examples/starter-todo/), then run `/nano-run` |
-| Already shipping with AI agents | Install Nanostack, then start with `/think` or `/feature` |
-| Evaluating safety | Read [Guard](#guard) and the [host enforcement matrix](#what-enforces-on-which-agent) |
-| Building your own workflow | Start with [`EXTENDING.md`](EXTENDING.md) and [`compliance-release`](examples/custom-stack-template/compliance-release/) |
-| Inspecting what the agent did | Render any phase as local HTML with [visual artifacts](#visual-artifacts) (`bin/render-artifact.sh`) |
-
-## Try it safely first
-
-Not sure yet? Start with a disposable sandbox from the Examples Library. It gives you a real sprint without risking your product.
-
-| Example | Best for | Stack | Time |
-|---|---|---|---|
-| [`starter-todo`](examples/starter-todo/) | new and non-technical users | one HTML file | 5-10 min |
-| [`cli-notes`](examples/cli-notes/) | CLI workflows | Bash | 5-15 min |
-| [`api-healthcheck`](examples/api-healthcheck/) | backend flows | Node stdlib HTTP | 10-15 min |
-| [`static-landing`](examples/static-landing/) | founders and designers | static HTML/CSS | 10-15 min |
-| [`compliance-release`](examples/custom-stack-template/compliance-release/) | teams building a custom workflow stack | license + privacy + release gate | 15-30 min |
-
-Each example has a copy-paste prompt, expected sprint flow, success criteria, and reset steps. Full Examples Library: [`examples/`](examples/).
-
-`compliance-release` is advanced. It is not a starter app and it is not a compliance certification. It shows how several custom skills can compose into one release workflow.
-
-## Quick start
-
-```bash
-npx create-nanostack
-```
-
-One command. Detects your agents, installs everything, runs setup.
-
-Then run `/nano-run` in your agent to configure your project through a conversation. On your first sprint, `/think` shows the full pipeline so you know what comes next.
-
-If you want to see the workflow before installing into a real repo, use one of the sandbox examples above.
 
 ## See it work
 
@@ -206,6 +96,120 @@ You:    /ship
 ```
 
 That is the difference: not just code generation, but a delivery loop you can inspect.
+
+## What changes after installing Nanostack
+
+| Without Nanostack | With Nanostack |
+| --- | --- |
+| ❌ A vague prompt turns into code immediately. | ✅ `/think` turns the idea into a brief, risk, and smallest useful starting point. |
+| ❌ The plan disappears in chat. | ✅ `/nano` saves a plan with files, risks, checks, and out-of-scope items. |
+| ❌ The agent quietly refactors three things you did not ask for. | ✅ `/review` compares the code against the plan. Scope drift is visible before merge. |
+| ❌ QA and security happen only if someone remembers. | ✅ `/qa` opens your app and exercises it. `/security` runs on every ship and catches the mistakes that make headlines. |
+| ❌ Your PR says "add notifications" and nobody knows what actually changed or why. | ✅ `/ship` explains why the change exists, how it was checked, and what remains. |
+| ❌ You rush-commit Friday 5pm and Monday find out it broke something unrelated. | ✅ The sprint blocks `git commit` until `/review`, `/security`, and `/qa` pass. (Enforcement varies by agent; see honesty matrix below.) |
+| ❌ Every session re-pastes the same context: what we use, what is fragile. | ✅ Every skill reads the artifact the previous skill wrote. Sprint journals preserve decisions in `.nanostack/`. |
+
+## Nanostack is right for you if
+
+- ✅ You have an AI agent open all day and still feel like you ship slowly
+- ✅ You want reviews that catch scope drift, not just typos
+- ✅ You want a security audit before every ship, not once a quarter
+- ✅ You want PR descriptions that explain the WHY, not just list files
+- ✅ You want a process that works across Claude Code, Cursor, OpenAI Codex, OpenCode, and Gemini CLI
+- ✅ You want the skills on disk, inspectable, not locked in a SaaS
+
+## Try it safely first
+
+Not sure yet? Start with a disposable sandbox from the Examples Library. It gives you a real sprint without risking your product.
+
+| Example | Best for | Stack | Time |
+|---|---|---|---|
+| [`starter-todo`](examples/starter-todo/) | new and non-technical users | one HTML file | 5-10 min |
+| [`cli-notes`](examples/cli-notes/) | CLI workflows | Bash | 5-15 min |
+| [`api-healthcheck`](examples/api-healthcheck/) | backend flows | Node stdlib HTTP | 10-15 min |
+| [`static-landing`](examples/static-landing/) | founders and designers | static HTML/CSS | 10-15 min |
+| [`compliance-release`](examples/custom-stack-template/compliance-release/) | teams building a custom workflow stack | license + privacy + release gate | 15-30 min |
+
+Each example has a copy-paste prompt, expected sprint flow, success criteria, and reset steps. Full Examples Library: [`examples/`](examples/).
+
+`compliance-release` is advanced. It is not a starter app and it is not a compliance certification. It shows how several custom skills can compose into one release workflow.
+
+## Quick start
+
+```bash
+npx create-nanostack
+```
+
+One command. Detects your agents, installs everything, runs setup.
+
+Then run `/nano-run` in your agent to configure your project through a conversation. On your first sprint, `/think` shows the full pipeline so you know what comes next.
+
+If you want to see the workflow before installing into a real repo, use one of the sandbox examples above.
+
+## Choose your path
+
+| If you are... | Start here |
+|---|---|
+| New to agent workflows | Try [`starter-todo`](examples/starter-todo/), then run `/nano-run` |
+| Already shipping with AI agents | Install Nanostack, then start with `/think` or `/feature` |
+| Evaluating safety | Read [Guard](#guard) and the [host enforcement matrix](#what-enforces-on-which-agent) |
+| Building your own workflow | Start with [`EXTENDING.md`](EXTENDING.md) and [`compliance-release`](examples/custom-stack-template/compliance-release/) |
+| Inspecting what the agent did | Render any phase as local HTML with [visual artifacts](#visual-artifacts) (`bin/render-artifact.sh`) |
+
+## What is Nanostack?
+
+Your agent can already edit files and run commands. Nanostack gives it a method: 13 built-in skills, a seven-phase default sprint, and a framework for composing your own workflow stacks.
+
+The default sprint turns a request into a scoped, reviewed, security-checked, tested change with a PR and a sprint journal. Each phase writes a structured artifact: a small local file that records what was decided and what was checked. Later phases read those files instead of depending only on chat history.
+
+The bet is artifact-first delivery:
+
+- Skills are plain text.
+- Artifacts are local JSON.
+- Gates verify evidence before release.
+- Visual artifacts render the same evidence as local HTML.
+- Custom workflow stacks extend the same pipeline with your own phases.
+
+On Claude Code, Nanostack can enforce parts of the workflow through PreToolUse hooks. On other agents, the same workflow runs as guided instructions. See [What enforces on which agent](#what-enforces-on-which-agent) for the honest per-host table.
+
+The built-in sprint is the default stack:
+
+|        | Step              | What the specialist does                                                |
+| ------ | ----------------- | ----------------------------------------------------------------------- |
+| **01** | `/think`          | Challenges scope. Finds the smallest useful version.                    |
+| **02** | `/nano`           | Plans the implementation. Names files, risks, and checks.               |
+| **03** | build             | You or the agent writes the code.                                       |
+| **04** | `/review`         | Two-pass code review. Scope drift detection. Auto-fixes the mechanical. |
+| **05** | `/security`       | OWASP A01-A10 audit + STRIDE threat modeling. Graded A-F.               |
+| **06** | `/qa`             | Tests the thing. Browser, API, CLI, or root-cause debug.                |
+| **07** | `/ship`           | PR creation, CI verification, release notes, sprint journal. Production deployment stays explicit and user-controlled. |
+
+## Two profiles, same rigor
+
+Nanostack adapts the explanation, not the standard.
+
+| Profile | What changes |
+|---------|--------------|
+| **Guided** | Plain language, one next action, safer defaults, no hidden jargon. |
+| **Professional** | Denser output, deeper tradeoffs, explicit files, commands, and risks. |
+
+Local mode uses Guided language by default. A git project can still use Guided if the user wants simpler explanations.
+
+The wording rules live in [`reference/plain-language-contract.md`](reference/plain-language-contract.md). The session fields that select the profile live in [`reference/session-state-contract.md`](reference/session-state-contract.md).
+
+## What is enforced depends on your agent
+
+Nanostack is agent-agnostic, but agent hosts do not expose the same control points. The adapter files in [`adapters/`](adapters/) are the source of truth for each host.
+
+| Level | Meaning |
+|-------|---------|
+| **L0 Guided** | The skill tells the agent what to do but cannot block it. Also covers a capability the host cannot provide at all. |
+| **L1 Checked** | Nanostack can detect and report the issue, but cannot block it. |
+| **L2 Guarded** | The host runs a nanostack hook before the action. |
+| **L3 Enforced** | The hook can block the action and the host honors the block. |
+| **L4 Continuously verified** | A CI job exercises the capability on every change. |
+
+A detailed per-host matrix (Bash guard, Write/Edit guard, phase gate) lives further down in [What enforces on which agent](#what-enforces-on-which-agent).
 
 ## The sprint
 


### PR DESCRIPTION
## Summary

The README had the right content in the wrong order. Its two most convincing assets, the /think conversation demo and the before/after table, sat below several walls of framework vocabulary. A non-technical reader met enforcement levels and architecture counts before seeing what Nanostack actually does for them.

This PR reshapes the top of both READMEs as a funnel: show the value first, route each reader to their depth, keep every technical section intact below.

## What changed

- New hero: leads with the outcome (your agent ships work you can trust) and keeps the technical category line as a subtitle.
- The conversation demo, the what-changes table, the sandbox examples, and the install command now come first.
- Profiles, enforcement levels, and architecture detail keep their full content but move below the choose-your-path router.
- The first use of "artifact" explains itself in plain words.
- The open source thesis is stated once up front: plain text on your disk, you can read every rule your agent follows.
- README.es.md mirrors the same shape: new hero, outcome-first intro, conversation example ahead of installation.

## What did not change

No claims changed. Verified adapters wording, enforcement honesty per agent, profile framing, and every locked token stay exactly as they were. The skill and phase counts moved into the What is Nanostack section.

## Validation

All three README lock scripts pass (narrative, public copy, release docs), the Spanish parity section list is intact, and no em-dashes were introduced. Independent review found no broken references.