### PR TITLE
ci: avoid queuing main builds behind earlier merges

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Only PR revisions share a group; main builds must not queue behind each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

Keeps main builds independent while preserving cancellation of obsolete PR runs.

The concurrency group introduced in #267 also serialized main builds. Give non-PR runs a unique group so one merge does not wait for another merge's validation to finish. Revisions of the same PR still share a group and cancel the older run.

No checks, permissions, or triggers change.

## Validation

- YAML parses and the harness manifest passes.
- Same-PR revisions share a group; different PRs and separate main runs use different groups.
- Existing PR-only cancellation condition is unchanged.
