### PR TITLE
skills: keep sprint coordination and repairs in one place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,14 @@ This file lists every built-in skill shipped by Nanostack for the verified adapt
 
 ### Default sprint
 
+`/feature` coordinates the built-in sprint, either directly or after `/think --autopilot` completes its brief. `/nano` returns a plan; review, security, and QA return findings. Repairs happen in build after verification readers stop, then verification runs again. Automatic plan approval does not authorize publication.
+
 | Skill | Directory | Description |
 |-------|-----------|-------------|
 | think | `think/` | Refines a rough idea before code: questions one at a time, alternatives with trade-offs, design walked in sections. Calibrated per archetype. Saves a structured artifact (value proposition, scope mode, target user, narrowest wedge, key risk, premise validation). |
 | nano  | `plan/` | Implementation planning. Planned files, plan approval, scope assessment, product standards. |
 | review | `review/` | Two-pass code review (structural + adversarial). Scope drift detection against /nano. Conflict precedence with /security. |
-| qa     | `qa/` | Browser, API, CLI, or debug testing. WTF heuristic. |
+| qa     | `qa/` | Browser, API, CLI, or debug testing. Reports reproducible findings without repairing product code. |
 | security | `security/` | OWASP Top 10 + STRIDE audit. Cross-references /review for conflicts. |
 | ship   | `ship/` | Pre-flight, PR creation, CI monitoring, post-deploy verification. Generates the sprint journal on success. |
 | compound | `compound/` | Knowledge capture after /ship. Promotes proven solutions across sprints (bug, pattern, decision) with confidence and applied_count. |
@@ -27,7 +29,7 @@ This file lists every built-in skill shipped by Nanostack for the verified adapt
 
 | Skill | Directory | Description |
 |-------|-----------|-------------|
-| feature   | `feature/` | Fast sprint for an existing project. Skips /think, runs plan through ship. |
+| feature   | `feature/` | Coordinates plan through authorized shipping. Direct calls skip discovery; think autopilot hands off its existing session. |
 | nano-run  | `start/` | First-run onboarding. Reads adapter capabilities, writes a setup artifact, configures permissions and stack preferences through a conversation. |
 | nano-help | `help/` | Quick reference for all built-in skills and the default sprint flow. |
 | nano-doctor | `doctor/` | Diagnostic. Reports the actual enforcement level for the running adapter and any drift between adapter declarations and the local install. |

--- a/README.es.md
+++ b/README.es.md
@@ -118,8 +118,8 @@ Nanostack es un proceso, no una colección de herramientas. Las skills corren en
 |-------|-----------------|----------|
 | `/think` | **CEO / Founder** | Se activa antes de construir. Refina una idea cruda con preguntas, de a una. Explora 2-3 caminos con sus trade-offs. Recorre el diseño con vos, sección por sección. Guarda un brief que los próximos pasos leen. `--autopilot` corre el sprint completo después de aprobar el brief. `--retro` reflexiona sobre lo que ya se hizo. |
 | `/nano` | **Eng Manager** | Genera specs de producto (alcance Mediano) o specs de producto + técnico (alcance Grande) antes de los pasos de implementación. Estándares por tipo de proyecto (web, CLI/TUI). |
-| `/review` | **Staff Engineer** | Revisión de código en dos pasadas: estructural y luego adversarial. Auto-arregla cosas mecánicas. Detecta scope drift contra el plan. |
-| `/qa` | **QA Lead** | Testing funcional + Visual QA. Toma screenshots y analiza la UI contra los estándares de producto. Modos browser, API, CLI y debug. |
+| `/review` | **Staff Engineer** | Revisión de código en dos pasadas: estructural y luego adversarial. Propone correcciones y señala decisiones que necesitan tu criterio. Detecta scope drift contra el plan. |
+| `/qa` | **QA Lead** | Testing funcional + Visual QA. Toma screenshots y analiza la UI contra los estándares de producto. Modos browser, API, CLI y debug. Reporta errores reproducibles sin editar el código del producto. |
 | `/security` | **Security Engineer** | Auto-detecta tu stack, escanea secretos, inyecciones, auth, CI/CD, vulnerabilidades de IA/LLM. Reporte calificado A-F. |
 | `/ship` | **Release Engineer** | Pre-flight + checks de calidad del repo. Crea el PR, monitorea CI, genera el sprint journal. Después del commit pregunta: corro local, deploy a producción, o terminé. |
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ Each skill feeds into the next. `/nano` writes an artifact that `/review` reads 
 |-------|----------------|--------------|
 | `/think` | **Product discovery** | Activates before you build. Refines a rough idea through questions, one at a time. Explores 2-3 approaches with trade-offs. Walks the design with you, section by section. Saves a brief your next steps read. Supports guided archetypes, search privacy modes (`local_only`, `private`, `public`), `--retro` for sprint reflection, and `--autopilot` after the brief is complete. |
 | `/nano` | **Eng Manager** | Auto-generates product specs (Medium scope) or product + technical specs (Large scope) before implementation steps. Product standards for web (shadcn/ui), CLI/TUI (Bubble Tea, Rich, Ink, Ratatui). Stack defaults with CLI preference for beginners. |
