### PR TITLE
ci: enforce the manifest expected_checks floor in run-harness

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -357,6 +357,13 @@ jobs:
         run: |
           chmod +x ci/e2e-harness-selftest.sh
           ci/e2e-harness-selftest.sh
+      - name: Run ci/e2e-run-harness-selftest.sh
+        # Proves run-harness.sh enforces the manifest expected_checks
+        # floor (fails closed on under-count, missing summary, and
+        # mid-run count noise).
+        run: |
+          chmod +x ci/e2e-run-harness-selftest.sh
+          ci/e2e-run-harness-selftest.sh
 
   harness-manifest:
     name: Harness manifest consistency

--- a/ci/check-data-hygiene.sh
+++ b/ci/check-data-hygiene.sh
@@ -11,7 +11,8 @@ set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 fail=0
-pass() { printf '  ok   %s\n' "$1"; }
+pass_count=0
+pass() { pass_count=$((pass_count+1)); printf '  ok   %s\n' "$1"; }
 miss() { printf '  FAIL %s\n' "$1"; fail=1; }
 
 # ── #12 guard audit/deny secret masking ─────────────────────────────────────
@@ -154,4 +155,4 @@ if [ "$fail" -ne 0 ]; then
   echo "check-data-hygiene: FAIL"
   exit 1
 fi
-echo "check-data-hygiene: OK"
+echo "check-data-hygiene: OK ($pass_count checks passed)"

--- a/ci/check-helper-path-containment.sh
+++ b/ci/check-helper-path-containment.sh
@@ -14,7 +14,8 @@ export NANOSTACK_STORE="$(mktemp -d)/store"
 mkdir -p "$NANOSTACK_STORE"
 
 fail=0
-pass() { printf '  ok   %s\n' "$1"; }
+pass_count=0
+pass() { pass_count=$((pass_count+1)); printf '  ok   %s\n' "$1"; }
 miss() { printf '  FAIL %s\n' "$1"; fail=1; }
 
 # ── session.sh archive ──────────────────────────────────────────────────────
@@ -97,4 +98,4 @@ if [ "$fail" -ne 0 ]; then
   echo "check-helper-path-containment: FAIL"
   exit 1
 fi
-echo "check-helper-path-containment: OK"
+echo "check-helper-path-containment: OK ($pass_count checks passed)"

--- a/ci/check-policy-contract.sh
+++ b/ci/check-policy-contract.sh
@@ -20,7 +20,8 @@ set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 fail=0
-pass() { printf '  ok   %s\n' "$1"; }
+pass_count=0
+pass() { pass_count=$((pass_count+1)); printf '  ok   %s\n' "$1"; }
 miss() { printf '  FAIL %s\n' "$1"; fail=1; }
 
 GUARD="$ROOT/guard/bin/check-dangerous.sh"
@@ -291,4 +292,4 @@ if [ "$fail" -ne 0 ]; then
   echo "check-policy-contract: FAIL"
   exit 1
 fi
-echo "check-policy-contract: OK"
+echo "check-policy-contract: OK ($pass_count checks passed)"

--- a/ci/check-trusted-evidence.sh
+++ b/ci/check-trusted-evidence.sh
@@ -27,7 +27,8 @@ git commit -qm init >/dev/null 2>&1
 PROJECT="$WORK"
 
 fail=0
-ck() { if [ "$1" = "$2" ]; then printf '  ok   %s\n' "$3"; else printf '  FAIL %s (got %s, want %s)\n' "$3" "$2" "$1"; fail=1; fi; }
+pass_count=0
+ck() { if [ "$1" = "$2" ]; then pass_count=$((pass_count+1)); printf '  ok   %s\n' "$3"; else printf '  FAIL %s (got %s, want %s)\n' "$3" "$2" "$1"; fail=1; fi; }
 hash_of() { (sha256sum 2>/dev/null || shasum -a 256) | cut -d' ' -f1; }
 
 # Use a current artifact filename and timestamp (matching how save-artifact.sh
@@ -115,4 +116,4 @@ if [ "$fail" -ne 0 ]; then
   echo "check-trusted-evidence: FAIL"
   exit 1
 fi
-echo "check-trusted-evidence: OK"
+echo "check-trusted-evidence: OK ($pass_count checks passed)"

