### PR TITLE
think: collaborative cadence, alternatives pass, sectioned brief

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2610,6 +2610,70 @@ jobs:
             exit 1
           fi
 
+  think-collaborative-contract:
+    name: /think collaborative cadence + alternatives contract
+    runs-on: ubuntu-latest
+    # think vNext (brainstorm-grade): the diagnostic asks one question per
+    # message, Phase 4.5 presents 2-3 alternatives with trade-offs before
+    # the scope mode, the brief walks in sections when interactive, and
+    # the artifact carries optional alternatives_considered and
+    # design_summary fields that the brief gate never reads. Lock the
+    # mechanics so a later edit cannot silently regress /think to
+    # batched-question, single-verdict behavior.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Diagnostic declares the one-question cadence
+        run: |
+          set -e
+          if ! grep -qF 'one question per message' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md no longer declares the one-question-per-message cadence"
+            exit 1
+          fi
+      - name: Phase 4.5 alternatives pass exists and keeps the reduce bias
+        run: |
+          set -e
+          if ! grep -qF '### Phase 4.5: Alternatives' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md is missing the Phase 4.5 Alternatives section"
+            exit 1
+          fi
+          if ! grep -qF 'recommend the smaller one' think/SKILL.md; then
+            echo "FAIL: Phase 4.5 lost the smaller-approach recommendation bias"
+            exit 1
+          fi
+      - name: Interactive brief walks in sections, autopilot keeps the gate
+        run: |
+          set -e
+          if ! grep -qF 'walk the brief in sections' think/SKILL.md; then
+            echo "FAIL: think/SKILL.md is missing the sectioned brief validation instruction"
+            exit 1
+          fi
+          if ! grep -qF 'Under autopilot, skip the section walk' think/SKILL.md; then
+            echo "FAIL: the section walk no longer defers to the brief gate under autopilot"
+            exit 1
+          fi
+      - name: Optional collaborative fields documented and gate-exempt
+        run: |
+          set -e
+          for f in think/SKILL.md reference/artifact-schema.md; do
+            for field in alternatives_considered design_summary; do
+              if ! grep -qF "$field" "$f"; then
+                echo "FAIL: $f does not document $field"
+                exit 1
+              fi
+            done
+          done
+          if ! grep -qF 'Alternatives Considered' think/references/brief-template.md; then
+            echo "FAIL: brief-template.md is missing the Alternatives Considered section"
+            exit 1
+          fi
+          # The brief gate jq filter must keep checking exactly the five
+          # required fields and never consult the collaborative ones.
+          gate_block=$(sed -n '/### Phase 6.6/,/### Phase 7/p' think/SKILL.md)
+          if printf '%s' "$gate_block" | grep -qE 'alternatives_considered|design_summary'; then
+            echo "FAIL: the brief gate consults a collaborative field; it must stay optional"
+            exit 1
+          fi
+
   phase-registry-contract:
     name: Phase registry library exposes the public API
     runs-on: ubuntu-latest

--- a/ci/e2e-think-flows.sh
+++ b/ci/e2e-think-flows.sh
@@ -21,6 +21,9 @@
 #      top of the static lint).
 #   7. Search privacy modes — reference doc declares the three modes
 #      and the search_summary fields exist by name.
+#   8. Collaborative fields — alternatives_considered + design_summary
+#      roundtrip when present, and the brief gate passes with or
+#      without them (they are optional, never gate input).
 #
 # Usage:
 #   ci/e2e-think-flows.sh
@@ -330,6 +333,48 @@ cell_search_privacy_modes() {
   done
 }
 
