### PR TITLE
ci: isolate write_guard e2e flow from ambient session

### DIFF
--- a/ci/e2e-user-flows.sh
+++ b/ci/e2e-user-flows.sh
@@ -254,6 +254,14 @@ flow_write_guard() {
   cd "$proj"
   local guard="$REPO/guard/bin/check-write.sh"
 
+  # Hermetic store: this flow tests the secret/symlink denylist, not the
+  # read-phase block (flow 5 covers that). Without an isolated store the
+  # guard falls back to ~/.nanostack, so a developer with an ambient
+  # sprint session would see every "allow" assertion fail under that
+  # session's read-only phase. Point at an empty, sessionless store.
+  export NANOSTACK_STORE="$proj/.nanostack"
+  mkdir -p "$NANOSTACK_STORE"
+
   # Block list — basename matches do not need symlink resolution.
   assert_false "write blocks: .env" "$guard" "$proj/.env"
 
@@ -295,6 +303,7 @@ flow_write_guard() {
   assert_true "write allows: relative symlink within project" \
     "$guard" "$proj/safe-link/notes.txt"
 
+  unset NANOSTACK_STORE
   cd "$REPO"
 }
 


### PR DESCRIPTION
## What this does

Makes the `write_guard` end-to-end flow hermetic. It now runs against its own empty store instead of falling back to the developer's `~/.nanostack`.

## Why it matters

The flow tests the write guard's secret and symlink denylist (block `.env`, block symlinks that reach `/etc`, allow `.env.example` and in-project files). It did not set `NANOSTACK_STORE`, so the guard fell back to the global session. A developer with an active sprint session in a read-only phase saw every "allow" assertion fail, because writes are correctly blocked during read-only phases. CI runners have no global session, so this only showed up on local `run-harness.sh --all` runs.

The read-phase block itself is already covered by a separate flow, so this flow should not depend on whatever session happens to be active.

## What changed

`flow_write_guard` points `NANOSTACK_STORE` at an empty, sessionless store for the duration of the flow and unsets it afterward. No production code changes.

## Testing

Full local `ci/run-harness.sh --all` is green, including the previously local-only `write_guard` failures.
