### PR TITLE
fix: require explicit opt-in for legacy artifact recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ A review artifact captures everything: findings, scope drift, conflicts resolved
 }
 ```
 
-Every artifact `bin/save-artifact.sh` writes carries a SHA-256 `integrity` field over the canonical JSON, so a downstream consumer can detect a tampered file. Strict consumers call `bin/find-artifact.sh --require-integrity` to also reject artifacts whose `.integrity` field is missing. The save path validates the structured shape per phase (see `bin/lib/artifact-schemas.sh`); the legacy `--from-session` form still works for manual recovery but writes `schema_legacy: true` so downstream tools know the artifact was reconstructed instead of produced by the structured flow.
+Every artifact `bin/save-artifact.sh` writes carries a SHA-256 `integrity` field over the canonical JSON, so a downstream consumer can detect a tampered file. Strict consumers call `bin/find-artifact.sh --require-integrity` to also reject artifacts whose `.integrity` field is missing. The save path validates the structured shape per phase (see `bin/lib/artifact-schemas.sh`); the legacy `--from-session` form is for manual recovery only and skips that validation, so it is gated behind `NANOSTACK_ALLOW_LEGACY_ARTIFACT=1` and writes `schema_legacy: true` so downstream tools know the artifact was reconstructed instead of produced by the structured flow.
 
 Full schema in [`reference/artifact-schema.md`](reference/artifact-schema.md). To disable auto-save, set `auto_save: false` in `.nanostack/config.json`.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -287,10 +287,10 @@ If a phase shows `in_progress` but you saw it report success, the artifact save 
 tail -20 .nanostack/audit.log
 ```
 
-Look for `phase_complete` events. If the second-to-last review has no `phase_complete`, the agent forgot to call `save-artifact.sh`. Re-run the phase manually:
+Look for `phase_complete` events. If the second-to-last review has no `phase_complete`, the agent forgot to call `save-artifact.sh`. Re-run the phase manually. The `--from-session` recovery form skips per-phase schema validation, so it is gated behind an explicit opt-in:
 
 ```bash
-~/.claude/skills/nanostack/bin/save-artifact.sh --from-session review 'manual save: <summary>'
+NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 ~/.claude/skills/nanostack/bin/save-artifact.sh --from-session review 'manual save: <summary>'
 ```
 
 Then continue the sprint.

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -17,6 +17,12 @@
 # emits a deprecation warning to stderr. The core SKILL.md files
 # (plan/review/security/qa/ship) no longer document it.
 #
+# Because the validator bypass produces an artifact that downstream gates
+# still trust as "verified", --from-session is gated behind an explicit
+# opt-in (NANOSTACK_ALLOW_LEGACY_ARTIFACT=1). No normal-flow skill sets
+# it, so a buggy or compromised call cannot silently write a
+# schema-bypassing artifact; manual recovery sets it deliberately.
+#
 # Validates JSON has required fields before saving. Fails on invalid input.
 set -e
 
@@ -34,6 +40,20 @@ if [ "${1:-}" = "--from-session" ]; then
   PHASE="${2:?Usage: save-artifact.sh --from-session <phase> <summary>}"
   SUMMARY_TEXT="${3:?Missing summary argument}"
   LEGACY_MODE=1
+
+  # Gate the validator bypass behind an explicit opt-in. The resulting
+  # schema_legacy artifact is still treated as a verified upstream by
+  # resolve.sh / the phase gate, so an accidental or programmatic call
+  # could otherwise pass an unvalidated prose blob off as a completed
+  # phase. Manual recovery sets NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 on
+  # purpose; no normal-flow skill does.
+  if [ "${NANOSTACK_ALLOW_LEGACY_ARTIFACT:-0}" != "1" ]; then
+    echo "save-artifact.sh: --from-session is gated. It bypasses per-phase schema" >&2
+    echo "                  validation and exists only for manual recovery. Re-run with" >&2
+    echo "                  NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 if you truly need it, or use" >&2
+    echo "                  the structured form (see reference/artifact-schema.md)." >&2
+    exit 1
+  fi
 
   echo "save-artifact.sh: --from-session is a legacy mode for manual recovery." >&2
   echo "                  Normal-path skills must call the structured form (see reference/artifact-schema.md)." >&2