+# ─── Cell 8: collaborative fields are optional and roundtrip ─────────
+
+cell_collaborative_fields() {
+  # 8a: artifact with alternatives_considered + design_summary saves,
+  # and every collaborative field is retrievable by name.
+  new_project "cell8-collab"
+  git init -q
+  "$REPO/bin/session.sh" init development >/dev/null
+  local think_json
+  think_json=$(build_think_json | jq '
+    .summary.alternatives_considered = [
+      {approach: "full importer with schema migrations", tradeoff: "three weeks before any signal", chosen: false},
+      {approach: "CLI imports one JSON snapshot", tradeoff: "no migrations, manual re-run", chosen: true}
+    ]
+    | .summary.design_summary = "The CLI reads a snapshot file, validates the shape, and writes records in one pass."')
+  "$REPO/bin/save-artifact.sh" think "$think_json" >/dev/null
+  local artifact
+  artifact=$(ls .nanostack/think/*.json | head -1)
+  assert_true "alternatives_considered roundtrips (2 entries)" \
+    jq -e '.summary.alternatives_considered | length == 2' "$artifact"
+  assert_true "exactly one alternative is chosen" \
+    jq -e '[.summary.alternatives_considered[] | select(.chosen)] | length == 1' "$artifact"
+  assert_true "design_summary roundtrips non-empty" \
+    jq -e '.summary.design_summary | length > 0' "$artifact"
+  local gate
+  gate=$(brief_gate_pass "$artifact")
+  assert_eq "gate passes WITH collaborative fields present" "true" "$gate"
+
+  # 8b: a brief WITHOUT the collaborative fields is still a complete
+  # brief — the gate never consults them.
+  new_project "cell8-nocollab"
+  git init -q
+  "$REPO/bin/session.sh" init development >/dev/null
+  think_json=$(build_think_json)
+  "$REPO/bin/save-artifact.sh" think "$think_json" >/dev/null
+  artifact=$(ls .nanostack/think/*.json | head -1)
+  assert_true "collaborative fields absent from a v1-shaped brief" \
+    jq -e '.summary | has("alternatives_considered") | not' "$artifact"
+  gate=$(brief_gate_pass "$artifact")
+  assert_eq "gate passes WITHOUT collaborative fields" "true" "$gate"
+}
+
 # ─── Run ──────────────────────────────────────────────────────────────
 
 echo "Nanostack /think vNext flows"
@@ -343,6 +388,7 @@ cell brief_gate_complete
 cell brief_gate_incomplete
 cell preset_no_dump
 cell search_privacy_modes
+cell collaborative_fields
 
 echo ""
 echo "============================"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -153,7 +153,7 @@
       "tier": "opt-in",
       "surface": ["think", "session"],
       "deps": ["bash", "jq", "git"],
-      "expected_checks": 32,
+      "expected_checks": 38,
       "timeout_minutes": 6,
       "workflow": ".github/workflows/e2e.yml",
       "job": "e2e-think-flows"

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -146,6 +146,7 @@ Every artifact can include a `context_checkpoint` — a self-contained summary t
 **Required vs optional in `summary`:**
 - Required: `value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. The autopilot brief gate (`/think --autopilot`) refuses to advance to `/nano` when any of these are missing or empty.
 - Optional: `out_of_scope`, `manual_delivery_test`, `search_summary`. Skills downstream of `/think` consume them when present, fall back to safe defaults when absent.
+- Optional collaborative fields: `alternatives_considered` (array of `{approach, tradeoff, chosen}` objects from the Phase 4.5 alternatives pass; the chosen approach has `chosen: true`) and `design_summary` (string, 2-4 sentences describing how the chosen approach works). The brief gate does NOT require these; a brief without alternatives is still a complete brief.
 - Optional Guided Archetypes v1: `archetype`, `archetype_confidence`, `archetype_source`, `archetype_reason`, `example_reference`. The brief gate does NOT require these. Skills that opt into archetype-aware behavior read them when present and fall back to canonical neutrality when absent. The full archetype contract lives in [`think/references/archetypes.md`](../think/references/archetypes.md).
 
 ### /nano

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -396,7 +396,7 @@ Understand the landscape, then determine the mode.
 
 **If the user didn't provide an idea or problem** (e.g. they just said `/think` or `/think --autopilot` with no context), simply ask in your response: "What do you want to build?" Do NOT use `AskUserQuestion` for this. Just ask in plain text and wait for their reply.
 
-**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, starting point and risk. The user chose autopilot because they want speed, not a conversation.
+**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions, run a compressed Phase 4.5 (consider 2-3 approaches internally, pick one, record the discarded ones in `alternatives_considered` without asking the user), and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, starting point and risk. The user chose autopilot because they want speed, not a conversation; speed skips the dialogue, not the consideration of alternatives.
 
 Determine the mode from the user's description:
 
@@ -626,7 +626,7 @@ Save a clean markdown brief to `.nanostack/know-how/briefs/YYYY-MM-DD-<slug>.md`
 mkdir -p .nanostack/know-how/briefs
 ```
 
-Format and rules: see `think/references/brief-template.md`. Keep under 20 lines, skip sections that don't apply.
+Format and rules: see `think/references/brief-template.md`. Keep under 30 lines, skip sections that don't apply.
 
 ### Phase 6.6: Minimum Viable Brief Gate
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -396,7 +396,7 @@ Understand the landscape, then determine the mode.
 
 **If the user didn't provide an idea or problem** (e.g. they just said `/think` or `/think --autopilot` with no context), simply ask in your response: "What do you want to build?" Do NOT use `AskUserQuestion` for this. Just ask in plain text and wait for their reply.
 
-**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions, run a compressed Phase 4.5 (consider 2-3 approaches internally, pick one, record the discarded ones in `alternatives_considered` without asking the user), and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, starting point and risk. The user chose autopilot because they want speed, not a conversation; speed skips the dialogue, not the consideration of alternatives.
+**If AUTOPILOT is active:** Do NOT ask clarifying questions. Work with the information provided. Default to Builder mode. If the description is clear enough to plan, skip the diagnostic questions, run a compressed Phase 4.5 (consider 2-3 approaches internally, pick one, record the full set in `alternatives_considered` with the winner flagged `chosen: true`, without asking the user), and go straight to Phase 5 (scope recommendation) with a brief that covers value prop, scope, starting point and risk. The user chose autopilot because they want speed, not a conversation; speed skips the dialogue, not the consideration of alternatives.
 
 Determine the mode from the user's description:
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -441,6 +441,8 @@ Whatever mode you used, write the result to `summary.search_summary` in the stru
 
 ### Phase 2: The Diagnostic
 
+**Question cadence: one question per message.** Ask, wait for the answer, then ask the next. When a question has natural options, offer 2-4 short choices the user can pick from; an open answer is always welcome. Never batch the diagnostic into a numbered list of questions. The mode's questions still need to land before the brief is complete; the cadence changes how they arrive, not how many there are.
+
 **Apply the archetype lens to the opening question and the diagnostic emphasis** (see lens definitions in `think/references/archetypes.md`). The archetype selects and reorders the forcing questions, it does not replace them. Cover the **active mode's** diagnostic set: Startup forcing questions for `founder_validation` and `landing_experience`; Builder forcing questions for `cli_tooling` and `api_backend`. The archetype→mode mapping lives in `think/references/archetypes.md` ("Mode interaction"). The lens decides which question opens the conversation and which risks get extra airtime.
 
 | Archetype | Primary opening question | Diagnostic emphasis |
@@ -486,9 +488,17 @@ Then apply the **latent vs deterministic lens** from `think/references/latent-vs
 
 Then **argue the opposite**: construct the strongest case this should NOT be built. If the opposite argument is stronger, say so. If the original holds, it's battle-tested.
 
+### Phase 4.5: Alternatives
+
+Before recommending a scope mode, lay out the solution space. Present 2-3 genuinely different ways to attack the problem, each in 2-3 lines: what it is, what it trades away, what it costs to try. Make at least one a clearly smaller cut than the user's original framing. Then recommend one and say why.
+
+Keep the bias /think is known for: when two approaches deliver similar learning, recommend the smaller one. The point of the alternatives is not neutrality, it is making the recommendation legible: the user sees what was considered and what was traded, instead of receiving a single verdict.
+
+In Guided profile, present the approaches in plain language as "a few ways to do this" with no internal labels. The chosen approach feeds Phase 5: it becomes the scope the mode applies to. The discarded approaches become candidates for `out_of_scope` and land in the brief's "Alternatives considered" section and the artifact's optional `alternatives_considered` field.
+
 ### Phase 5: Scope Mode Selection
 
-Based on the diagnostic, recommend one of four scope modes:
+Based on the diagnostic and the approach chosen in Phase 4.5, recommend one of four scope modes:
 
 | Mode | When to use | Behavior |
 |------|-------------|----------|
@@ -519,9 +529,11 @@ Produce a clear brief for the next phase:
 - {{optional second, cap at three}}
 ```
 
+**Interactive validation (autopilot off): walk the brief in sections.** Do not drop the whole Think Summary as one blob and ask "look good?". Present it in three small passes, one per message, same cadence as the diagnostic: first what we are building (value proposition + starting point), then who it is for and the key risk, then what stays out of scope. Confirm each section before moving to the next and fold corrections in as they arrive. When the last section is confirmed, write the final Think Summary and save. Under autopilot, skip the section walk: the brief gate in Phase 6.6 is the validation.
+
 Immediately after writing the Think Summary — before anything else, before presenting next steps — save the artifact as **structured JSON** that matches the canonical schema in `reference/artifact-schema.md`. Downstream skills (`/nano`, `bin/sprint-journal.sh`, `bin/resolve.sh`) read the named fields, so the prose-blob form (`--from-session`) is no longer acceptable for `/think`.
 
-Build the JSON inline and pass it to `save-artifact.sh`. Required fields (the autopilot brief gate refuses to advance without them): `value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. Optional but encouraged: `out_of_scope`, `manual_delivery_test`, `search_summary`, `context_checkpoint`.
+Build the JSON inline and pass it to `save-artifact.sh`. Required fields (the autopilot brief gate refuses to advance without them): `value_proposition`, `scope_mode`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. Optional but encouraged: `out_of_scope`, `manual_delivery_test`, `search_summary`, `alternatives_considered`, `design_summary`, `context_checkpoint`. The brief gate never consults the optional fields, so a brief without alternatives is still a complete brief.
 
 Use `jq -n` so the output is real JSON, not a string with embedded quotes:
 
@@ -541,6 +553,8 @@ THINK_JSON=$(jq -n \
   --argjson out_of_scope          '[]' \
   --argjson manual_delivery_test  '{"possible": false, "steps": []}' \
   --argjson search_summary        '{"mode": "local_only", "result": "", "existing_solution": "none"}' \
+  --argjson alternatives_considered '[]' \
+  --arg design_summary            "" \
   --arg archetype                 "unknown" \
   --arg archetype_confidence      "low" \
   --arg archetype_source          "fallback" \
@@ -559,6 +573,8 @@ THINK_JSON=$(jq -n \
        out_of_scope:      $out_of_scope,
        manual_delivery_test: $manual_delivery_test,
        search_summary:    $search_summary,
+       alternatives_considered: $alternatives_considered,
+       design_summary:    $design_summary,
        archetype:            $archetype,
        archetype_confidence: $archetype_confidence,
        archetype_source:     $archetype_source,
@@ -584,6 +600,8 @@ When an archetype WAS detected or set explicitly, replace the five default value
 | No signal hit threshold | `fallback` | `low` |
 
 `archetype_reason` is one short sentence the user could read: e.g. `"Current project has server.js and the prompt references an endpoint."` Empty string is acceptable for the `unknown`/`fallback` case.
+
+`alternatives_considered` carries the Phase 4.5 pass when it happened: one object per approach, `{"approach": "string", "tradeoff": "string", "chosen": false}`, with `chosen: true` on the one that won. `design_summary` is 2-4 sentences on how the chosen approach works, the same prose that lands in the brief's Design section. Leave both empty when Phase 4.5 collapsed to a single obvious approach; the gate never reads them.
 
 `example_reference` is `null` when archetype is `unknown`. Otherwise it is the object documented in `think/references/archetypes.md` for that archetype:
 

--- a/think/references/brief-template.md
+++ b/think/references/brief-template.md
@@ -25,6 +25,12 @@ This is a human-readable document the user can share with a team, paste into a d
 ## Key Risk
 <the one thing most likely to make this fail>
 
+## Alternatives Considered
+<one line per approach from Phase 4.5: what it was, what it traded away, and which one was chosen and why>
+
+## Design
+<2-4 sentences: how the chosen approach works, written so a teammate who missed the conversation can follow it>
+
 ## What We Decided NOT to Build
 <out of scope items from the diagnostic>
 
@@ -34,9 +40,9 @@ This is a human-readable document the user can share with a team, paste into a d
 
 ## Rules
 
-- Keep it under 20 lines total.
+- Keep it under 30 lines total.
 - No filler, no headers without content.
-- Skip sections that don't apply (e.g., omit "What We Decided NOT to Build" if nothing was excluded).
+- Skip sections that don't apply (e.g., omit "What We Decided NOT to Build" if nothing was excluded, omit "Alternatives Considered" and "Design" if Phase 4.5 collapsed to a single obvious approach).
 - The slug is derived from the value proposition: lowercase, hyphenated, max ~5 words.
 
 ## Retro briefs


### PR DESCRIPTION
## Summary

/think challenged scope well but delivered its verdict in one block: questions in free order, a single recommendation, one brief presented whole. Users coming from conversational design tools experience that as an interrogation followed by a verdict.

This PR makes the same rigor feel like working with a partner, without losing what makes /think /think: the bias toward the smallest version that ships still wins.

## What changed

- **One question per message.** The diagnostic now asks, waits, and offers 2-4 short choices when the question has natural options. The six forcing questions per mode are unchanged; only the delivery cadence is specified.
- **Alternatives before the verdict.** A new Phase 4.5 presents 2-3 genuinely different approaches with trade-offs, then recommends one. When two approaches deliver similar learning, it recommends the smaller one. Discarded approaches feed out_of_scope and a new "Alternatives Considered" section in the shareable brief. Autopilot runs the same pass compressed: considered internally, recorded in the artifact, no dialogue.
- **The brief validates in sections.** Interactive runs walk the Think Summary in three small passes (what we build, who it is for and the risk, what stays out) instead of dropping one blob. Autopilot skips the walk; the existing brief gate remains the validation.

## Compatibility

The artifact gains two optional fields, `alternatives_considered` and `design_summary`. The five-field brief gate is untouched and never consults them, so every existing consumer and any v1-shaped brief keep working unchanged.

## Validation

- New `think-collaborative-contract` lint job locks the cadence, the alternatives pass with its bias, the sectioned walk with its autopilot exemption, and the gate exemption of the new fields.
- New e2e cell proves the fields roundtrip and the gate passes with and without them: think-flows 38/38, think-archetypes 25/25, structured-artifacts 31/31, all static-contract suites, harness manifest.
- Independent review ran three passes; both findings (autopilot bypassing the alternatives pass, conflicting brief length limits) were fixed in follow-up commits.