### PR TITLE
refactor(session): hold a shared lock across every session.json mutation

### DIFF
--- a/bin/budget.sh
+++ b/bin/budget.sh
@@ -9,6 +9,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/pricing.sh"
+source "$SCRIPT_DIR/lib/session-lock.sh"
 
 SESSION_FILE="$NANOSTACK_STORE/session.json"
 
@@ -30,11 +31,13 @@ cmd_set() {
     exit 1
   fi
 
+  nano_session_lock "$SESSION_FILE"
   jq \
     --argjson max "$max_usd" \
     --arg model "$model" \
     '.budget.max_usd = $max | .budget.model = $model' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+  nano_session_unlock
 
   echo "OK: budget set to \$$max_usd ($model)"
 }
@@ -55,6 +58,10 @@ cmd_check() {
     exit 0
   fi
 
+  # Lock across the token read + accumulate + write so two concurrent
+  # checks cannot both read the old totals and lose one increment.
+  nano_session_lock "$SESSION_FILE"
+
   local max_usd model prev_input prev_output
   max_usd=$(jq -r '.budget.max_usd // "null"' "$SESSION_FILE")
   model=$(jq -r '.budget.model // "sonnet-4"' "$SESSION_FILE")
@@ -63,6 +70,7 @@ cmd_check() {
 
   # No budget set: always continue
   if [ "$max_usd" = "null" ]; then
+    nano_session_unlock
     echo '{"action":"continue","reason":"no_budget_set"}'
     exit 0
   fi
@@ -101,6 +109,7 @@ cmd_check() {
     --argjson spent "$spent_usd" \
     '.budget.tokens_input = $input | .budget.tokens_output = $output | .budget.spent_usd = $spent' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+  nano_session_unlock
 
   jq -n \
     --argjson spent "$spent_usd" \

--- a/bin/lib/session-lock.sh
+++ b/bin/lib/session-lock.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# session-lock.sh — atomic, trap-safe advisory lock for session.json writes.
+#
+# Architecture review round (2026-06-11). Before this lib, only
+# session.sh phase-start held a lock around its read-modify-write of
+# session.json; phase-complete, archive, init, and budget.sh all mutated
+# the same file with no lock. Two agents (e.g. /conductor running phases
+# in parallel) could interleave their `jq … > tmp; mv tmp session.json`
+# and silently drop one update. The lock was also released by an explicit
+# `rm -rf` at each return path, so a jq failure between acquire and
+# release leaked the lockdir and wedged every later writer for 30s.
+#
+# This is the single primitive every session.json writer now shares:
+#   nano_session_lock "$SESSION_FILE"   # blocks until held; fails closed at 30s
+#   …read-modify-write…
+#   nano_session_unlock                 # idempotent
+#
+# Properties:
+#   - Atomic via mkdir (every POSIX filesystem). flock is intentionally
+#     not used: stock macOS has no flock(1).
+#   - Trap-safe: acquiring installs an EXIT/INT/TERM trap that releases
+#     the lock, so a mid-write crash cannot leak the lockdir. Callers
+#     should therefore NOT register their own EXIT trap after locking.
+#   - Stale-owner reclaim: the holder records its PID in <lockdir>/owner;
+#     a waiter whose owner PID is gone reclaims the lock. A missing owner
+#     file is treated conservatively as a live holder.
+#   - Bash 3.2 compatible; safe under set -e (the acquire loop never
+#     aborts the caller on a failed mkdir).
+
+# Idempotent: safe to source more than once in a process.
+if [ "${_NANO_SESSION_LOCK_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_NANO_SESSION_LOCK_LOADED=1
+
+# Path of the lockdir currently held by THIS process, or "" when unlocked.
+_NANO_SESSION_LOCKDIR=""
+
+# nano_session_lock <session_file>
+# Blocks until the lock is held. Fails closed (exit 1) after 30s of live
+# contention rather than racing the current writer.
+nano_session_lock() {
+  local session_file="${1:?nano_session_lock requires the session file path}"
+  local lockdir="${session_file}.lockdir"
+  local waited=0 owner_pid=""
+
+  while ! mkdir "$lockdir" 2>/dev/null; do
+    waited=$((waited + 1))
+
+    # Once per second, check whether the lockholder is still alive. If the
+    # owner file names a PID that no longer exists, the holder crashed or
+    # exited mid-write and we reclaim the lock. A live PID means real
+    # contention, so keep waiting. Missing owner file is treated as live.
+    if [ $((waited % 10)) -eq 0 ] && [ -f "$lockdir/owner" ]; then
+      owner_pid=$(cat "$lockdir/owner" 2>/dev/null)
+      if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
+        rm -rf "$lockdir" 2>/dev/null || true
+        echo "INFO: previous session lockholder (pid $owner_pid) is gone, reclaiming" >&2
+        continue
+      fi
+    fi
+
+    if [ "$waited" -gt 300 ]; then
+      echo "ERROR: session lock held >30s (owner pid ${owner_pid:-unknown}). Retry after the other agent finishes, or remove $lockdir if nothing is running." >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+
+  _NANO_SESSION_LOCKDIR="$lockdir"
+  # Release on any exit path so a failed read-modify-write cannot leak the
+  # lock. Callers must not install their own EXIT trap after locking.
+  trap 'nano_session_unlock' EXIT INT TERM
+
+  # Record ownership so a waiter can detect a stale lock if we crash.
+  # Best-effort: if the write fails the lock still works for liveness
+  # (waiters fall back to the conservative "live" treatment).
+  echo "$$" > "$lockdir/owner" 2>/dev/null || true
+}
+
+# nano_session_unlock — release the lock held by this process. Idempotent:
+# safe to call when nothing is held, and safe to call twice (the EXIT trap
+# may fire after an explicit call).
+nano_session_unlock() {
+  if [ -n "$_NANO_SESSION_LOCKDIR" ]; then
+    rm -rf "$_NANO_SESSION_LOCKDIR" 2>/dev/null || true
+    _NANO_SESSION_LOCKDIR=""
+  fi
+}

--- a/bin/session.sh
+++ b/bin/session.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NANOSTACK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/store-path.sh"
 source "$SCRIPT_DIR/lib/audit.sh"
+source "$SCRIPT_DIR/lib/session-lock.sh"
 [ -f "$SCRIPT_DIR/lib/preflight.sh" ] && { source "$SCRIPT_DIR/lib/preflight.sh"; nanostack_require jq; }
 [ -f "$SCRIPT_DIR/lib/phases.sh" ] && . "$SCRIPT_DIR/lib/phases.sh"
 
@@ -178,6 +179,11 @@ cmd_init() {
   fi
   [ -z "$plan_approval" ] && plan_approval="manual"
 
+  # Lock across archive-existing + new-session write so a concurrent
+  # writer cannot land an update on the old session between our snapshot
+  # and its replacement, and cannot race two inits into one file.
+  nano_session_lock "$SESSION_FILE"
+
   # Archive existing session if present
   if [ -f "$SESSION_FILE" ]; then
     local old_id
@@ -315,6 +321,8 @@ cmd_init() {
       last_updated: $date
     }' > "$SESSION_FILE"
 
+  nano_session_unlock
+
   audit_log "session_init" "$session_id" "$type"
 
   # Snapshot git state for loop guard
@@ -324,9 +332,9 @@ cmd_init() {
 }
 
 # ─── phase-start ────────────────────────────────────────────
-# Uses an atomic mkdir-lock so concurrent agents (e.g., /conductor) cannot
-# double-register the same phase. mkdir is atomic on every POSIX filesystem;
-# flock would not work on macOS without coreutils.
+# Holds the shared session lock (see lib/session-lock.sh) across the
+# read-modify-write so concurrent agents (e.g., /conductor) cannot
+# double-register the same phase or interleave writes to session.json.
 cmd_phase_start() {
   local phase="${1:?Usage: session.sh phase-start <phase>}"
 
@@ -335,42 +343,7 @@ cmd_phase_start() {
     exit 1
   fi
 
-  local lockdir="${SESSION_FILE}.lockdir"
-  local owner_pid=""
-  local waited=0
-  while ! mkdir "$lockdir" 2>/dev/null; do
-    waited=$((waited + 1))
-
-    # Once per second, check whether the current lockholder is still alive.
-    # If the owner file names a PID that no longer exists, the lock is
-    # stale (the holder crashed or exited mid-write) and we reclaim it.
-    # If the PID is still alive, we are in live contention and keep
-    # waiting. Missing owner file is treated as live (conservative).
-    if [ $((waited % 10)) -eq 0 ] && [ -f "$lockdir/owner" ]; then
-      owner_pid=$(cat "$lockdir/owner" 2>/dev/null)
-      if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
-        rm -rf "$lockdir" 2>/dev/null || true
-        echo "INFO: previous session lockholder (pid $owner_pid) is gone, reclaiming" >&2
-        continue
-      fi
-    fi
-
-    if [ "$waited" -gt 300 ]; then
-      # 30 seconds of live contention. Fail closed rather than race the
-      # writer: conductor mode specifically needs consistent session.json
-      # state. The user can retry or remove the lockdir manually after
-      # confirming no other agent is running.
-      echo "ERROR: session lock held >30s (owner pid ${owner_pid:-unknown}). Retry after the other agent finishes, or remove $lockdir if nothing is running." >&2
-      exit 1
-    fi
-    sleep 0.1
-  done
-
-  # Record ownership so other agents can detect a stale lock if we crash.
-  # Best-effort: if the write fails, the lock still works for liveness
-  # (other agents fall back to conservative "live" treatment). Removed
-  # together with the lockdir on release.
-  echo "$$" > "$lockdir/owner" 2>/dev/null || true
+  nano_session_lock "$SESSION_FILE"
 
   # Re-check inside the lock (idempotent under concurrency)
   local existing
@@ -378,7 +351,7 @@ cmd_phase_start() {
     '[.phase_log[] | select(.phase == $p and (.status == "completed" or .status == "in_progress"))] | length' \
     "$SESSION_FILE" 2>/dev/null || echo "0")
   if [ "$existing" -gt 0 ]; then
-    rm -rf "$lockdir" 2>/dev/null || true
+    nano_session_unlock
     echo "OK: $phase already in log"
     return 0
   fi
@@ -432,7 +405,7 @@ cmd_phase_start() {
     fi
   fi
 
-  rm -rf "$lockdir" 2>/dev/null || true
+  nano_session_unlock
 
   audit_log "phase_start" "$phase"
   echo "OK: $phase started"
@@ -450,6 +423,11 @@ cmd_phase_complete() {
     echo "ERROR: no active session." >&2
     exit 1
   fi
+
+  # Hold the lock across the whole read-modify-write: the ready/next
+  # computation below reads session.json and the jq mutation rewrites it,
+  # so a concurrent phase-start/complete must not interleave between them.
+  nano_session_lock "$SESSION_FILE"
 
   # ─── next phase via phase_graph ───────────────────────────
   # PR 4 of the 2026-05-10 architecture audit: next-phase logic now
@@ -533,6 +511,8 @@ cmd_phase_complete() {
      .ready_phases = $ready |
      .last_updated = $date' "$SESSION_FILE" > "${SESSION_FILE}.tmp"
   mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+
+  nano_session_unlock
 
   audit_log "phase_complete" "$phase" "${duration}s"
 
@@ -662,6 +642,11 @@ cmd_archive() {
     exit 0
   fi
 
+  # Lock across read + archive write + removal so a concurrent writer
+  # cannot mutate session.json after we snapshot it but before we remove
+  # it (which would silently discard that update).
+  nano_session_lock "$SESSION_FILE"
+
   local session_id
   session_id=$(jq -r '.session_id' "$SESSION_FILE")
   session_id=$(nano_safe_id "$session_id")
@@ -670,6 +655,8 @@ cmd_archive() {
 
   jq --arg date "$NOW" '.status = "archived" | .archived_at = $date' "$SESSION_FILE" > "$archive_dir/${session_id}.json"
   rm "$SESSION_FILE"
+
+  nano_session_unlock
 
   echo "OK: archived $session_id"
 }


### PR DESCRIPTION
## Summary

`session.json` is the workflow's source of truth, and it is mutated by several commands. Until now only `session.sh phase-start` held a lock around its read-modify-write. `phase-complete`, `archive`, `init`, and `budget.sh` (both `set` and `check`) rewrote the same file with no lock at all. When two agents run in parallel (the `/conductor` case), their `jq … > tmp; mv tmp session.json` cycles can interleave and silently drop one update: a lost phase-log entry, or lost token accounting.

The previous inline lock also released by an explicit `rm -rf` at each return path, with no trap. A failure between acquire and release leaked the lockdir and wedged every later writer for 30 seconds.

## What changes

- **New `bin/lib/session-lock.sh`** — the single lock primitive every `session.json` writer shares. Atomic via `mkdir` (no `flock` on stock macOS). Acquiring installs an `EXIT`/`INT`/`TERM` trap that releases the lock, so a mid-write crash can no longer leak it. An uncatchable `SIGKILL` is still recovered by the existing stale-owner-PID reclaim path.
- **`session.sh`** — `phase-start` now uses the shared helper (its inline lock is removed); `phase-complete`, `archive`, and `init` now hold the lock across their full read-modify-write.
- **`budget.sh`** — `set` and `check` now lock around their read-modify-write, so concurrent token checks cannot lose an increment.

No behavior change for the single-agent path; this only serializes concurrent writers and makes lock release crash-safe.

## Test plan

- **Lost-update stress:** 20 concurrent `budget check --input-tokens 1000` runs accumulate to exactly 20000 (was lossy before), session.json stays valid JSON, no leaked lockdir.
- **Trap safety:** a holder that exits non-zero mid-hold, and one that receives `SIGTERM`, both release the lock (no leak). A `SIGKILL`ed holder is reclaimed by the next waiter via the dead-PID check.
- **Regression:** full `ci/run-harness.sh --all` gauntlet green, including concurrency-parity, graph-aware-session, and the bin/lib unit suite.