### PR TITLE
docs: correct guard tier order in README (EN + ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -201,14 +201,14 @@ Los agentes cometen errores. Corren `rm -rf` cuando querían `rm -r`, hacen forc
 
 ### Seis tiers de seguridad
 
-Cada comando de Bash pasa por estos seis tiers, en este orden:
+Cada comando de Bash pasa por estos seis tiers, en este orden. El orden importa: los gates globales corren antes del allowlist y del atajo in-project, así que un comando allowlisteado o in-project no puede saltearlos.
 
 1. **Block rules**: las reglas de bloqueo corren primero. Cubren borrado masivo (`rm -rf .`, `find . -delete`), destrucción de historia (`git push --force`), lecturas de secretos (`.env`, `*.pem`), drops de DB, deploys a producción y ejecución remota (`curl | sh`). Una coincidencia bloquea aunque el binario esté en el allowlist de abajo. La fuente de verdad es [`guard/rules.json`](guard/rules.json); para ver el conteo actual: `jq '[.tiers.block.rules[].id] | length' guard/rules.json`.
-2. **Allowlist**: para comandos que pasaron las block rules, los allowlisteados (`git status`, `ls`, `cat`, `jq`, etc.) saltan el resto.
-3. **In-project**: operaciones que solo tocan archivos del repo actual pasan. El control de versiones es la red de seguridad.
-4. **Concurrencia por fase**: durante fases read-only (review, security, qa), las operaciones de escritura quedan bloqueadas para evitar race conditions.
-5. **Phase gate**: cuando hay un sprint activo, `git commit` y `git push` quedan bloqueados hasta que existan artifacts frescos de review, security y qa.
-6. **Budget gate**: cuando el sprint tiene un presupuesto y se gastó 95%+, todos los comandos no-allowlist quedan bloqueados.
+2. **Concurrencia por fase**: durante fases read-only (review, security, qa), las operaciones de escritura quedan bloqueadas para que las fases que corren en paralelo no muten estado compartido. La detección cubre más que las utilidades obvias: redirección de salida, editores in-place (`sed -i`, `perl -i`), código inline de intérprete (`python -c`, `node -e`, `sh -c`, `eval`), escrituras de gestores de paquetes, y mutaciones de index, worktree o refs de git. Lock: `ci/e2e-read-phase-writes.sh`.
+3. **Phase gate**: cuando hay un sprint activo, `git commit` y `git push` quedan bloqueados hasta que existan artifacts frescos de review, security y qa.
+4. **Budget gate**: cuando el sprint tiene un presupuesto y se gastó 95%+, todos los comandos no-allowlist quedan bloqueados.
+5. **Allowlist**: recién después de que pasen los gates de arriba, las lecturas seguras (`git status`, `ls`, `cat`, `jq`, etc.) saltan el resto. Correr el allowlist después de los gates globales es lo que evita que un binario allowlisteado se saltee una fase read-only o el phase gate.
+6. **In-project**: operaciones que solo tocan archivos del repo actual pasan, después de que corrieron los gates. El control de versiones es la red de seguridad.
 
 Mas un tier de reglas de advertencia (`warn`) para operaciones que requieren atención sin llegar a bloqueo. Las definiciones también viven en `guard/rules.json`.
 

--- a/README.md
+++ b/README.md
@@ -457,19 +457,19 @@ AI agents make mistakes. They run `rm -rf` when they mean `rm -r`, force push to
 
 ### Six tiers
 
-Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every Bash command through six tiers in this order:
+Inspired by [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), guard evaluates every Bash command through six tiers in this order. The order matters: the global gates run before the allowlist and in-project shortcuts, so a safe-listed or in-project command cannot skip them.
 
-**Tier 1: Block rules.** Patterns for mass deletion, history destruction, database drops, production deploys, remote code execution, secret reads, security degradation and safety bypasses run first. A match exits 1 immediately, even if the command's binary is on the allowlist below. This ordering closes the bypass class where `find . -delete` or `cat .env` slipped past Tier 2 because `find` and `cat` were on the allowlist. Block rule definitions live in [`guard/rules.json`](guard/rules.json); query the live count with `jq '[.tiers.block.rules[].id] | length' guard/rules.json`.
+**Tier 1: Block rules.** Patterns for mass deletion, history destruction, database drops, production deploys, remote code execution, secret reads, security degradation and safety bypasses run first. A match exits 1 immediately, even if the command's binary is on the allowlist below. This ordering closes the bypass class where `find . -delete` or `cat .env` slipped past the allowlist because `find` and `cat` were safe-listed. Block rule definitions live in [`guard/rules.json`](guard/rules.json); query the live count with `jq '[.tiers.block.rules[].id] | length' guard/rules.json`.
 
-**Tier 2: Allowlist.** After block rules clear, commands like `git status`, `ls`, `cat`, `jq` skip the remaining checks. They are read-only or otherwise side-effect-free for safe arguments.
+**Tier 2: Phase-aware concurrency.** During read-only phases (review, security, qa), write operations are blocked so phases that run in parallel cannot mutate shared state. Detection covers more than the obvious utilities: output redirection, in-place editors (`sed -i`, `perl -i`), inline interpreter code (`python -c`, `node -e`, `sh -c`, `eval`), package-manager writes, and git index, worktree, or ref mutations. The agent reports findings instead of auto-fixing. Locked by `ci/e2e-read-phase-writes.sh`.
 
-**Tier 3: In-project.** Operations that only touch files inside the current git repo pass through. If the agent writes a bad file, you revert it. Version control is the safety net.
+**Tier 3: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security, and qa artifacts exist and are fresher than the latest code change. This prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
 
-**Tier 4: Phase-aware concurrency.** During read-only phases (review, security, qa), write operations are blocked. This prevents race conditions when multiple agents run in parallel. The agent reports findings instead of auto-fixing.
+**Tier 4: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but cannot execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
 
-**Tier 5: Phase gate.** When a sprint is active, `git commit` and `git push` are blocked until review, security, and qa artifacts exist and are fresher than the latest code change. This prevents the agent from skipping pipeline phases on simple tasks. Bypass with `NANOSTACK_SKIP_GATE=1` for non-sprint commits.
+**Tier 5: Allowlist.** Only after the gates above clear do safe reads like `git status`, `ls`, `cat`, `jq` short-circuit the rest. They are read-only or otherwise side-effect-free for safe arguments. Running the allowlist after the global gates is what stops a safe-listed binary from skipping a read-only phase or the phase gate.
 
-**Tier 6: Budget gate.** When a sprint budget is set and 95%+ spent, all non-allowlisted commands are blocked. The agent can still run safe commands (`ls`, `git status`, `cat`) to save work, but cannot execute builds, tests, or deploys. Bypass with `NANOSTACK_SKIP_BUDGET=1`.
+**Tier 6: In-project.** Operations that only touch files inside the current git repo pass through, after the gates have run. If the agent writes a bad file, you revert it. Version control is the safety net.
 
 Plus a Tier 7 of warn rules for operations that need attention but not blocking. Warn rule definitions also live in `guard/rules.json`.
 


### PR DESCRIPTION
## What this does

Corrects the guard "Six tiers" section in both READMEs so the documented order matches the actual code.

## Why it matters

The section listed the allowlist and the in-project shortcut before the phase-concurrency, phase gate, and budget gates. The guard runs the global gates first, which is the ordering introduced so a safe-listed or in-project command cannot skip a read-only phase or the phase gate. The old text described the behavior that ordering was meant to prevent, and it contradicted the `/guard` description elsewhere in the same README.

## What changed

- Reordered the six tiers in `README.md` and `README.es.md` to: block rules, phase-aware concurrency, phase gate, budget gate, allowlist, in-project.
- Added a one-line note that the global gates run before the allowlist and in-project shortcuts.
- Folded the broadened read-phase write detection (redirection, in-place editors, inline interpreter code, package-manager and git mutations) into the concurrency tier description.

Documentation only. No code or behavior change.