-| `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Auto-fixes mechanical issues, asks about judgment calls. Detects scope drift against the plan. Cross-references `/security` with 10 conflict precedents. |
-| `/qa` | **QA Lead** | Functional testing + Visual QA. Takes screenshots and analyzes UI against product standards. Browser, API, CLI and debug modes. WTF heuristic stops before fixes cause regressions. |
+| `/review` | **Staff Engineer** | Two-pass code review: structural then adversarial. Reports proposed repairs and decisions needing your input. Detects scope drift against the plan. Cross-references `/security` with 10 conflict precedents. |
+| `/qa` | **QA Lead** | Functional testing + Visual QA. Takes screenshots and analyzes UI against product standards. Browser, API, CLI and debug modes. Reports reproducible bugs without editing product code. |
 | `/security` | **Security Engineer** | Auto-detects your stack, scans secrets, injection, auth, CI/CD, AI/LLM vulnerabilities. Graded report (A-F). Cross-references `/review` for conflict detection. Every finding includes the fix. |
 | `/ship` | **Release Engineer** | Pre-flight + repo quality checks. PR creation, CI monitoring, sprint journal. After commit, asks: run locally, deploy to production, or done. Production path guides through hosting, domain, monitoring, costs. |
 
@@ -228,7 +228,7 @@ You:    /nano
 You:    [builds the feature]
 
 You:    /review
-        Review: 3 findings (2 auto-fixed, 1 ask). Scope drift: CLEAN.
+        Review: 3 findings (2 proposed repairs, 1 decision). Scope drift: CLEAN.
 
 You:    /security
         Security: CRITICAL (0) HIGH (0) MEDIUM (1) LOW (1). Score: A.

--- a/ci/e2e-graph-aware-session.sh
+++ b/ci/e2e-graph-aware-session.sh
@@ -727,6 +727,39 @@ assert_eq "professional after plan = review wording" \
   "Run /review to check scope, structure, and edge cases." \
   "$msg"
 
+# Explicit build tracking is the coordinator's boundary between writers and readers.
+echo "[11] explicit build blocks verification until completion"
+new_project "cell11-explicit-build"
+"$SESSION_SH" init feature --autopilot --plan-approval auto >/dev/null
+"$SESSION_SH" phase-start plan >/dev/null
+"$SESSION_SH" phase-complete plan >/dev/null
+"$SESSION_SH" phase-start build >/dev/null
+assert_eq "build is active" "build" "$(jq -r '.current_phase' "$NANOSTACK_STORE/session.json")"
+assert_eq "active build leaves no ready verification" "0" \
+  "$(jq '[.ready_phases[] | select(. == "review" or . == "security" or . == "qa")] | length' "$NANOSTACK_STORE/session.json")"
+"$SESSION_SH" phase-complete build >/dev/null
+assert_eq "completed build makes verification ready" "3" \
+  "$(jq '[.ready_phases[] | select(. == "review" or . == "security" or . == "qa")] | length' "$NANOSTACK_STORE/session.json")"
+
+# These are instruction regression locks, not evidence of model compliance.
+echo "[12] specialist instructions preserve coordinator ownership"
+assert_eq "plan returns rather than building" "1" \
+  "$(grep -cF 'Do not build or invoke downstream specialists.' "$REPO/plan/SKILL.md")"
+assert_eq "think hands off through feature" "1" \
+  "$(grep -cF 'then invoke `/feature` without waiting' "$REPO/think/SKILL.md")"
+assert_eq "QA cannot commit repairs" "1" \
+  "$(grep -cF 'Do not edit product files or commit fixes during QA.' "$REPO/qa/SKILL.md")"
+for skill in review security qa; do
+  assert_eq "$skill returns to caller" "1" \
+    "$(grep -cF 'Return the artifact and findings to the caller.' "$REPO/$skill/SKILL.md" || true)"
+done
+assert_eq "publication permission remains separate" "1" \
+  "$(grep -cF '**Auto-approval is not publication permission.**' "$REPO/feature/SKILL.md")"
+assert_eq "repairs invalidate the verification batch" "1" \
+  "$(grep -cF 're-run all three verification phases before `/ship`' "$REPO/feature/SKILL.md")"
+assert_eq "no gated legacy recovery command" "0" \
+  "$(grep -cF 'save-artifact.sh --from-session' "$REPO/plan/SKILL.md" || true)"
+
 cd "$TMP_ROOT"
 
 echo

--- a/ci/harnesses.json
+++ b/ci/harnesses.json
@@ -285,7 +285,7 @@
         "jq",
         "git"
       ],
-      "expected_checks": 61,
+      "expected_checks": 73,
       "timeout_minutes": 6,
       "workflow": ".github/workflows/lint.yml",
       "job": "runtime-contracts"

--- a/feature/SKILL.md
+++ b/feature/SKILL.md
@@ -39,7 +39,7 @@ Before anything else, ensure the project is configured. Run this once (skips if 
 
 ## Session
 
-Initialize the sprint session with autopilot and explicit plan auto-approval. `--autopilot` already implies `--plan-approval auto` per the session contract, but passing it explicitly makes the intent obvious to anyone reading `session.json`.
+For a direct invocation, initialize the sprint session with autopilot and explicit plan auto-approval. When `/think` hands off a completed autopilot brief, keep that active session instead: do not archive it or initialize a replacement. Confirm its workspace matches the current project, `type=development`, `autopilot=true`, `run_mode=normal`, think is completed, no phase is in progress, and plan has not started. If that handoff state is inconsistent, stop and report it rather than overwrite the session.
 
 ```bash
 ~/.claude/skills/nanostack/bin/session.sh init feature --autopilot --plan-approval auto
