### PR TITLE
fix(skills): align profile fallback, add guided output to review/security, handle report-only compound

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2085,7 +2085,7 @@ jobs:
           fi
           # Each user-facing skill must point at the contract so wording
           # changes don't drift away from the canonical list.
-          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md; do
+          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md review/SKILL.md security/SKILL.md; do
             if ! grep -q "reference/plain-language-contract.md" "$skill"; then
               echo "FAIL: $skill must reference reference/plain-language-contract.md"
               fail=1
@@ -2101,7 +2101,7 @@ jobs:
           # the contract's term table. Patterns use word boundaries so
           # "diff" doesn't match "different".
           patterns='\bartifact\b|\bartifacts\b|\bPR\b|\bPRs\b|\bCI\b|\bbranch\b|\bbranches\b|\bdiff\b|\bdiffs\b|\bhook\b|\bhooks\b|\bphase\b|\bphases\b|\bsecurity audit\b|\bQA\b|\bscope drift\b'
-          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md reference/plain-language-contract.md; do
+          for skill in think/SKILL.md plan/SKILL.md qa/SKILL.md ship/SKILL.md doctor/SKILL.md review/SKILL.md security/SKILL.md reference/plain-language-contract.md; do
             # Extract fenced blocks. awk emits one line per block,
             # joined with " || " so grep -E -i sees the full block.
             blocks=$(awk '

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -44,6 +44,13 @@ The output is JSON with `upstream_artifacts` containing paths for think, plan, r
 - `/think` scope decisions (these are decisions worth recording)
 - `/qa` failures that were debugged (these are bugs with investigation trails)
 
+**Report-only ship check.** Read the ship artifact's `run_mode`. If it is `"report_only"`, `/ship` only previewed the delivery and nothing was published (no commit, no PR, no deploy). Tell the user plainly that the ship was report-only, then keep going: the investigation from `/review`, `/security`, and `/qa` is still worth capturing if it was non-trivial. But do not write a solution or summary that claims work was shipped or that the sprint closed. There is no shipment to record yet.
+
+```bash
+SHIP_ARTIFACT=$(~/.claude/skills/nanostack/bin/resolve.sh compound 2>/dev/null | jq -r '.upstream_artifacts.ship // empty')
+SHIP_RUN_MODE=$(jq -r '.run_mode // "normal"' "$SHIP_ARTIFACT" 2>/dev/null || echo "normal")
+```
+
 ### 2. Identify what's worth capturing
 
 Not everything needs a solution document. Capture:

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -205,7 +205,25 @@ Use `.user_message` for the prose to show the user (it is profile-aware). Use `.
 
 The legacy positional form (`next-step.sh review`) still works and emits a space-separated list of pending phases for the autopilot logging line below; prefer `--json` for everything else.
 
-When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block.
+When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block. Use plain words (no "review", "findings", "blocking"). Example:
+
+<!-- guided-output:start -->
+```
+Resultado: El trabajo esta solido y se entiende bien.
+
+Como verlo:
+1. Corre el comando que te indique mas arriba y segui las instrucciones.
+
+Que revise:
+- La logica principal hace lo que tiene que hacer.
+- Los casos comunes quedan cubiertos, sin cabos sueltos.
+- El codigo es claro para la proxima persona que lo toque.
+
+Pendiente:
+- Anote un par de detalles menores para mas adelante.
+- No mire casos muy poco frecuentes.
+```
+<!-- guided-output:end -->
 
 ## Final Headline
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -263,7 +263,25 @@ After the security audit is complete and the artifact is saved:
 
 Use `.user_message` for the prose and `.next_phase` for the phase name. The legacy positional form (`next-step.sh security`) is still supported.
 
-When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block.
+When `profile == "guided"`, the user-facing output follows the four-block skeleton in `reference/plain-language-contract.md` (Result / How to try / What was checked / What remains). Whether it is safe to try goes inside Result; do not add a separate block. Use plain words (no "vulnerability", "threat model", "STRIDE"). Example:
+
+<!-- guided-output:start -->
+```
+Resultado: Es seguro para probar. No vi problemas que te expongan.
+
+Como verlo:
+1. Corre el comando que te indique mas arriba y segui las instrucciones.
+
+Que revise:
+- Nadie entra sin permiso a lo que deberia estar protegido.
+- Los datos sensibles no quedan a la vista.
+- Las entradas raras no rompen ni dejan escapar informacion.
+
+Pendiente:
+- No probe contra un ataque dirigido y sostenido.
+- No revise servicios externos que no controlamos.
+```
+<!-- guided-output:end -->
 
 ## Final Headline
 

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -366,7 +366,7 @@ After `session.sh init`, read the canonical session fields per `reference/sessio
 SESSION=$NANOSTACK_STORE/session.json
 [ -f "$SESSION" ] || SESSION="$HOME/.nanostack/session.json"
 
-PROFILE=$(jq -r '.profile // "professional"' "$SESSION" 2>/dev/null || echo "professional")
+PROFILE=$(jq -r '.profile // (if (.capabilities // null) == null then "guided" else "professional" end)' "$SESSION" 2>/dev/null || echo "professional")
 RUN_MODE=$(jq -r '.run_mode // "normal"' "$SESSION" 2>/dev/null || echo "normal")
 AUTOPILOT=$(jq -r '.autopilot // false' "$SESSION" 2>/dev/null || echo "false")
 PLAN_APPROVAL=$(jq -r '.plan_approval // (if .autopilot then "auto" else "manual" end)' "$SESSION" 2>/dev/null || echo "manual")


### PR DESCRIPTION
## Summary

Three consistency fixes in the skill layer, all surfaced by the architecture review. Each one is a place where a skill diverged from a contract the rest of the suite already follows.

## What changes

**1. Profile fallback drift in /think**
When a session has no `profile` field, `/think` fell back to `professional` with a bare `.profile // "professional"`, while `/ship` and the session-state contract use a capabilities-aware fallback (guided when the host declared no capabilities, otherwise professional). The same profile-less session was treated as professional by one skill and potentially guided by another. `/think` now uses the canonical snippet, so profile resolution is identical across the suite.

**2. Guided output missing in /review and /security**
The plain-language contract requires every Guided phase (think, plan, qa, ship, doctor, **review, security**) to emit the four-block skeleton, and the contract's CI check greps inside `<!-- guided-output -->` example blocks for banned process vocabulary. review and security carried only the prose pointer with no example block, and the CI job did not include them, so the requirement was unenforced for exactly two phases. This adds the example block to both (banned-term clean) and extends the CI job's two loops to cover them, closing the gap.

**3. /compound after a report-only ship**
A report-only `/ship` previews delivery without publishing anything (no commit, no PR, no deploy) and saves a looser artifact tagged `run_mode: report_only`. `/compound` had no awareness of this: it would resolve that artifact and record the sprint as if work had shipped. It now reads the ship artifact's `run_mode` and, when report-only, still captures genuine investigation learnings but does not claim a shipment occurred or that the sprint closed.

## Test plan

- Reproduced the contract's banned-term scan locally across all seven Guided skills (think, plan, qa, ship, doctor, review, security): all pass, every skill has a fenced block, no banned terms.
- Verified `/think` now matches `reference/session-state-contract.md` and `/ship` exactly for the profile fallback.
- End-to-end: saved a `report_only` ship artifact, confirmed `resolve.sh compound` exposes it and the new snippet reads `run_mode == report_only`.
- Workflow YAML parses.