--- a/bin/save-artifact.sh
+++ b/bin/save-artifact.sh
@@ -20,8 +20,8 @@
 # Because the validator bypass produces an artifact that downstream gates
 # still trust as "verified", --from-session is gated behind an explicit
 # opt-in (NANOSTACK_ALLOW_LEGACY_ARTIFACT=1). No normal-flow skill sets
-# it, so a buggy or compromised call cannot silently write a
-# schema-bypassing artifact; manual recovery sets it deliberately.
+# it, so accidental calls fail by default; manual recovery sets it
+# deliberately. Callers able to set the environment can opt in too.
 #
 # Validates JSON has required fields before saving. Fails on invalid input.
 set -e

--- a/ci/e2e-structured-artifacts.sh
+++ b/ci/e2e-structured-artifacts.sh
@@ -122,15 +122,26 @@ cell_save_writes_valid() {
   nh_assert_true "ship report_only artifact file exists" test -f "$saved_ship_ro"
 }
 
-# Cell 5: --from-session still works, emits deprecation, marks legacy.
+# Cell 5: --from-session works WITH the opt-in, emits deprecation, marks legacy.
 cell_from_session_legacy() {
   local out rc saved_legacy
-  nh_capture out rc "$SAVE" --from-session qa 'N tests passed'
+  nh_capture out rc env NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 "$SAVE" --from-session qa 'N tests passed'
   saved_legacy=$(printf '%s\n' "$out" | tail -1)
   nh_assert_eq "legacy save exit code is 0" "0" "$rc"
   nh_assert_true "legacy artifact file exists" test -f "$saved_legacy"
   nh_assert_jq_file "legacy artifact has schema_legacy: true" "$saved_legacy" '.schema_legacy == true'
   nh_assert_contains "deprecation warning printed" "$out" "--from-session is a legacy mode"
+}
+
+# Cell 5b: WITHOUT the opt-in, --from-session is refused and writes nothing.
+cell_from_session_gated() {
+  local out rc before after
+  before=$(ls "$NANOSTACK_STORE/review" 2>/dev/null | wc -l | tr -d ' ')
+  nh_capture out rc "$SAVE" --from-session review 'ad-hoc prose'
+  nh_assert_eq "ungated --from-session exits non-zero" "1" "$rc"
+  nh_assert_contains "refusal names the opt-in" "$out" "NANOSTACK_ALLOW_LEGACY_ARTIFACT=1"
+  after=$(ls "$NANOSTACK_STORE/review" 2>/dev/null | wc -l | tr -d ' ')
+  nh_assert_eq "no artifact written when gated" "$before" "$after"
 }
 
 # Cell 6: legacy artifacts remain readable by find-artifact + resolve.
@@ -139,7 +150,7 @@ cell_legacy_readable() {
   # Self-contained under --filter: ensure a legacy qa artifact exists even
   # when from-session-legacy was filtered out. The full run also seeds one
   # there; re-seeding is harmless (find/resolve take the newest).
-  "$SAVE" --from-session qa 'N tests passed' >/dev/null 2>&1 || true
+  NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 "$SAVE" --from-session qa 'N tests passed' >/dev/null 2>&1 || true
   found=$( "$FIND" qa 30 2>/dev/null )
   nh_assert_true "find-artifact returns the legacy qa artifact" test -f "$found"
   resolved=$( "$RESOLVE" ship 2>/dev/null )
@@ -179,6 +190,7 @@ nh_cell validator-rejects      cell_validator_rejects
 nh_cell save-rejects-invalid   cell_save_rejects_invalid
 nh_cell save-writes-valid      cell_save_writes_valid
 nh_cell from-session-legacy    cell_from_session_legacy
+nh_cell from-session-gated     cell_from_session_gated
 nh_cell legacy-readable        cell_legacy_readable
 nh_cell skill-md-clean         cell_skill_md_clean
 nh_cell save-wires-validator   cell_save_wires_validator

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -181,7 +181,7 @@
         "jq",
         "git"
       ],