@@ -47,13 +47,13 @@ Initialize the sprint session with autopilot and explicit plan auto-approval. `-
 
 Manual feature work should use `/think` + `/nano` instead. `/feature` itself does not accept a manual mode flag.
 
-Then run `session.sh phase-start plan`. This activates the phase gate — `git commit` will be blocked until review, security, and qa are complete.
+Let `/nano` start the plan phase. Phase-gate enforcement depends on the active adapter; do not describe guided hosts as hook-enforced.
 
 ## Process
 
-You are an autonomous orchestrator. You run the entire sprint without stopping between phases. Do NOT wait for user input between steps. Do NOT ask "should I continue?" or "ready for review?". Invoke each skill, wait for it to complete, then immediately invoke the next one. The only reasons to stop are blocking issues or critical vulnerabilities.
+You are the full-sprint coordinator. Invoke each specialist once and wait for its result. Continue routine work without asking permission between phases; stop for unresolved scope, unsafe test environments, blocking findings you cannot fix, or an action requiring user authorization.
 
-**Auto-approval contract for sub-skills.** The session records `plan_approval=auto` and `autopilot=true`, so `/nano`, `/review`, `/security`, `/qa`, and `/ship` read those fields and behave accordingly: present briefly, do not pause for approval. If any of them asks "ready to proceed?", treat it as a regression in that skill, not a signal to stop.
+**Auto-approval is not publication permission.** `plan_approval=auto` approves planning, not PR creation, merge, or deployment. Preserve `/ship`'s preview and explicit authorization requirements. Tell delegated specialists to return their artifacts and findings to this coordinator, not launch another phase.
 
 ### Step 1: Context
 
@@ -68,40 +68,29 @@ The output is JSON with `upstream_artifacts` (think, plan, ship paths if recent)
 ### Step 2: Plan
 
 ```
