### PR TITLE
docs: describe /think in grounded language across every surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file lists every built-in skill shipped by Nanostack for the verified adapt
 
 | Skill | Directory | Description |
 |-------|-----------|-------------|
-| think | `think/` | Strategic product thinking with calibrated intensity per archetype. Saves a structured artifact (value proposition, scope mode, target user, narrowest wedge, key risk, premise validation). |
+| think | `think/` | Refines a rough idea before code: questions one at a time, alternatives with trade-offs, design walked in sections. Calibrated per archetype. Saves a structured artifact (value proposition, scope mode, target user, narrowest wedge, key risk, premise validation). |
 | nano  | `plan/` | Implementation planning. Planned files, plan approval, scope assessment, product standards. |
 | review | `review/` | Two-pass code review (structural + adversarial). Scope drift detection against /nano. Conflict precedence with /security. |
 | qa     | `qa/` | Browser, API, CLI, or debug testing. WTF heuristic. |

--- a/README.es.md
+++ b/README.es.md
@@ -154,7 +154,7 @@ Nanostack es un proceso, no una colección de herramientas. Las skills corren en
 
 | Skill | Tu especialista | Qué hace |
 |-------|-----------------|----------|
-| `/think` | **CEO / Founder** | Cuestiona el alcance antes de construir. Tres modos de intensidad (Founder, Startup, Builder). Seis preguntas de calibración. `--autopilot` corre el sprint completo después de aprobar el brief. `--retro` reflexiona sobre lo que ya se hizo. |
+| `/think` | **CEO / Founder** | Se activa antes de construir. Refina una idea cruda con preguntas, de a una. Explora 2-3 caminos con sus trade-offs. Recorre el diseño con vos, sección por sección. Guarda un brief que los próximos pasos leen. `--autopilot` corre el sprint completo después de aprobar el brief. `--retro` reflexiona sobre lo que ya se hizo. |
 | `/nano` | **Eng Manager** | Genera specs de producto (alcance Mediano) o specs de producto + técnico (alcance Grande) antes de los pasos de implementación. Estándares por tipo de proyecto (web, CLI/TUI). |
 | `/review` | **Staff Engineer** | Revisión de código en dos pasadas: estructural y luego adversarial. Auto-arregla cosas mecánicas. Detecta scope drift contra el plan. |
 | `/qa` | **QA Lead** | Testing funcional + Visual QA. Toma screenshots y analiza la UI contra los estándares de producto. Modos browser, API, CLI y debug. |

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The built-in sprint is the default stack:
 
 |        | Step              | What the specialist does                                                |
 | ------ | ----------------- | ----------------------------------------------------------------------- |
-| **01** | `/think`          | Challenges scope. Finds the smallest useful version.                    |
+| **01** | `/think`          | Refines your rough idea through questions. Finds the smallest useful version. |
 | **02** | `/nano`           | Plans the implementation. Names files, risks, and checks.               |
 | **03** | build             | You or the agent writes the code.                                       |
 | **04** | `/review`         | Two-pass code review. Scope drift detection. Auto-fixes the mechanical. |
@@ -223,7 +223,7 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 
 | Skill | Your specialist | What they do |
 |-------|----------------|--------------|