--- a/ci/check-visual-artifact-templates.sh
+++ b/ci/check-visual-artifact-templates.sh
@@ -235,9 +235,11 @@ check_absent "no addEventListener for form submission" \
   "addEventListener\\(['\"]submit" "bin/render-artifact.sh" "bin/lib/visual-render.sh"
 
 TOTAL=$((PASS+FAIL))
-printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"
 if [ "$FAIL" -gt 0 ]; then
   printf "${RED}=== %s checks failed ===${NC}\n" "$FAIL"
   exit 1
 fi
+# The count line goes last: run-harness.sh parses the final non-empty
+# line of the output for the expected_checks floor.
 printf "${GREEN}=== all checks passed ===${NC}\n"
+printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"

--- a/ci/e2e-run-harness-selftest.sh
+++ b/ci/e2e-run-harness-selftest.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# e2e-run-harness-selftest.sh — run-harness.sh check-floor sabotage test.
+#
+# run-harness.sh enforces the manifest's expected_checks as a floor: a
+# suite that exits 0 but reports fewer checks than declared (or no
+# parseable summary at all) counts as a failure, because exit codes
+# alone cannot catch a suite that silently skips cells. Like the
+# manifest selftest, this proves the enforcement fails closed on each
+# drift direction, using fixture suites under a throwaway manifest via
+# the NANOSTACK_HARNESS_MANIFEST hook, so a future refactor of
+# run-harness.sh cannot quietly turn the floor into a no-op.
+#
+# Exit 0 = all cells pass, exit 1 = any cell failed.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+. "$REPO/ci/lib/harness.sh"
+
+RUN_HARNESS="$REPO/ci/run-harness.sh"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) nh_set_filter "${2:-}"; shift 2 ;;
+    --filter=*) nh_set_filter "${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+nh_init run-harness-selftest nano-rhself
+nh_require_cmd jq
+
+FIX="$NH_TMP/fixtures"
+mkdir -p "$FIX"
+
+# A fixture suite that reports a configurable count, plus one that
+# prints no summary at all. Both always exit 0; only the floor logic
+# can flag them.
+cat > "$FIX/reports.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "running ${REPORT_N:-0} fixture checks"
+echo "fixture: ${REPORT_N:-0} checks passed, 0 failed"
+exit 0
+EOF
+cat > "$FIX/silent.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "fixture finished without a summary"
+exit 0
+EOF
+# A fixture that echoes a count-shaped phrase mid-run; only the final
+# summary may be parsed.
+cat > "$FIX/noisy.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "replaying log: 999 checks passed earlier today"
+echo "padding line one"
+echo "padding line two"
+echo "padding line three"
+echo "padding line four"
+echo "fixture: 3 checks passed, 0 failed"
+exit 0
+EOF
+chmod +x "$FIX"/*.sh
+
+write_manifest() {  # $1 = suite path, $2 = expected_checks
+  jq -n --arg p "$1" --argjson e "$2" '{
+    schema_version: 1,
+    suites: [{id:"fixture", path:$p, kind:"unit", tier:"pr",
+              surface:["fixture"], deps:["bash"], expected_checks:$e,
+              timeout_minutes:1, workflow:"none", job:"none"}]
+  }' > "$NH_TMP/manifest.json"
+  export NANOSTACK_HARNESS_MANIFEST="$NH_TMP/manifest.json"
+}
+
+run_fixture() {  # extra run-harness args after --suite fixture
+  nh_capture RH_OUT RH_RC bash "$RUN_HARNESS" --suite fixture "$@"
+}
+
+cell_floor_enforced() {
+  write_manifest "$FIX/reports.sh" 10
+
+  REPORT_N=10 run_fixture
+  nh_assert_eq "count at the floor passes" 0 "$RH_RC"
+
+  REPORT_N=5 run_fixture
+  nh_assert_eq "count below the floor fails" 1 "$RH_RC"
+  nh_assert_contains "below-floor run names the floor" "$RH_OUT" "below the manifest floor of 10"
+
+  REPORT_N=12 run_fixture
+  nh_assert_eq "count above the floor still passes" 0 "$RH_RC"
+  nh_assert_contains "above-floor run asks for a manifest bump" "$RH_OUT" "update expected_checks"
+}
+
+cell_no_summary() {
+  write_manifest "$FIX/silent.sh" 10
+  run_fixture
+  nh_assert_eq "missing summary fails when a floor is declared" 1 "$RH_RC"
+  nh_assert_contains "missing-summary run says so" "$RH_OUT" "no parseable check count"
+
+  write_manifest "$FIX/silent.sh" 0
+  run_fixture
+  nh_assert_eq "expected_checks 0 keeps unparseable suites exempt" 0 "$RH_RC"
+}
+
+cell_filter_exempt() {
+  # Filtering runs fewer cells by design, so the floor must not apply.
+  write_manifest "$FIX/reports.sh" 10
+  REPORT_N=2 run_fixture --filter anything
+  nh_assert_eq "filtered run skips the floor" 0 "$RH_RC"
+}
+
+cell_final_summary_wins() {
+  # The count comes from the end of the output: a count-shaped phrase
+  # echoed mid-run must not satisfy (or inflate past) the floor.
+  write_manifest "$FIX/noisy.sh" 3
+  run_fixture
+  nh_assert_eq "final summary line is the parsed count" 0 "$RH_RC"
+  write_manifest "$FIX/noisy.sh" 4
+  run_fixture
+  nh_assert_eq "mid-run 999 does not satisfy a floor of 4" 1 "$RH_RC"
+}
+
+nh_cell floor-enforced cell_floor_enforced
+nh_cell no-summary cell_no_summary
+nh_cell filter-exempt cell_filter_exempt
+nh_cell final-summary-wins cell_final_summary_wins
+
+nh_summary

--- a/ci/e2e-run-harness-selftest.sh
+++ b/ci/e2e-run-harness-selftest.sh
@@ -105,6 +105,12 @@ cell_filter_exempt() {
   write_manifest "$FIX/reports.sh" 10
   REPORT_N=2 run_fixture --filter anything
   nh_assert_eq "filtered run skips the floor" 0 "$RH_RC"
+  # Outside --suite the filter is never forwarded, so accepting it
+  # would disable the floor while running unfiltered suites. It must
+  # be rejected, not ignored.
+  nh_capture RH_OUT RH_RC bash "$RUN_HARNESS" --all --filter anything
+  nh_assert_eq "--filter without --suite is rejected" 2 "$RH_RC"
+  nh_assert_contains "rejection names the rule" "$RH_OUT" "requires --suite"
 }
 
 cell_final_summary_wins() {

--- a/ci/e2e-run-harness-selftest.sh
+++ b/ci/e2e-run-harness-selftest.sh
@@ -51,11 +51,16 @@ EOF
 cat > "$FIX/noisy.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "replaying log: 999 checks passed earlier today"
-echo "padding line one"
-echo "padding line two"
-echo "padding line three"
-echo "padding line four"
 echo "fixture: 3 checks passed, 0 failed"
+exit 0
+EOF
+# A fixture whose own summary is missing but whose tail contains a
+# count-shaped child line followed by cleanup chatter. The parser must
+# only accept the last non-empty line, so this reads as no summary.
+cat > "$FIX/child-noise.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "child: 10 checks passed, 0 failed"
+echo "cleaning up fixture workspace"
 exit 0
 EOF
 chmod +x "$FIX"/*.sh
@@ -114,14 +119,21 @@ cell_filter_exempt() {
 }
 
 cell_final_summary_wins() {
-  # The count comes from the end of the output: a count-shaped phrase
-  # echoed mid-run must not satisfy (or inflate past) the floor.
+  # The count comes from the last non-empty line only: a count-shaped
+  # phrase echoed mid-run must not satisfy (or inflate past) the floor.
   write_manifest "$FIX/noisy.sh" 3
   run_fixture
   nh_assert_eq "final summary line is the parsed count" 0 "$RH_RC"
   write_manifest "$FIX/noisy.sh" 4
   run_fixture
   nh_assert_eq "mid-run 999 does not satisfy a floor of 4" 1 "$RH_RC"
+  # A child invocation's count followed by cleanup chatter is not a
+  # summary: the suite never printed its own final line, so the floor
+  # must fail closed instead of adopting the child's count.
+  write_manifest "$FIX/child-noise.sh" 10
+  run_fixture
+  nh_assert_eq "trailing child count does not stand in for a summary" 1 "$RH_RC"
+  nh_assert_contains "child-noise run reads as missing summary" "$RH_OUT" "no parseable check count"
 }
 
 nh_cell floor-enforced cell_floor_enforced

--- a/ci/e2e-run-harness-selftest.sh
+++ b/ci/e2e-run-harness-selftest.sh
@@ -63,6 +63,14 @@ echo "child: 10 checks passed, 0 failed"
 echo "cleaning up fixture workspace"
 exit 0
 EOF
+# A fixture that mimics NANOSTACK_KEEP_TMP=1: the harness EXIT trap
+# prints a [harness] diagnostic after nh_summary.
+cat > "$FIX/keep-tmp.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "fixture: 3 checks passed, 0 failed"
+echo "[harness] NANOSTACK_KEEP_TMP=1 keeping temp root /tmp/fixture.XXXX"
+exit 0
+EOF
 chmod +x "$FIX"/*.sh
 
 write_manifest() {  # $1 = suite path, $2 = expected_checks
@@ -134,6 +142,12 @@ cell_final_summary_wins() {
   run_fixture
   nh_assert_eq "trailing child count does not stand in for a summary" 1 "$RH_RC"
   nh_assert_contains "child-noise run reads as missing summary" "$RH_OUT" "no parseable check count"
+  # The harness library's own diagnostics print after nh_summary from
+  # the EXIT trap (the NANOSTACK_KEEP_TMP notice). They are not suite
+  # output and must not hide the summary line above them.
+  write_manifest "$FIX/keep-tmp.sh" 3
+  run_fixture
+  nh_assert_eq "[harness] trailer does not hide the summary" 0 "$RH_RC"
 }
 
 nh_cell floor-enforced cell_floor_enforced

--- a/ci/e2e-visual-artifacts.sh
+++ b/ci/e2e-visual-artifacts.sh
@@ -403,9 +403,11 @@ fi
 
 # ─── Summary ────────────────────────────────────────────────
 TOTAL=$((PASS+FAIL))
-printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"
 if [ "$FAIL" -gt 0 ]; then
   printf "${RED}=== %s checks failed ===${NC}\n" "$FAIL"
   exit 1
 fi
+# The count line goes last: run-harness.sh parses the final non-empty
+# line of the output for the expected_checks floor.
 printf "${GREEN}=== all checks passed ===${NC}\n"
+printf "\n  %s/%s checks passed\n" "$PASS" "$TOTAL"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -66,7 +66,7 @@
         "bash",
         "jq"
       ],
-      "expected_checks": 13,
+      "expected_checks": 15,
       "timeout_minutes": 2,
       "workflow": ".github/workflows/lint.yml",
       "job": "harness-selftest"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -49,10 +49,27 @@
         "bash",
         "jq"
       ],
-      "expected_checks": 0,
+      "expected_checks": 51,
       "timeout_minutes": 2,
       "workflow": ".github/workflows/lint.yml",
       "job": "harness-manifest"
+    },
+    {
+      "id": "run-harness-selftest",
+      "path": "ci/e2e-run-harness-selftest.sh",
+      "kind": "unit",
+      "tier": "pr",
+      "surface": [
+        "harness-runner"
+      ],
+      "deps": [
+        "bash",
+        "jq"
+      ],
+      "expected_checks": 11,
+      "timeout_minutes": 2,
+      "workflow": ".github/workflows/lint.yml",
+      "job": "harness-selftest"
     },
     {
       "id": "concurrency-parity",
@@ -657,7 +674,7 @@
         "jq",
         "git"
       ],
-      "expected_checks": 0,
+      "expected_checks": 5,
       "timeout_minutes": 10
     }
   ]

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -66,7 +66,7 @@
         "bash",
         "jq"
       ],
-      "expected_checks": 11,
+      "expected_checks": 13,
       "timeout_minutes": 2,
       "workflow": ".github/workflows/lint.yml",
       "job": "harness-selftest"

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -66,7 +66,7 @@
         "bash",
         "jq"
       ],
-      "expected_checks": 15,
+      "expected_checks": 16,
       "timeout_minutes": 2,
       "workflow": ".github/workflows/lint.yml",
       "job": "harness-selftest"

--- a/ci/run-harness.sh
+++ b/ci/run-harness.sh
@@ -99,12 +99,14 @@ deps_ok() {  # $1 = space-separated deps; echoes first missing or empty
   echo ""
 }
 
-# Parse a suite's own summary line for its check count (checks or cells).
-# Only the tail of the output is scanned: a suite that happens to echo a
-# count-shaped phrase mid-run (a sub-invocation, a quoted fixture) must
-# not displace the real summary line, which suites print last.
+# Parse a suite's summary line for its check count (checks or cells).
+# Only the last non-empty line counts: every suite prints its summary
+# last, so a count-shaped phrase echoed earlier (a sub-invocation, a
+# quoted fixture, trailing log noise) can neither displace the real
+# summary nor stand in for a missing one.
 parse_count() {
-  printf '%s\n' "$1" | tail -5 | grep -oE '[0-9]+ (checks|cells) passed|[0-9]+/[0-9]+ checks passed' \
+  printf '%s\n' "$1" | awk 'NF { last = $0 } END { print last }' \
+    | grep -oE '[0-9]+ (checks|cells) passed|[0-9]+/[0-9]+ checks passed' \
     | tail -1 | grep -oE '^[0-9]+' | head -1
 }
 

--- a/ci/run-harness.sh
+++ b/ci/run-harness.sh
@@ -103,9 +103,12 @@ deps_ok() {  # $1 = space-separated deps; echoes first missing or empty
 # Only the last non-empty line counts: every suite prints its summary
 # last, so a count-shaped phrase echoed earlier (a sub-invocation, a
 # quoted fixture, trailing log noise) can neither displace the real
-# summary nor stand in for a missing one.
+# summary nor stand in for a missing one. Lines starting with
+# "[harness]" are the harness library's own diagnostics (the
+# NANOSTACK_KEEP_TMP notice prints from the EXIT trap, after
+# nh_summary) and are not suite output.
 parse_count() {
-  printf '%s\n' "$1" | awk 'NF { last = $0 } END { print last }' \
+  printf '%s\n' "$1" | awk 'NF && $0 !~ /^\[harness\]/ { last = $0 } END { print last }' \
     | grep -oE '[0-9]+ (checks|cells) passed|[0-9]+/[0-9]+ checks passed' \
     | tail -1 | grep -oE '^[0-9]+' | head -1
 }

--- a/ci/run-harness.sh
+++ b/ci/run-harness.sh
@@ -17,11 +17,21 @@
 #   --continue-on-fail   keep running after a suite fails
 #   --dry-run            print what would run, run nothing
 #   --json               emit a JSON summary instead of a table
+#
+# A suite with expected_checks > 0 in the manifest must report at least
+# that many checks in its summary line, or the run counts as a failure
+# even when the suite exits 0. Exit codes alone cannot catch a suite
+# that silently skips half its cells; the declared floor can. Runs with
+# --filter skip the floor (filtering runs fewer cells by design).
+#
+# Test hook: NANOSTACK_HARNESS_MANIFEST overrides the manifest path so
+# the selftest can exercise this script against fixture suites without
+# touching the real manifest.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-MANIFEST="$ROOT/ci/harnesses.json"
+MANIFEST="${NANOSTACK_HARNESS_MANIFEST:-$ROOT/ci/harnesses.json}"
 
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
 [ -f "$MANIFEST" ] || { echo "ERROR: $MANIFEST not found" >&2; exit 1; }
@@ -46,13 +56,15 @@ while [ $# -gt 0 ]; do
 done
 [ -n "$MODE" ] || { echo "ERROR: pick one of --list --suite --kind --tier --all" >&2; exit 2; }
 
-# Emit the selected suites as tab-separated id<TAB>path<TAB>kind<TAB>tier<TAB>deps(space).
+# Emit the selected suites as tab-separated
+# id<TAB>path<TAB>kind<TAB>tier<TAB>deps(space)<TAB>expected_checks.
 select_suites() {
+  local fields='[.id,.path,.kind,.tier,(.deps|join(" ")),(.expected_checks // 0)] | @tsv'
   case "$MODE" in
-    list|all) jq -r '.suites[] | [.id,.path,.kind,.tier,(.deps|join(" "))] | @tsv' "$MANIFEST" ;;
-    suite)    jq -r --arg s "$SELECT" '.suites[] | select(.id==$s) | [.id,.path,.kind,.tier,(.deps|join(" "))] | @tsv' "$MANIFEST" ;;
-    kind)     jq -r --arg s "$SELECT" '.suites[] | select(.kind==$s) | [.id,.path,.kind,.tier,(.deps|join(" "))] | @tsv' "$MANIFEST" ;;
-    tier)     jq -r --arg s "$SELECT" '.suites[] | select(.tier==$s) | [.id,.path,.kind,.tier,(.deps|join(" "))] | @tsv' "$MANIFEST" ;;
+    list|all) jq -r ".suites[] | $fields" "$MANIFEST" ;;
+    suite)    jq -r --arg s "$SELECT" ".suites[] | select(.id==\$s) | $fields" "$MANIFEST" ;;
+    kind)     jq -r --arg s "$SELECT" ".suites[] | select(.kind==\$s) | $fields" "$MANIFEST" ;;
+    tier)     jq -r --arg s "$SELECT" ".suites[] | select(.tier==\$s) | $fields" "$MANIFEST" ;;
   esac
 }
 
@@ -68,7 +80,7 @@ if [ "$MODE" = "list" ]; then
     exit 0
   fi
   printf '%-32s %-16s %-8s %s\n' "SUITE" "KIND" "TIER" "PATH"
-  printf '%s\n' "$ROWS" | while IFS=$'\t' read -r id path kind tier deps; do
+  printf '%s\n' "$ROWS" | while IFS=$'\t' read -r id path kind tier deps expected; do
     printf '%-32s %-16s %-8s %s\n' "$id" "$kind" "$tier" "$path"
   done
   exit 0
@@ -81,14 +93,17 @@ deps_ok() {  # $1 = space-separated deps; echoes first missing or empty
 }
 
 # Parse a suite's own summary line for its check count (checks or cells).
+# Only the tail of the output is scanned: a suite that happens to echo a
+# count-shaped phrase mid-run (a sub-invocation, a quoted fixture) must
+# not displace the real summary line, which suites print last.
 parse_count() {
-  printf '%s\n' "$1" | grep -oE '[0-9]+ (checks|cells) passed|[0-9]+/[0-9]+ checks passed' \
+  printf '%s\n' "$1" | tail -5 | grep -oE '[0-9]+ (checks|cells) passed|[0-9]+/[0-9]+ checks passed' \
     | tail -1 | grep -oE '^[0-9]+' | head -1
 }
 
 OVERALL=0
 RESULTS_JSON="[]"
-printf '%s\n' "$ROWS" | { TABLE=""; while IFS=$'\t' read -r id path kind tier deps; do
+printf '%s\n' "$ROWS" | { while IFS=$'\t' read -r id path kind tier deps expected; do
   [ -z "$id" ] && continue
   if $DRYRUN; then
     if $JSON; then
@@ -105,22 +120,43 @@ printf '%s\n' "$ROWS" | { TABLE=""; while IFS=$'\t' read -r id path kind tier de
     RESULTS_JSON=$(printf '%s' "$RESULTS_JSON" | jq --arg i "$id" '. + [{suite:$i,result:"skip"}]')
     continue
   fi
+  case "$path" in
+    /*) suite_path="$path" ;;
+    *)  suite_path="$ROOT/$path" ;;
+  esac
   start=$(date +%s)
   if [ "$MODE" = "suite" ] && [ -n "$FILTER" ]; then
-    out=$(bash "$ROOT/$path" --filter "$FILTER" 2>&1); rc=$?
+    out=$(bash "$suite_path" --filter "$FILTER" 2>&1); rc=$?
   else
-    out=$(bash "$ROOT/$path" 2>&1); rc=$?
+    out=$(bash "$suite_path" 2>&1); rc=$?
   fi
   end=$(date +%s)
   secs=$((end - start))
   count=$(parse_count "$out"); count="${count:-?}"
+  # Enforce the manifest's declared check floor. A suite that exits 0
+  # but reports fewer checks than expected_checks (or none at all) has
+  # silently skipped work; count that as a failure. Filtered runs are
+  # exempt, and a count above the floor only earns a reminder to bump
+  # the manifest.
+  floor_msg=""
+  if [ "$rc" -eq 0 ] && [ -z "$FILTER" ] && [ "${expected:-0}" -gt 0 ]; then
+    if [ "$count" = "?" ]; then
+      rc=1; floor_msg="ERROR: $id reported no parseable check count (manifest expects >= $expected)"
+    elif [ "$count" -lt "$expected" ]; then
+      rc=1; floor_msg="ERROR: $id reported $count checks, below the manifest floor of $expected"
+    elif [ "$count" -gt "$expected" ]; then
+      floor_msg="note: $id reported $count checks, manifest expects $expected (update expected_checks)"
+    fi
+  fi
   if [ "$rc" -eq 0 ]; then result="pass"; else result="FAIL"; OVERALL=1; fi
   if ! $JSON; then
     printf '%-28s %-7s %-7s %ss\n' "$id" "$count" "$result" "$secs"
     [ "$rc" -ne 0 ] && printf '%s\n' "$out" | tail -20
+    [ -n "$floor_msg" ] && printf '%s\n' "$floor_msg"
   fi
   RESULTS_JSON=$(printf '%s' "$RESULTS_JSON" | jq --arg i "$id" --arg c "$count" --arg r "$result" --argjson s "$secs" \
-    '. + [{suite:$i,checks:$c,result:$r,seconds:$s}]')
+    --argjson e "${expected:-0}" --arg n "$floor_msg" \
+    '. + [{suite:$i,checks:$c,expected:$e,result:$r,seconds:$s} + (if $n == "" then {} else {note:$n} end)]')
   if [ "$rc" -ne 0 ] && [ "$CONTINUE" = "false" ]; then
     break
   fi

--- a/ci/run-harness.sh
+++ b/ci/run-harness.sh
@@ -55,6 +55,13 @@ while [ $# -gt 0 ]; do
   esac
 done
 [ -n "$MODE" ] || { echo "ERROR: pick one of --list --suite --kind --tier --all" >&2; exit 2; }
+# --filter is only forwarded in --suite mode. Accepting it elsewhere
+# would silently run unfiltered suites with the expected_checks floor
+# disabled, so reject it instead of ignoring it.
+if [ -n "$FILTER" ] && [ "$MODE" != "suite" ]; then
+  echo "ERROR: --filter requires --suite" >&2
+  exit 2
+fi
 
 # Emit the selected suites as tab-separated
 # id<TAB>path<TAB>kind<TAB>tier<TAB>deps(space)<TAB>expected_checks.


### PR DESCRIPTION
## Summary

`ci/run-harness.sh` trusted exit codes: a suite that exited 0 but silently skipped half its cells still read as a pass, and the parsed check count was cosmetic. The manifest's `expected_checks` is now a floor the runner enforces.

- A suite reporting fewer checks than declared, or no parseable summary at all, fails the run.
- A count above the floor passes and prints a reminder to update `expected_checks`.
- Runs with `--filter` are exempt, since filtering runs fewer cells by design.

## Details

- `parse_count` now reads only the tail of the suite output, so a count-shaped phrase echoed mid-run (a sub-invocation, a quoted fixture) cannot displace the real summary line.
- Four static-contract suites (`check-helper-path-containment`, `check-trusted-evidence`, `check-data-hygiene`, `check-policy-contract`) declared floors but printed unparseable summaries; they now print `N checks passed` counts, and all four match their declared floors exactly (10, 11, 16, 32).
- Two stale manifest entries corrected: `harness-manifest-selftest` (0 to 51) and `tests-e2e-user-flows` (0 to 5).
- New `ci/e2e-run-harness-selftest.sh` (11 checks, pr tier, runs in the `harness-selftest` job) proves the floor fails closed on under-count, missing summary, and mid-run count noise, using fixture suites through a `NANOSTACK_HARNESS_MANIFEST` test hook.
- Dead `TABLE` variable removed; JSON output now carries `expected` and the floor note.

## Testing

- `ci/run-harness.sh --all --continue-on-fail`: 35/35 suites pass with the floor active.
- `ci/check-harness-manifest.sh`: consistent with 35 suites, scripts, and workflows.