-Use Skill tool: skill="nano"
+Invoke /nano using the active host's skill mechanism.
 ```
 
 Wait for /nano to complete. It saves its own artifact. Then immediately build.
 
 ### Step 3: Build
 
-Build the feature. Do not ask for approval. The plan was the contract.
+Run `session.sh phase-start build`, then implement the approved plan. Run `session.sh phase-complete build` only after implementation finishes. Do not launch verification against an unfinished build.
 
 ### Step 4: Review + Security + QA (parallel)
 
-These three phases are independent. They all read the build output but don't depend on each other. Launch all three using the Agent tool in a single message with three parallel tool calls:
+Use native delegation only when the active host exposes it. Give each specialist the approved scope, build under test, and this boundary: inspect and report; do not edit product files, commit, or invoke another skill. QA must use isolated test data and output directories. Shared mutable services or fixtures require sequential verification.
 
-```
-Agent: subagent_type="general-purpose", prompt="Run /review on this project. Use Skill tool: skill='review'"
-Agent: subagent_type="general-purpose", prompt="Run /security on this project. Use Skill tool: skill='security'"
-Agent: subagent_type="general-purpose", prompt="Run /qa on this project. Use Skill tool: skill='qa'"
-```
+Otherwise invoke `/review`, `/security`, and `/qa` sequentially using the host's skill mechanism. If delegation fails after any reader has started, wait for or cancel and confirm termination of that reader before falling back; never launch duplicate work against a still-running batch. Guided adapters rely on these instructions, not universal hook enforcement.
 
-If parallel agents are not available, fall back to sequential:
-```
-Use Skill tool: skill="review"
-Use Skill tool: skill="security"
-Use Skill tool: skill="qa"
-```
-
-If any phase finds blocking issues or critical vulnerabilities: fix them, then re-run that phase only.
+If verification finds blocking issues, wait for all readers to finish (or confirm cancellation), return to build, and apply repairs there. After any product change, re-run all three verification phases before `/ship`. Do not carry passing results from the previous build forward. If a repair exceeds approved scope, ask the user instead.
 
 `Feature: review + security + qa complete. Running /ship...`
 
-### Step 7: Ship
+### Step 5: Ship
 
 ```
-Use Skill tool: skill="ship"
+Invoke /ship using the active host's skill mechanism.
 ```
 
 /ship commits, creates PR if remote exists, generates sprint journal, runs /compound, and shows the result with next feature suggestions.
@@ -120,9 +109,9 @@ Pass `abort` or `error` instead of `success` if the feature flow did not complet
 
 ## Rules
 
-- **Do not stop between phases.** This is the most important rule. Plan → build → review → security → qa → ship runs as one continuous flow. No pauses, no questions, no confirmations.
-- Each skill is invoked via the Skill tool, not implemented inline.
+- **One orchestration owner.** `/feature` owns planning, build, verification, and the authorized shipping handoff. Specialists return results; they do not start another sprint.
+- Invoke each skill through the active host's skill mechanism, not by reimplementing it inline.
 - Each skill saves its own artifact. You do not save artifacts — the skills do.
 - Between steps, show one line of status: `Feature: review complete. Running /security...`
-- Stop ONLY if a skill finds a blocking issue or critical vulnerability you cannot fix.
+- Stop when scope, safety, or publication authorization requires a user decision.
 - If the feature already exists in the codebase, tell the user and suggest alternatives.

--- a/plan/SKILL.md
+++ b/plan/SKILL.md
@@ -85,11 +85,7 @@ Pendiente:
   - If solutions are returned, read the summaries first, then load only those relevant to the current task. Past mistakes and patterns should inform the sprint.
   - If `sprint_metrics` is present, use it for scope calibration: last sprint's lines changed and file count help estimate whether the current task is Small, Medium, or Large relative to recent work.
 
-  **If think artifact is missing but /think ran** (you can see a Think Summary in the conversation above), recover it now:
-  ```bash
-  ~/.claude/skills/nanostack/bin/save-artifact.sh --from-session think 'Value prop: <from summary>. Scope: <from summary>. Wedge: <from summary>. Risk: <from summary>. Premise: <from summary>.'
-  ```
-  This saves the think output retroactively so /review can check scope drift and the sprint journal is complete.
+  **If think artifact is missing but /think ran**, use the visible Think Summary as planning context and disclose the missing artifact. Do not use `--from-session` or enable the legacy artifact bypass. Ask for missing scope information rather than inventing a brief or marking discovery complete retroactively.
 
 - Check git history for recent changes in the affected area — someone may have already started this work or made decisions you need to respect.
 - If the affected modules are known, check for diarizations (structured module briefs from past sprints) in `.nanostack/know-how/diarizations/`. If a diarization exists for a module in scope, read it for recurring issues, known risks, and unresolved tensions. These should inform your risk assessment.
@@ -196,34 +192,22 @@ PLAN_JSON=$(jq -n \
 ~/.claude/skills/nanostack/bin/save-artifact.sh plan "$PLAN_JSON"
 ```
 
-**Step 2: Build and proceed.**
+**Step 2: Return the plan.**
 
 ## Next Step
 
-After the user approves the plan and you finish building:
+After the plan artifact is saved:
 
 **If `PLAN_APPROVAL` is `auto`:**
 