-| `/think` | **Product discovery** | Challenges scope before planning. Produces a structured brief with value proposition, target user, smallest wedge, key risk, and premise state. Supports guided archetypes, search privacy modes (`local_only`, `private`, `public`), `--retro` for sprint reflection, and `--autopilot` after the brief is complete. |
+| `/think` | **Product discovery** | Activates before you build. Refines a rough idea through questions, one at a time. Explores 2-3 approaches with trade-offs. Walks the design with you, section by section. Saves a brief your next steps read. Supports guided archetypes, search privacy modes (`local_only`, `private`, `public`), `--retro` for sprint reflection, and `--autopilot` after the brief is complete. |
 | `/nano` | **Eng Manager** | Auto-generates product specs (Medium scope) or product + technical specs (Large scope) before implementation steps. Product standards for web (shadcn/ui), CLI/TUI (Bubble Tea, Rich, Ink, Ratatui). Stack defaults with CLI preference for beginners. |
 | `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan. Cross-references `/security` with 10 conflict precedents. |
 | `/qa` | **QA Lead** | Functional testing + Visual QA. Takes screenshots and analyzes UI against product standards. Browser, API, CLI and debug modes. WTF heuristic stops before fixes cause regressions. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ You have access to a set of composable engineering workflow skills. Each skill i
 
 | Skill | When to use | Modes | Key files |
 |-------|-------------|-------|-----------|
-| `/think` | Before planning — strategic product thinking, premise validation, scope decisions. | — | `think/references/forcing-questions.md`, `think/references/cognitive-patterns.md` |
+| `/think` | Before you build. Refines a rough idea through questions, explores alternatives, walks the design in sections. | — | `think/references/forcing-questions.md`, `think/references/cognitive-patterns.md` |
 | `/nano` | Before starting any non-trivial work. Produces a scoped, actionable plan. | — | `plan/templates/plan-template.md` |
 | `/review` | After code is written. Two-pass review + scope drift detection + conflict resolution. | `--quick` `--standard` `--thorough` | `review/checklist.md`, `reference/conflict-precedents.md` |
 | `/qa` | To verify code works. Browser-based testing with Playwright, plus root-cause debugging. | `--quick` `--standard` `--thorough` | `qa/bin/screenshot.sh` |

--- a/bin/about.sh
+++ b/bin/about.sh
@@ -48,7 +48,7 @@ Local workflow framework for AI coding agents. The built-in sprint plus a framew
 
 | Command | What it does |
 |---------|-------------|
-| /think | Challenge assumptions, find the starting point. --autopilot for full sprint. --retro to reflect. |
+| /think | Refine a rough idea through questions and alternatives, find the starting point. --autopilot for full sprint. --retro to reflect. |
 | /nano | Turn idea into implementation plan with file names and risks. |
 | /review | Two-pass code review: structural + adversarial. |
 | /security | OWASP Top 10 + STRIDE audit. |

--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@ Other agents may read the SKILL.md files directly, but are not verified adapters
 
 ## Default sprint
 
-- /think: Strategic product thinking with calibrated intensity per archetype (founder validation, CLI tooling, API backend, landing experience). Saves a structured artifact with value proposition, scope mode, target user, narrowest wedge, key risk, and premise validation.
+- /think: Refines a rough idea before any code is written: questions one at a time, 2-3 alternative approaches with trade-offs, design walked in sections. Calibrates intensity per archetype (founder validation, CLI tooling, API backend, landing experience). Saves a structured artifact with value proposition, scope mode, target user, narrowest wedge, key risk, and premise validation.
 - /nano (alias /plan): Implementation plan with planned_files, plan approval, scope assessment, and product standards.
 - build: The agent's own dev work. Not a saved phase; the artifact appears on review.
 - /review: Two-pass code review (structural + adversarial). Detects scope drift against the plan and conflict-precedence against prior /security.

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: think
-description: Use before planning when you need strategic clarity — product discovery, scope decisions, premise validation. Applies YC-grade product thinking to challenge assumptions and find the smallest starting point. Supports --autopilot to run the full sprint automatically after approval. Use --retro after a sprint to reflect on what shipped. Triggers on /think, /office-hours, /ceo-review.
+description: Use when you have a rough idea and want it sharpened before any code is written. Refines the idea through questions, one at a time. Explores 2-3 approaches with trade-offs. Walks the design with you, section by section. Saves a brief your next steps read. Still challenges scope and finds the smallest starting point. Supports --autopilot to run the full sprint automatically after approval. Use --retro after a sprint to reflect on what shipped. Triggers on /think, /office-hours, /ceo-review.
 concurrency: read
 depends_on: []
-summary: "Strategic product thinking. Challenges assumptions, finds the smallest starting point, validates premise before planning."
+summary: "Refines a rough idea through questions, alternatives, and a sectioned brief. Challenges scope, finds the smallest starting point."
 estimated_tokens: 450
 ---
 


### PR DESCRIPTION
## Summary

The /think descriptions read as strategy vocabulary: strategic clarity, premise validation, calibrated intensity. After #253 the skill behaves like a design partner, and the words should say what a first-time user will experience, not name the methodology.

## What changed

Every public surface now describes /think the same way:

> Activates before you build. Refines a rough idea through questions, one at a time. Explores 2-3 approaches with trade-offs. Walks the design with you, section by section. Saves a brief your next steps read.

Updated surfaces: the skill frontmatter, both README sprint tables, README.es.md in the same voice, llms.txt, AGENTS.md, the root skill table, and the generated self-description. Feature mentions (archetypes, search privacy modes, --retro, --autopilot) and the artifact field list stay where they were.

## Validation

Every static-contract suite, think-flows 38/38, think-archetypes 25/25, and the three README lock scripts pass. Wording only; no behavior changed.