-      "expected_checks": 31,
+      "expected_checks": 34,
       "timeout_minutes": 3,
       "workflow": ".github/workflows/e2e.yml",
       "job": "e2e-structured-artifacts"

--- a/ci/visual-artifacts/core-render.sh
+++ b/ci/visual-artifacts/core-render.sh
@@ -200,7 +200,7 @@ PROJ="$TMP_ROOT/cell9b"
 setup_project "$PROJ"
 export NANOSTACK_STORE="$PROJ/.nanostack"
 mkdir -p "$NANOSTACK_STORE"
-(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" "$REPO/bin/save-artifact.sh" --from-session plan "legacy summary" >/dev/null 2>&1)
+(cd "$PROJ" && NANOSTACK_STORE="$NANOSTACK_STORE" NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 "$REPO/bin/save-artifact.sh" --from-session plan "legacy summary" >/dev/null 2>&1)
 set +e
 HTML=$(cd "$PROJ" && "$REPO/bin/render-artifact.sh" plan --latest 2>/dev/null)
 RC=$?

--- a/reference/artifact-schema.md
+++ b/reference/artifact-schema.md
@@ -5,7 +5,7 @@
 `bin/save-artifact.sh` has two modes:
 
 - **Structured (normal path)**: `save-artifact.sh <phase> '<json>'`. The JSON is validated against the per-phase contract in `bin/lib/artifact-schemas.sh` before write. Core SKILL.md files (`plan`, `review`, `qa`, `security`, `ship`) document only this form. See "Required fields per phase" below for the contract each phase must satisfy.
-- **Legacy `--from-session` (manual recovery)**: `save-artifact.sh --from-session <phase> '<prose summary>'`. Builds a minimal JSON from git state plus the prose summary, marks it with `schema_legacy: true`, emits a deprecation warning to stderr, and writes without strict validation. Use this only when an artifact must be reconstructed after the fact (for example, `/think` ran but did not save, and `/plan` needs the artifact to exist). Normal flows never call this form.
+- **Legacy `--from-session` (manual recovery)**: `NANOSTACK_ALLOW_LEGACY_ARTIFACT=1 save-artifact.sh --from-session <phase> '<prose summary>'`. Builds a minimal JSON from git state plus the prose summary, marks it with `schema_legacy: true`, emits a deprecation warning to stderr, and writes without strict validation. Without the explicit opt-in it refuses to write. Use this only when an artifact must be reconstructed after the fact (for example, `/think` ran but did not save, and `/plan` needs the artifact to exist). Normal flows never call this form. The opt-in prevents accidental use; it is not an authorization boundary for callers able to set environment variables.
 
 Legacy artifacts saved before this contract are still readable by `bin/find-artifact.sh` and `bin/resolve.sh`; only the write path enforces the structured contract.
 


### PR DESCRIPTION
## Summary

Makes artifact recovery an explicit choice. The normal save command validates each phase's data; the legacy `--from-session` command reconstructs a record from a summary and git state without that validation.

Legacy saves now require `NANOSTACK_ALLOW_LEGACY_ARTIFACT=1`. Without it, the command exits before writing an artifact. The recovery instructions and artifact contract show the opt-in.

This prevents accidental use of the recovery path. It does not prevent a caller from setting the variable, and existing legacy artifacts remain readable.

## Validation

- Structured-artifact suite: 34 checks pass, including refusal without opt-in and recovery with opt-in.
- Visual core-render section: 102 checks pass, including legacy rendering.
- Shell syntax, release documentation locks, and diff checks pass.

The original June CI result is historical. Current repository-wide checks also need adapter revalidation and telemetry dependency updates, as surfaced by PR #265.