-After build completes, invoke each skill in sequence using the Skill tool. Do NOT implement review/security/qa logic yourself — invoke the skill and let it run its full process.
-
-1. Invoke review: `Use Skill tool: skill="review"`
-   Wait for completion. Show: `Autopilot: review complete. Running /security...`
-
-2. Invoke security: `Use Skill tool: skill="security"`
-   Wait for completion. Show: `Autopilot: security complete. Running /qa...`
-
-3. Invoke qa: `Use Skill tool: skill="qa"`
-   Wait for completion. Show: `Autopilot: qa complete. Running /ship...`
-
-4. Invoke ship: `Use Skill tool: skill="ship"`
-
-Stop the sequence if any skill finds blocking issues or critical vulnerabilities. For parallel execution across multiple terminals, use `/conductor`.
+Return the approved plan to the caller. Do not build or invoke downstream specialists. `/feature` owns the full sprint; a standalone `/nano` call ends with the plan even when approval is automatic.
 
 **Otherwise (`manual` or `not_required`):**
 
 Tell the user:
 
-> Build complete. Next steps in the sprint:
+> Plan ready. Next steps in the sprint:
+> - Build the approved plan
 > - `/review` to run a two-pass code review with scope drift detection
 > - `/security` to audit for vulnerabilities
 > - `/qa` to test that everything works

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -3,13 +3,15 @@ name: qa
 description: Use to verify that code works correctly — browser-based testing with Playwright, native app testing with computer use, CLI testing, API testing, or root-cause debugging. Supports --quick, --standard, --thorough modes. Triggers on /qa.
 concurrency: read
 depends_on: [build]
-summary: "QA testing. Browser, native, API, CLI, or debug modes. Finds and fixes bugs with atomic commits."
+summary: "QA testing. Browser, native, API, CLI, or debug modes. Reproduces bugs and reports evidence for repair."
 estimated_tokens: 450
 ---
 
 # /qa — Quality Assurance & Debugging
 
-You test like a real user and fix like an engineer. Click everything, fill every form, check every state. When you find a bug, you own it: fix it with an atomic commit, re-verify, and move on. If a fix touches more than it should, stop and report instead.
+You verify behavior and report reproducible findings. Do not edit product files or commit fixes during QA. Return repairs to the caller's build step, after all verification readers have stopped. A standalone QA invocation ends with the report, not a repair or publication.
+
+Read-only means no product mutation, not side-effect-free execution: tests, browsers, and builds can write files or change services. Use disposable fixtures and dedicated temporary/results directories. Do not regenerate tracked snapshots, run migrations on shared data, or test production. If isolation is unavailable, report the affected checks as untested. Follow the active host's permissions; never bypass a guard to produce test output.
 
 ## Telemetry preamble
 
@@ -25,18 +27,18 @@ unset _P
 
 If the user specifies a mode flag, use it. Otherwise, check `bin/init-config.sh` for `preferences.default_intensity`.
 
-| Mode | Flag | Scope | Bug fix limit |
-|------|------|-------|---------------|
-| **Quick** | `--quick` | Happy path only, screenshots on failure only | Max 3 fixes |
-| **Standard** | (default) | Happy path + error states + empty states | Max 10 fixes |
-| **Thorough** | `--thorough` | Happy + error + edge + load + regression tests | Max 20 fixes |
-| **Report only** | `--report-only` | Same scope as standard, but NO fixes | 0 — findings only |
+| Mode | Flag | Scope |
+|------|------|-------|
+| **Quick** | `--quick` | Happy path only, screenshots on failure only |
+| **Standard** | (default) | Happy path + error states + empty states |
+| **Thorough** | `--thorough` | Happy + error + edge + load + regression tests |
+| **Report only** | `--report-only` | Same scope as standard; no automatic continuation |
 
-`--report-only` can combine with any intensity: `/qa --thorough --report-only` scans everything but touches nothing. Use when you want a bug inventory without code changes.
+`--report-only` remains supported with any intensity. All QA modes report findings without repairing product code.
 
 ### WTF-Likelihood Heuristic
 
-Track regression probability: +15% per revert, +5% per >3-file fix, +20% if touching unrelated files. Stop at 20%. Hard cap: quick=3 fixes, standard=10, thorough=20.
+Describe regression concerns from observed failures and coverage gaps. The legacy `wtf_likelihood` field is qualitative, not a measured probability; do not invent percentages or a numeric safety score.
 
 ## Mode Selection
 
@@ -143,16 +145,16 @@ Find the actual cause, not just the symptom:
 - "The API returns 500" is a symptom
 - "The handler doesn't check for nil user before accessing user.email" is a root cause
 
-### 4. Fix and Verify
-- Fix the root cause, not the symptom
-- Write a test that fails before the fix and passes after
-- Check for the same pattern elsewhere in the codebase
+### 4. Report the Repair
+- Explain the root cause and the smallest proposed fix
+- Specify a regression test for the build step to add
+- Check for the same pattern elsewhere without changing files
 
 ## Output Format
 
 Open with a summary line:
 ```
-QA: 12 tests, 11 passed, 1 failed. 1 bug found, 1 fixed. WTF: 0%.
+QA: 12 tests, 11 passed, 1 failed. 1 bug needs repair.
 ```
 
 Then the full report:
@@ -171,7 +173,7 @@ Then the full report:
 - **{{severity}}:** {{description}}
   - **Reproduce:** {{steps}}
   - **Root cause:** {{why it happens}}
-  - **Fix:** {{what you changed, with commit hash}}
+  - **Proposed fix:** {{smallest repair and regression test}}
 
 ### What's Working
 - {{2-3 specific things that work well. Not filler.}}
@@ -212,9 +214,8 @@ QA_JSON=$(jq -n \
 | Test scope | Happy path only | Happy + error + empty | Happy + error + edge + load |
 | Screenshots | On failure only | Key checkpoints | Every state |
 | Visual QA | Skip | Main states + mobile | Every state + mobile + dark mode |
-| Bug fix limit | 3 | 10 | 20 |
-| Regression tests | Skip | If fixing a bug | Full regression suite |
-| WTF threshold | 20% | 20% | 20% |
+| Product repairs | Report only | Report only | Report only |
+| Regression tests | Targeted | Relevant existing tests | Full regression suite |
 
 ## Session state
 
@@ -224,9 +225,9 @@ Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/sess
 
 After QA is complete and the artifact is saved:
 
-**If `autopilot == true` and tests pass:** Proceed to `/ship`. Show: `Autopilot: qa passed (X tests, 0 failed). Running /ship...`
+**If `autopilot == true`:** Return the artifact and findings to the caller. Do not invoke `/ship` or any other specialist. The coordinator decides whether the whole verification batch passed.
 
-**If autopilot and tests fail:** Stop and ask the user. Show failures and wait.
+**If tests fail:** Include reproduction steps and proposed repairs. The caller must leave verification before editing product code, then verify the repaired build again.
 
 **Otherwise:** Read the next action from session state:
 
@@ -286,4 +287,4 @@ Pass `abort` or `error` instead of `success` if the QA session did not complete 
 - **Don't confuse "no errors" with "working."** A page that renders without errors but shows the wrong data is still broken. Assert content, not just absence of errors.
 - **Screenshots are evidence.** When a visual test passes, capture a screenshot anyway. When it fails, the screenshot is your debug tool.
 - **If the test environment is flaky, say so.** Don't retry silently hoping it passes. Flakiness is a finding.
-- **Respect the WTF heuristic.** When it says stop, stop. Listing remaining bugs is more valuable than introducing regressions.
+- **Report coverage honestly.** Untested behavior and environment failures are not passing checks.

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -13,7 +13,7 @@ hooks:
 
 # /review — Two-Pass Code Review
 
-You are a skeptical senior engineer who has seen production go down because someone skipped the second look. Two passes, two mindsets. Do not blend them. You own the findings: if something is mechanical, fix it yourself. If it needs judgment, ask.
+You are a skeptical senior engineer who has seen production go down because someone skipped the second look. Two passes, two mindsets. Do not blend them. Report findings and proposed repairs without editing product files, including mechanical fixes.
 
 ## Telemetry preamble
 
@@ -49,9 +49,9 @@ Calibrate depth by diff size: **Small** (< 100 lines, quick pass) / **Medium** (
 Run `source bin/lib/git-context.sh && detect_git_mode`. If `local` (no git):
 - **File source:** use `context_checkpoint.key_files` from the plan artifact instead of git diff. If no plan artifact, list files in the project directory.
 - **Skip:** scope drift check (no diff to compare), PR preview.
-- **Language:** replace all jargon with plain terms. "Revisé N archivos. Encontré X cosas:" instead of "Diff: N files, X findings." Replace "nit" → "detalle menor", "auto-fix" → "ya lo arreglé", "blocking" → "hay que arreglar esto", "finding" → "cosa". Explain each issue in plain language — what's wrong, why it matters, and whether you already fixed it.
+- **Language:** replace jargon with plain terms. "Revise N archivos. Encontre X cosas:" instead of "Diff: N files, X findings." Explain what is wrong, why it matters, and the proposed repair. Do not claim a reported issue has already been fixed.
 - **Next steps:** do NOT list slash commands. Instead: "¿Querés que revise la seguridad antes de darlo por terminado?"
-- **Everything else stays the same:** two passes (structural + adversarial), severity levels, auto-fix vs ask.
+- **Everything else stays the same:** two passes (structural + adversarial), severity levels, mechanical repairs versus decisions needing user input.
 
 ## Step 0: Resolve Context
 
@@ -119,15 +119,15 @@ Now forget everything you just read. Approach the code as if you are trying to b
 
 ## Output Format
 
-Classify every finding as AUTO-FIX or ASK:
+Classify each proposed repair as MECHANICAL or ASK:
 
-**AUTO-FIX** (mechanical, high confidence, no judgment needed): dead code, missing error return, off-by-one, stale imports, typos in strings. Fix it, report what you did.
+**MECHANICAL** (high confidence, no design decision needed): dead code, missing error return, off-by-one, stale imports, typos in strings. Describe the repair for the build step; do not apply it during review.
 
 **ASK** (needs judgment, design decision, or user context): race conditions, API contract changes, removing functionality, security tradeoffs. Show the problem, recommend a fix, wait for approval.
 
 Open with a summary line:
 ```
-Review: 5 findings (2 auto-fixed, 2 ask, 1 nit). 3 things done well.
+Review: 5 findings (2 mechanical repairs, 2 decisions, 1 nit). 3 things done well.
 ```
 
 Then group by severity: **Blocking** (must fix), **Should Fix** (tech debt, confusion), **Nitpicks** (prefix "nit:"), **What's Good** (always include, be specific about what the code does right).

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -191,9 +191,9 @@ Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/sess
 
 After the review is complete and the artifact is saved, proceed:
 
-**If `autopilot == true` (or `plan_approval == "auto"`) and no blocking issues found:** Proceed directly to the next pending skill. Show: `Autopilot: review complete (X findings, 0 blocking). Running /security...`
+**If `autopilot == true` (or `plan_approval == "auto"`):** Return the artifact and findings to the caller. Do not invoke another specialist. `/feature` owns continuation and waits for the whole verification batch.
 
-**If autopilot and blocking issues found:** Stop and ask the user to resolve. Show the blocking issues and wait. After resolution, continue autopilot.
+**If blocking issues are found:** Report them without repairing product files. The caller handles repairs in the build step after all verification readers have stopped.
 
 **Otherwise:** Read the next action from session state. Do not encode the wording here:
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -295,10 +295,10 @@ Use `WARN` instead of `OK` if any critical or high findings exist.
 
 ## After Fixes
 
-When the model or user fixes security findings, do NOT re-run the full audit. Instead:
+When the caller returns a repaired build for verification, focus the new audit on changed code and affected trust boundaries:
 
 - **CRITICAL/HIGH fixes:** Re-audit only the affected files and the specific vulnerability class. Verify the fix resolves the finding. Save a new artifact.
-- **MEDIUM/LOW fixes:** Verify the specific fix by reading the changed code. No re-audit needed. Do not save a new artifact — the original audit with the fix note is sufficient.
+- **MEDIUM/LOW fixes:** Verify the specific fix by reading the changed code. Save a new artifact recording the current result and the narrower coverage; do not treat the original audit as evidence for a changed build.
 
 Re-running the full OWASP scan after fixing a missing Content-Type header wastes time and tokens. Target the verification.
 

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -251,9 +251,9 @@ Read `profile`, `run_mode`, `autopilot`, and `plan_approval` per `reference/sess
 
 After the security audit is complete and the artifact is saved:
 
-**If `autopilot == true` and no critical/high findings:** Proceed to next pending skill. Show: `Autopilot: security grade X (0 critical, 0 high). Running /qa...`
+**If `autopilot == true`:** Return the artifact and findings to the caller. Do not invoke another specialist. `/feature` owns continuation and waits for the whole verification batch.
 
-**If autopilot and critical or high findings:** Stop and ask the user to review. Show the findings and wait. After resolution, continue autopilot.
+**If critical or high findings are found:** Report them without repairing product files. The caller handles repairs in the build step after all verification readers have stopped.
 
 **Otherwise:** Read the next action from session state:
 
@@ -323,4 +323,3 @@ Pass `abort` or `error` instead of `success` if the audit did not complete norma
 - **Auth ≠ authz.** Logged in ≠ has permission.
 - **Check git history for secrets.** `git log -p --all -S 'password\|secret\|key\|token'`
 - **Variant analysis in `--thorough`.** One finding = search for the pattern elsewhere.
-

--- a/think/SKILL.md
+++ b/think/SKILL.md
@@ -240,7 +240,7 @@ Not:
 
 ### Brief gate invariant (do not break)
 
-The Phase 6.6 autopilot brief gate checks five fields: `value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. It does NOT check `archetype`. A complete brief without an archetype must still advance to `/nano` under autopilot. Missing archetype alone never blocks the gate.
+The Phase 6.6 autopilot brief gate checks five fields: `value_proposition`, `target_user`, `narrowest_wedge`, `key_risk`, `premise_validated`. It does NOT check `archetype`. A complete brief without an archetype must still advance to `/feature` under autopilot. Missing archetype alone never blocks the gate.
 
 ## Retro Mode
 
@@ -380,7 +380,7 @@ How `/think` uses each field:
 | `PROFILE=guided` | Shorter conversation (max 3 opening questions). No internal labels (no "Founder mode", "Phase 1.5", "Startup mode"). Output follows `reference/plain-language-contract.md`. The Spanish four-block skeleton applies on local mode. |
 | `PROFILE=professional` | Keep the full Founder/Startup/Builder mode framework, the diagnostic, the staff-engineer scorecard. |
 | `RUN_MODE=report_only` | Brief produced and saved as artifact, but `/think` does NOT advance to `/nano` (no autopilot continuation, no plan_approval=auto). |
-| `AUTOPILOT=true` and brief is complete | Continue to `/nano` without pausing for approval (per session contract). The Minimum Viable Brief Gate decides "complete". |
+| `AUTOPILOT=true` and brief is complete | Hand off to `/feature`, which invokes `/nano` in the same session. The Minimum Viable Brief Gate decides "complete". |
 | `AUTOPILOT=true` and brief is incomplete | Pause once with a single focused question — see Phase 5 (Brief gate). Do not invent fields. |
 | `HOST=codex/cursor/opencode/gemini` | Even with a git repo, profile may already be `guided` because the host adapter declared `instructions_only`. Trust `PROFILE`, do not re-derive guided/professional from `detect_git_mode` alone. |
 
@@ -667,9 +667,9 @@ When `RUN_MODE=report_only`, skip the gate entirely. The brief is saved as the r
 
 **If `--autopilot` was used** (or the user said "autopilot", "run everything", "ship it end to end") AND the Brief Gate passed:
 
-> Autopilot active. Proceeding with the full sprint: /nano, build, /review, /security, /qa, /ship. I'll only stop for blocking issues or product questions I can't answer.
+> Autopilot active. `/feature` will coordinate /nano, build, /review, /security, /qa, /ship. I'll stop for unresolved scope, safety issues, or required publication approval.
 
-Then proceed directly to `/nano` without waiting. Set `AUTOPILOT=true` in your context and carry it through every subsequent skill.
+Finalize telemetry, then invoke `/feature` without waiting. Pass the completed brief and explicitly request reuse of this active development session, not initialization of a new feature session. `/feature` invokes `/nano` and owns the remaining sprint. Autopilot does not waive `/ship`'s publication authorization.
 
 **If `--autopilot` was used but the Brief Gate failed:** Stop. Ask the one question from Phase 6.6. Do not advance to `/nano`. Do not "decide for the user".
 


### PR DESCRIPTION
## Summary

Makes the sprint easier to follow: one coordinator moves work forward, while planning and verification skills return their results instead of starting overlapping work.

- `/think --autopilot` hands the completed brief to `/feature`, preserving the session. `/nano` returns the plan rather than launching its own sprint.
- Review, security, and QA report findings. Repairs happen in build after verification finishes, followed by a fresh verification pass.
- Parallel verification is optional and uses the active host. Shared test data or unavailable delegation falls back to sequential execution.
- Automatic plan approval does not authorize PR creation, merging, or deployment.
- QA no longer asks for product edits during a read-only phase or presents invented regression percentages. Planning no longer recommends gated legacy artifact recovery.

This changes skill instructions, not the runtime or artifact format. Existing local installation paths and adapter capabilities are unchanged.

## Validation

- Graph-aware session suite: 73/73, including explicit build readiness and nine instruction regression checks.
- Concurrency parity: 10/10.
- Manifest consistency and release-doc locks pass.
- All nine new instruction checks fail against the prior instructions and pass with this change.

Instruction checks protect the written contract; they are not a live-model evaluation or proof of enforcement on every host.